### PR TITLE
docs(migration): Add legacy folders

### DIFF
--- a/content/en/docs/_admin_guides/_index.md
+++ b/content/en/docs/_admin_guides/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Admin Guides (Legacy)"
+linkTitle: "Admin-Legacy"
+weight: 20
+---

--- a/content/en/docs/_admin_guides/advanced_configuration.md
+++ b/content/en/docs/_admin_guides/advanced_configuration.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: Advanced Configurations
+order: 80
+---
+
+{% include components/legacy_documentation.html %}
+
+This document reviews some advanced configuration for each of the Armory Spinnaker sub-services
+
+### Increasing Orca `WaitForCluster` timeout
+
+During deploy stages there is a task that waits for cluster to be ready before moving to the next stage of your pipeline.  If you're using [AWS Lifecycle hooks](https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html) you might need the `WaitForCluster` task to wait longer than the default 30 minutes.
+
+Below is an example of 60 minute `WaitForCluster` timeout:
+```
+tasks:
+  waitForClusterTimeout: 3600000
+```
+

--- a/content/en/docs/_admin_guides/ami-ancestry.md
+++ b/content/en/docs/_admin_guides/ami-ancestry.md
@@ -1,0 +1,44 @@
+---
+layout: post
+order: 90
+---
+
+{% include components/legacy_documentation.html %}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Using the dashboard.
+
+To find the ancestry tool, navigate your browser to: `http://${SPINNAKER_URL}/armory/audit/`.  You should find the audit dashboard:
+
+![ancestry](/images/Image 2017-05-16 at 10.03.15 AM.png)
+
+Entering in an AMI ID will return the parents and descendents of the AMI that was entered.
+
+## Necessary Configuration Changes
+
+We first need to enable Armory Lighthouse to cache the AMIs.  Add the following to `/opt/spinnaker/config/spinnaker-local.yml`:
+
+
+```
+services:
+  lighthouse:
+    amiCache:
+      enabled: true
+```
+
+Then we need to add a tag to all packer templates that require tracking through this tool.  This is done by adding the `base_ami` tag to `builders` section of your packer template, typically kept at `/opt/spinnaker/config/packer`:
+
+```
+{
+  "builders": [
+     {
+       "tags": {
+         "parent_ami": "{% raw  %}{{ user `aws_source_ami`}}{% endraw  %}"
+       }
+}
+```
+
+Once you've made the changes, restart Armory Spinnaker: `service armory-spinnaker restart`. Make sure the Armory Spinnaker Auto Scaling Group health check is set to EC2 rather than ELB. Otherwise the ASG will cycle your Armory Spinnaker instance.

--- a/content/en/docs/_admin_guides/api.md
+++ b/content/en/docs/_admin_guides/api.md
@@ -1,0 +1,74 @@
+---
+layout: post
+title: Adding Accounts
+order: 160
+published: false
+---
+{% include components/legacy_documentation.html %}
+
+# Spinnaker API (Gate)
+Spinnaker is backed by a robust set of RESTful APIs which are all JSON based and easy to use.  Every operation in
+
+## amazon-infrastructure-controller
+  Amazon Infrastructure Controller Description
+
+#### Endpoints
+
+## application-controller
+
+### Endpoints
+
+
+## Bake Controller
+
+
+## build-controller
+Build Controller Description
+
+## cluster-controller
+Cluster Controller Description
+
+## credentials-controller
+Credentials Controller Description
+
+## executions-controller
+Executions Controller Description
+
+## image-controller
+Image Controller Description
+
+## instance-controller
+Instance controller
+
+## job-controller
+Job Controller
+
+## load-balancer-controller
+Load Balancer Controller
+
+## network-controller
+Network Controller
+
+## pipeline-controller
+Pipeline Controller
+
+## project-controller
+Project Controller
+
+## search-controller
+Search Controller
+
+## security-group-controller
+security group controller
+
+## server-group-controller
+Server Group Controller
+
+## snapshot-controller
+Snapshot Controller
+
+## subnet-controller
+Subnet Controller
+
+## task-controller
+Task Controller

--- a/content/en/docs/_admin_guides/architecture.md
+++ b/content/en/docs/_admin_guides/architecture.md
@@ -1,0 +1,112 @@
+---
+layout: post
+title: Architecture
+order: 10
+# This is not to be redirected to the Armory Spinnaker architecture page, as it has different content.
+---
+{% include components/legacy_documentation.html %}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Armory Spinnaker
+
+<div class="mermaid">
+ graph TB
+
+ deck(Deck-Armory) --> gate;
+ api(Custom Script/API Caller) --> gate(Gate);
+ gate(Gate-Armory) --> kayenta(Kayenta);
+ orca(Orca-Armory) --> kayenta(Kayenta);
+ gate --> orca;
+ gate --> clouddriver(Clouddriver);
+ orca --> clouddriver;
+ gate --> rosco(Rosco);
+ orca --> front50;
+ orca --> rosco
+ gate --> front50(Front50);
+ gate --> fiat(Fiat);
+ gate --> kayenta(Kayenta);
+ orca --> kayenta;
+ clouddriver --> fiat;
+ orca --> fiat;
+ front50 --> fiat;
+ echo(Echo-Armory) --> orca;
+ echo --> front50;
+ igor(Igor) --> echo;
+ dinghy(Dinghy) --> front50;
+ dinghy --> orca;
+ configurator(Configurator) --> S3;
+ front50 --> S3;
+ platform(Platform) --> echo;
+ platform --> orca;
+
+ classDef default fill:#d8e8ec,stroke:#39546a;
+ linkStyle default stroke:#39546a,stroke-width:1px,fill:none;
+
+ classDef external fill:#c0d89d,stroke:#39546a;
+ class deck,api external
+ </div>
+
+ {% include components/mermaid.html %}
+
+We provide two methods of installing Spinnaker: Stand-Alone and High-Availability (HA).  The stand-alone version is there for development and evaluation purposes.  It's a simplified deployment and is the quickest way to evaluate Spinnaker.  The HA deployment provides redundancy and additional security such that there is no single point of failure.
+
+
+## Stand-Alone
+
+ * Local instance Redis
+ * Local networking
+ * Configuration persistance is done through s3
+
+
+Below is a diagram of the architecture & components deployed in a stand-alone configuration.
+
+![](/images/Image 2017-01-26 at 12.03.11 PM.png)
+
+
+### Security Groups
+In order to not expose any Spinnaker sub-services which may not contain authentication, we use internal and user-facing security groups.  The user-facing security group exposes ports for `gate` and `deck`, typically 8084 and 80 respectively.  A separate security group is used for internal communication between services.
+
+
+### Autoscaling Groups & Launch Configurations
+We'll create an ASG with the name `armoryspinnaker-preprod-v000`.  
+
+By default, we create an instance with a private IP and keys which should only be accessible by your team.
+
+
+## High Availability (HA)
+
+* Redudancy and solid performance
+    - Multiple Availability Zones (AZ) failovers
+    - Scheduled jobs failovers into a new AZ
+    - Polling jobs (jenkins, etc.) failovers into a new AZ
+* HA is our intermediate step before breaking up each sub-service into multiple AZs
+
+Below is a diagram of the architecture & components deployed in an HA configuration.
+
+![](/images/Image 2017-01-26 at 11.18.35 AM.png)
+
+## Polling and Non-Polling environments
+
+For certain components you'll only want a single instance running on an ASG on "polling" mode.  Namely Igor and Echo which need to run on a
+single instance so that multiple trigger events are not sent to Spinnaker and issuing multiple events for the same build.
+
+## Systems Requirements
+
+Armory Spinnaker runs only on Ubuntu & CentOS and RHEL based machines within AWS.  It uses AWS resources to run manage and run Armory Spinnaker.  
+
+### Cloud & Operating Systems
+
+We currently support running Armory Spinnaker in AWS.  By default it uses (3) m4.2xlarge machines for redudancy.  Once launched, this is completely configurable and based on your team's usage patterns can be scaled up and down with Spinnaker.
+
+### Target Cloud Providers
+We currently support AWS and Kubernetes. We plan to support GCP and Azure in the future.
+
+## Docker
+
+Armory Spinnaker uses Docker and Docker-Compose for every component possible.  
+
+### Security Groups
+In order to not expose any Spinnaker sub-services which may not contain authentication, we use internal and user-facing security groups to match the internal and external facing ELB.  The user-facing security group exposes ports for `gate` and `deck`, typically 8084 and 80 respectively.  If you choose to [configure SSL/HTTPS](http://docs.armory.io/admin-guides/auth/#enabling-httpsssl) at a later time, then 443 will need to be opened as well.  A separate security group is used for internal communication between services which exposes ports but only between members of the security group.

--- a/content/en/docs/_admin_guides/barometer.md
+++ b/content/en/docs/_admin_guides/barometer.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: Barometer
+order: 70
+published: False
+---
+{% include components/legacy_documentation.html %}
+
+{:.no_toc}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+# Enabling Barometer
+
+Update your environment file in `/opt/spinnaker/env/` to enable barometer with the following:
+`BAROMETER_ENABLED=true`
+
+## Open Ports
+
+On the internal ELB open up port 9092 which is the default port for `barometer`
+
+## Enabling Datadog
+
+In your `barometer-local.yml` file add your Datadog API Keys:
+
+```
+datadog:
+  apiKey: 0000000000AAAAAAAAAAAA-SAMPLE_KEY
+  applicationKey: AAAAAAAAAAAAAAAA00000000000-SAMPLE_KEY
+
+spinnaker:
+  redis:
+    host: ${services.redis.host}
+    port: ${services.redis.port}
+```
+
+Restart Armory Spinnaker
+
+```
+service armory-spinnaker restart
+```
+
+## Enabling ElasticSearch
+
+In your `barometer-local.yml` file add the following:
+```
+elasticsearch:
+  enabled: true
+  index: logs
+  baseUrl: http://elasticsearch-host
+```
+Where `index` is the index within your ElasticSearch instance. `baseUrl` is the full URL including port to ElasticSearch.
+
+If you are using AWS ElasticSearch we have found the [AWS Signing Proxy](https://hub.docker.com/r/cllunsford/aws-signing-proxy/`) to be helpful.

--- a/content/en/docs/_admin_guides/configure_kubernetes.md
+++ b/content/en/docs/_admin_guides/configure_kubernetes.md
@@ -1,0 +1,172 @@
+---
+layout: post
+title: Kubernetes Configuration
+order: 70
+published: True
+---
+
+{% include components/legacy_documentation.html %}
+
+To configure Kubernetes, you need to:
+{:.no_toc}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Configure your Docker Registries
+
+Add the following stanza to the file `/opt/spinnaker/config/clouddriver-local.yml` under
+the key `dockerRegistry`:
+```
+dockerRegistry:
+  enabled: true
+  accounts:
+    - name: dockerhub
+      address: MY_CONTAINER_PROVIDER  # If you are using dockerhub -
+                                      # https://index.docker.io
+      username: MY_USERNAME
+      passwordFile: /opt/spinnaker/credentials/dockerhub.password
+      repositories:
+        - myorg/app1
+        - myorg/app2
+        ...
+```
+Modify the key `address` to reflect the address of your docker registry.
+
+Modify the credentials in the key `username` and in the contents of the file `passwordFile` to reflect your login credentials.
+
+If you are using **Dockerhub**, you must list the repositories from which you will deploy because
+Dockerhub does not provide an api to discover available repositories.
+
+Complete example:
+```
+dockerRegistry:
+  enabled: true
+  accounts:
+    - name: dockerhub
+      address: https://index.docker.io
+      username: armoryspinnakerbot
+      passwordFile: /opt/spinnaker/credentials/dockerhub.password
+      repositories:
+        - armory/armory-hello-deploy
+        - armory/spinnaker-clouddriver
+        - armory/spinnaker-deck
+        - armory/spinnaker-igor
+```
+
+For additional insight into docker registries, see: [Docker Registries](https://www.spinnaker.io/setup/providers/docker-registry/).
+Note that the program **hal** is not used to configure Armory Spinnaker.
+
+### Using ECR Repositories
+
+[AWS ECR](https://aws.amazon.com/ecr/) repositories require special handling within Spinnaker. This is because ECR credentials expire after 12 hours.
+In order to use ECR repositories, you'll need to refresh credentials on a regular interval to ensure that Spinnaker can continue to communicate with the registry.
+
+
+[**Here's an easy way of setting up ECR with Spinnaker**]({% link _spinnaker_install_admin_guides/ecr-registry.md %})
+
+## Create a Kubectl Config File
+
+You need a config file that you can use to interact with your Kubernetes cluster.
+
+If you already have such a file that uses static configuration to talk
+to your cluster, great! A common configuration for the Google Container Engine uses a short-lived access token, which
+is problematic for Spinnaker.
+
+To create your inital config file, run the following commands:
+```
+# (1) Configure cluster - Use the IP address of your cluster
+kubectl config --kubeconfig=kubeconfig set-cluster mycluster --server https://192.168.1.1
+
+# (2) Add the CA cert used by your cluster, if necessary;
+kubectl config --kubeconfig=kubeconfig set-cluster mycluster --certificate-authority=/path/to/certfile
+#
+# or #
+#
+# edit kubeconfig, add the base64-encoded certificate data directory to the kubeconfig file in the
+# attribute certificate-authority-data; e.g.,
+#
+# - cluster:
+#     certificate-authority-data: LS0t...Qo=
+#     server: https://35.193.38.121
+#   name: mycluster
+
+# (3) Create a user with basic auth; Adjust the user/password.
+kubectl config --kubeconfig=kubeconfig set-credentials myuser --username=ADMIN --password=ADMINPASSWORD
+
+# (4) Create a context
+kubectl config --kubeconfig=kubeconfig set-context default --cluster mycluster --user=myuser
+kubectl config --kubeconfig=kubeconfig use-context default
+```
+
+[//]: # (Comment) XXX NOTE don - don't know why, the --certificate-authority=filename didn't work for me, don't know why;
+[//]: # (Comment) Tried putting both the plain cert and the base64 version in the file; YMMY.
+
+If your kubeconfig file is properly configured, you should now be able to run the following command
+to show your namespaces:
+```
+kubectl --kubeconfig=kubeconfig get ns
+```
+
+## Configure Clouddriver to use the kubectl Config File
+
+To configure clouddriver to use your  kubectl config file,
+copy your config file - either your existing .kube/config file or the kubeconfig file create above - to
+`/opt/spinnaker/credentials/kubeconfig`.
+
+Then, add the following stanza to the the file `/opt/spinnaker/config/clouddriver-local.yml`:
+
+```
+kubernetes:
+  enabled: true
+  accounts:
+    - name: kubernetes
+      kubeconfigFile: /opt/spinnaker/credentials/kubeconfig
+      namespaces:
+        - staging
+        - default
+        - demo
+      dockerRegistries: # WARNING! only include configured accounts here
+        - accountName: dockerhub
+```
+The listed namespaces are the the names of your kubernetes namespaces. You can find your configured
+namespaces by running the command to list namespaces in the section above.
+
+[//]: # (Comment) XXX NOTE don - What exactly is the point of listing the namespaces?
+[//]: # (Comment) Are these allowed namespaces, or what?
+
+Under `dockerRegistries`, you should list the account name of your docker registry.
+
+## Persistence and Secrets Management
+
+In many configurations, your kubeconfig file and your docker registry password file will contain
+secrets that you need to protect.
+
+A few possibilities for managing these secrets include:
+* Placing a script in /opt/spinnaker/bin/secret to install your credentials;
+* Using a secret management system;
+
+If your Kubernetes cluster is non-sensitive, you can keep your kubeconfig file in a source control system.
+
+## Verify Your Changes
+
+### Restart Spinnaker
+
+You must restart or redeploy Spinnaker before these changes will take effect.
+
+### Make Sure Kubernetes shows up as a cloud provider
+
+If Kubernetes is properly configured, kubernetes will appear as one of the choices for "Cloud Providers" when you use
+the New Application dialog:
+
+![NewApplication](/assets/images/kubernetes-newapplication.png)
+
+You should see a similar option in the "Cloud Provider" section of the Edit Application dialog when editing existing application attributes via: config -> Edit Application Attributes:
+
+![EditApplication](/assets/images/kubernetes-editapplication.png)
+
+
+## Additional Information
+
+For additional documentation on configuring Kubernetes, see the [Kubernetes Documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).

--- a/content/en/docs/_admin_guides/dns.md
+++ b/content/en/docs/_admin_guides/dns.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: Domain Name
+order: 60
+---
+
+{% include components/legacy_documentation.html %}
+
+Add a DNS Entry to your DNS management system.  You should only need to add a DNS entry for the user-facing ELB which is what you use to currently access Spinnaker.   It typically has a name such as the one below
+
+```
+armoryspinnaker-prod-external-123456789.us-west-1.elb.amazonaws.com
+```
+
+Add a CNAME entry for the given ELB then make sure to update your `DECK_HOST` and `API_HOST` in your environment file in the `/opt/spinnaker/env` directory
+
+```
+DECK_HOST=http://spinnaker.mydomain.com
+API_HOST=http://spinnaker.mydomain.com:8084
+```

--- a/content/en/docs/_admin_guides/ecr_registry.md
+++ b/content/en/docs/_admin_guides/ecr_registry.md
@@ -1,0 +1,83 @@
+---
+layout: post
+title: Configuring an ECR as a registry
+order: 120
+# migrated to spinnaker-install-admin-guides/ecr-registry
+published: false
+---
+
+This document reviews configuring ECR as a registry for a Spinnaker installation
+
+### Adding ECR as a Docker Registry
+
+When configuring a registry, you normally use the `hal` command for [adding a Docker Registry](https://www.spinnaker.io/reference/halyard/commands/#hal-config-provider-docker-registry-account-add).
+
+This works great for Dockerhub, but ECR requires a bit more work for configuration. Amazon ECR requires access tokens to access the images and those access tokens expire after a time.
+
+In order to automate updating the token, we will use a [sidecar container](https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar) with a script that does it for us. Since both Clouddriver and the sidecar container need access to the ECR access token, we will use a shared volume to store the access token.
+
+The sidecar we're going to add does not start with an access token, it needs to be able to request an access token from ECR. The Spinnaker installation must have the `AmazonEC2ContainerRegistryReadOnly` policy attached to the role assigned in order to request and update the required access token.
+
+
+Note: This will become easier to do in 1.10, you will be able to use the `--password-command` option to pass the command to update your access token. There will documentation for this once it becomes available in an Armory release.
+
+
+## Update Configs
+
+### Add a Sidecar for Token Refresh
+
+In your `~/.hal/config`, update the `deploymentEnvironment.sidecars` section:
+```
+  deploymentEnvironment:
+    sidecars:
+      spin-clouddriver:
+      - name: token-refresh
+        dockerImage: quay.io/skuid/ecr-token-refresh:latest
+        mountPath: /etc/passwords
+        configMapVolumeMounts:
+        - configMapName: token-refresh-config
+          mountPath: /opt/config/ecr-token-refresh
+```
+
+### Define ECR registry
+
+
+
+Create `~/.hal/<deployment>/profiles/clouddriver-local.yml`:
+```
+dockerRegistry:
+  enabled: true
+  accounts:
+  - name: my-ecr-registry
+    address: https://<aws-account-id>.dkr.ecr.<aws-region>.amazonaws.com
+    username: AWS
+    passwordFile: /etc/passwords/my-ecr-registry.pass
+```
+
+Create a `config.yaml`
+
+```
+interval: 30m # defines refresh interval
+registries: # list of registries to refresh
+  - registryId: "<aws-account-id>"
+    region: "<aws-region>"
+    passwordFile: "/etc/passwords/my-ecr-registry.pass"
+```
+
+Note: You can configure multiple registries here by adding another registry to both files listed above.
+
+
+Apply it to the cluster with:
+```
+kubectl -n <namespace> create configmap token-refresh-config --from-file <config.yaml location>
+```
+
+### Update your Spinnaker installation
+```
+hal deploy apply --service-names clouddriver
+```
+
+
+Now you can add ECR as a docker registry in the configuration stage
+
+![](/images/Image 2018-12-18 at 2.02.02 PM.png)

--- a/content/en/docs/_admin_guides/integration_test_pipelines.md
+++ b/content/en/docs/_admin_guides/integration_test_pipelines.md
@@ -1,0 +1,87 @@
+---
+layout: post
+title: Integration Test Pipelines
+order: 70
+published: True
+---
+
+This guide should include:
+{:.no_toc}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+# Approach
+
+Using Spinnaker's orchestration engine, we can quickly create pipelines that exercise the integration between Spinnaker and your cloud environment before deploying any upgrades to Spinnaker.  We'll walk through creating a master pipeline that kicks off sub-pipelines asynchronously and waits for them complete.
+
+![integration test pipeline](/images/Image 2018-04-05 at 9.25.12 PM.png)
+
+For each stage in the pipeline, we're calling other pipelines that contain the real functionality. This essentially makes the master pipeline your "test suite runner" and reports failures.
+
+![](/images/Image 2018-04-06 at 11.32.51 AM.png)
+
+### Where & When Should My Tests Run
+The tests should run on a [pre-prod or staging environment](https://docs.armory.io/admin-guides/preprod_environment/) and should be integrated as part of your [Spinnaker deploy Spinnaker](https://docs.armory.io/install-guide/spinnaker-deploy-spinnaker/) pipeline.  We'll use a Jenkins stage to execute the integration pipeline on the pre-prod or dev environment.
+
+![pipeline image](/images/Image 2018-04-05 at 9.45.15 PM.png)
+
+# Types of Test Pipelines
+These pipelines will be based on your usage of Spinnaker and should be similar to your production pipelines.  You won't need to deploy into your production accounts to validate Spinnaker functionality but you should deploy into multiple accounts from your pre-prod/dev environments. Below are some of the potential pipeline/stages you can consider.
+
+* **Bake and Deploy** - In this pipeline, you'll want to test your Rosco and Packer template configuration to make sure bakes happen properly as well as feed the resulting AMI to a deploy stage. The application yoo choose to deploy should be a simple application.  We use our [Hello Deploy application](https://github.com/armory-io/armory-hello-deploy) which has deb/rpm packaging as well as a docker image for your containerized deployments.
+>Note: If you're using multiple regions make sure to test this functionality as it may expose networking issues and invalid templates.
+
+![](/images/Image 2018-04-06 at 11.49.13 AM.png)
+
+* **Cluster/Server Group Operations** - For each cloud provider, you will want to ensure Spinnaker's core functionality is fully functional and valided with your accounts. We can utilize these stages, which are comprised of sub-tasks that are used elsewhere in Spinnaker. Some examples include:
+- Enable/disable Cluster/Server Group
+- Destroy Cluster/Server Group
+- Scale Down Cluster
+- Shrink Cluster`
+- Resize A Server Group
+- Clone Server Group
+- Scale Down Cluster
+- Rollback Cluster
+
+* **Other Functionality** - Pipeline Expressions, Jenkins stages, Modifying/Applying Pipeline Templates, Find image from tags, modify scaling operations, Tag Image.
+
+# Executing & Monitoring The Test Pipeline
+
+To execute the master pipeline you'll need to access the API.  You can either build your own client or use Armory's version of [roer](https://github.com/armory/roer) which is a thin API client for Spinnaker and contains functionality to execute  and monitor pipelines.
+
+### Roer Usage:
+```bash
+$ roer app exec --help
+```
+
+```
+NAME:
+   roer app exec - execute pipeline
+
+USAGE:
+   roer app exec [command options] [application name] [pipeline name]
+
+OPTIONS:
+   --monitor, -m            Continue to monitor the executing of the pipeline
+   --retry value, -r value  Number of times to have the monitor retry if a call fails or times out (default: 0)
+```
+
+### Example
+
+```bash
+SPINNAKER_API=https://armory-spinnaker.mycompany.com:8085 roer app exec -m -r 10 integration-test-app Preprod-Integration-Test-Suite-Runner
+```
+
+The example above will run the master pipeline `Preprod-Integration-Test-Suite-Runner` for the application `integration-test-app`.  It'll monitor the pipeline, which will wait for the pipeline to complete either through failure or success and report back it's exit status through 0 or 1.  It will also retry `10` times before exiting with a failure.  This is useful if you're waiting for your pre-prod/stage environment to stabilize.
+
+## Authentication & Authorization
+
+If you have configuring [authentication or authorization](https://docs.armory.io/install-guide/authz/) on your Armory instance then you'll need to make sure to also setup x509 certificate and potentially [service accounts](https://docs.armory.io/install-guide/authz/#configure-a-service-account) if you lock down applications and accounts with Fiat.
+
+If you have [x509 certificate and keys](https://docs.armory.io/install-guide/auth/#x509), you can pass them in with the follow CLI options:
+```
+--certPath value, -c value  HTTPS/x509/cert/path
+--keyPath value, -k value   HTTPS/x509/key/path
+ ```

--- a/content/en/docs/_admin_guides/notifications.md
+++ b/content/en/docs/_admin_guides/notifications.md
@@ -1,0 +1,139 @@
+---
+layout: post
+title: Notifications
+order: 80
+---
+{% include components/legacy_documentation.html %}
+
+The Echo service handles all notifications, scheduled pipelines(e.g. cron jobs) and audit logging to an external sources.  By default it stores events in memory but can also be configured to store results in an external source like Redis.  It is also responsible for triggering pipelines based on one of the available trigger integrations or the result of an executing pipeline.
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+
+## Notifications
+
+### Slack
+
+Add the following to your `/opt/spinnaker/config/spinnaker-local.yml` file:
+
+```
+echo:
+  notifications:
+    slack:
+      enabled: true
+      botName: ${YOUR_BOT_NAME}
+```
+
+Next add your Slack token to your `/opt/spinnaker/config/echo-local.yml`:
+
+```
+slack:
+  enabled: true
+  token: ${YOUR_SLACK_TOKEN}
+```  
+
+Restart Armory Spinnaker by issuing
+
+```
+service armory-spinnaker restart
+```
+
+Make sure to invite `${YOUR_BOT_NAME}` to any channel you want to be notified by spinnaker alerts.
+
+### E-mail
+
+Below is an example of how to use an email server to send notifications.
+
+Add the following to your `/opt/spinnaker/config/echo-local.yml` file:
+
+```
+mail:
+  enabled: true
+  from: xxxx@yourdomain.com
+spring:
+  mail:
+    host: smtp.yourdomain.com
+    username: xxxx@yourdomain.com
+    password: [ App Password - https://support.google.com/accounts/answer/185833?hl=en ]
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+        transport:
+          protocol: smtp
+#       debug: true <- this is useful if you are mucking around with smtp properties  
+```
+
+### Pager Duty
+
+## Audit Logs
+Audit logs are sent over HTTP to any destination.  Below is configuration for popular centralized logging destinations  
+
+### Sumo Logic
+
+First, you'll need to create an HTTP endpoint at Sumologic. The process is described in the [Sumologic help pages](https://help.sumologic.com/Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source).
+
+Sumologic will generate a new HTTP endpoint and unique URL.  That URL is represented as `${SUMOLOGIC_URL}` in the following config.
+
+Add the following to `opt/spinnaker/config/echo-local.yml`:
+
+```
+rest:
+  enabled: true
+  endpoints:
+    - wrap: false
+      url: "${SUMOLOGIC_URL}"
+```
+
+This tells the echo service to send any events to the Sumologic URL, and to send the events in full without a wrapper. Once you have configured echo restart Armory Spinnaker : `service armory-spinnaker restart`.
+
+You should start seeing events flowing to Sumologic. Because of the indexing delay in Sumologic, the best way to make sure the events are flowing is the [Live Tail function at Sumologic](https://help.sumologic.com/Search/Live-Tail/About-Live-Tail).
+
+### Splunk
+
+First, you'll need to make sure you have the [HTTP Event Collector configured](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) on your Splunk deployment.
+
+Once HEC is configured you should have a host/port to send events to, and an authorization token to add to the request headers. If you want to test out the basic setup you should be able to send in [test data using curl]( http://dev.splunk.com/view/event-collector/SP-CAAAE7G).
+
+ If everything is working the next step is to add to/create site specific config for echo so that it forwards all events to Splunk. Create/modify the file at `/opt/spinnaker/config/echo-local.yml` . The values `HEC_HOST`, `HEC_PORT`, and `HEC_TOKEN` should be replaced by the values you got during the Splunk HTTP Event Collector setup:
+
+ ```
+rest:
+  enabled: true
+  endpoints:
+    - wrap: true
+      url: "https://HEC_HOST:HEC_PORT/services/collector/event?"
+      headers:
+        Authorization: "Splunk HEC_TOKEN"
+      template: '{"event":{{ "{{event"}}}} }'
+      insecure: true
+```
+
+Once you've added this config, restart your spinnaker service: `service armory-spinnaker restart`. You should start seeing events appear in Splunk although indexing might delay the results in the search UI.
+
+### Auto Scaling Lifecycle Hooks
+
+Integrating with [Autoscaling Life Cycle Hooks](http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html) allows
+you to send notifications to an ARN whenever an ASG changes state.  This is useful for workloads that are asynchronous like CRON jobs and worker nodes and require the jobs to finish before terminating the instance. Spinnaker allows you to configure a [life cycle hook](http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html) per account.  To enable life cycle hooks you'll need to modify your `/opt/spinnaker/config/clouddriver-local.yml`.  Below is an example configuration:
+
+```
+aws:
+  accounts:
+    - name:
+      accountId: "0123456578999"
+      regions:
+        - name: us-west-2
+      lifecycleHooks:
+        - defaultResult: 'CONTINUE'
+          heartbeatTimeout: 7200
+          lifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING'
+          notificationTargetARN: 'arn:aws:sns:{{region}}:{{accountId}}:spinnaker-instance-terminating'
+          roleARN: 'arn:aws:iam::{{accountId}}:role/SpinnakerManagedRole'
+```
+
+> Note: in the example above, Spinnaker will replace {{region}} and {{accountId}} with valid values at runtime

--- a/content/en/docs/_admin_guides/preprod_environment.md
+++ b/content/en/docs/_admin_guides/preprod_environment.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title: Preprod Environment for Spinnaker
+order: 110
+published: true
+---
+
+{% include components/legacy_documentation.html %}
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Why Do I Need A Preprod Environment?
+Spinnaker is still actively being developed by a community of over 50 engineers across
+many different large organizations and changes are happening rapidly. This introduces a level of risk that can be reduced by creating a preprod environment coupled with a suite of integration pipelines that exercise the base functionality of Spinnaker. Additionally, everyone's cloud environment is unique. Permissions, networking, authentication, baking, and cloud targets differ wildly from environment to environment. This will help add confidence into your deployment practices to practice continuous delivery with Spinnaker itself.
+
+## Setting Up A Preprod Environment
+When Armory Spinnaker starts, it looks for a property file that matches its [stack name]({% link _overview/naming-conventions.md %}).  This file should contain key/value pairs that it will use for its environment. It pulls this stack name from an environment file located at: `/etc/default/server-env`.  If you're using Armory Spinnaker, this file is managed for you by using [clouddriver's global userdata]({% link _admin_guides/userdata.md %}). If a file is found it is appended to `default.env` and generates a `resolved.env` for use.
+
+For example, if the stack of your deploy is named `preprod`, Armory Spinnaker will look for a corresponding environment file named `/opt/spinnaker/env/preprod.env` and append those values to `default.env` should one exist.
+
+### Notable Environment Properties
+For your preprod environment you will want to have it match your production properties as closely as possible with the exception of a few environment properties described below.
+
+##### S3 Properties
+The following determines where Spinnaker will store persistent items like application details, pipelines, etc.  
+It's critical that these are not the same as your production deployment.
+```  
+ARMORYSPINNAKER_S3_BUCKET=mycompany-preprod-spinnaker
+ARMORYSPINNAKER_S3_PREFIX=front50
+SPINNAKER_AWS_DEFAULT_REGION=us-west-2
+```
+
+##### Redis
+Redis is used to maintain state of your cloud resources, pipeline executions, authentication sessions and other transient state. For your preprod environment you might want to use a local Redis instead of creating a new one using Elasticache.
+```
+LOCAL_REDIS=true
+REDIS_HOST=redis
+```
+
+Otherwise, if you want to use an external Redis to more closely match your production setup, do the following:
+```
+LOCAL_REDIS=false
+REDIS_HOST=armoryspinnaker-preprod.aaaaaaaaa.aa.0001.usw2.cache.amazonaws.com
+```
+
+##### Host Names
+You'll need to create a new ELB for your preprod Spinnaker. These should have the same settings, healthcheck and listeners as your production setup. You'll likely want to apply friendly DNS records to the given name from AWS. Once they have been configured you'll need to change the addresses below.
+```
+API_HOST=https://spinnaker.preprod.mycompany.com:8084
+DECK_HOST=https://spinnaker.preprod.mycompany.com
+```
+
+> Note: Make sure to remove your `DEFAULT_DNS_NAME` key from the environment file. Armory Spinnaker
+will automatically create an internal network for the sub-services to communicate with each other.
+
+##### Spring Profiles
+Spinnaker's core framework is Spring. Spring uses a hierarchical profile loading system. You can create environment specific properties files that are loaded at runtime. Make sure to leave the `armory` profiles as the first one in the list, followed by your environment specific profiles. In the example below `preprod` takes the highest precedence.
+```
+SPRING_PROFILES_ACTIVE=armory,local,preprod
+```
+
+### Create a new Deploy Stage
+Add a new deploy stage to your "Spinnaker Deploy Spinnaker" pipeline. When adding the stage and server group you can use production as the server template. You'll want to add a `manual judgement` or `integration test` stage following the deploy stage so you can confirm that your preprod environment is working as expected. Make sure to change the stack to the name chosen for your environment file, in this example: `preprod`.
+
+![deploy configuration](/images/Image 2017-10-20 at 1.06.30 PM.png)
+
+<br/>
+Your finished pipeline should resemble the following:
+<br/><br/>
+![preprod environment](/images/Image 2017-10-20 at 1.06.00 PM.png)

--- a/content/en/docs/_admin_guides/rosco.md
+++ b/content/en/docs/_admin_guides/rosco.md
@@ -1,0 +1,233 @@
+---
+layout: post
+title: Baking Configuration
+order: 120
+---
+
+{% include components/legacy_documentation.html %}
+
+# What is Rosco?
+{:.no_toc}
+
+Rosco is the sub-service that manages baking using [Packer](https://www.packer.io/docs/), a cloud agnostic tool that automates the creation of images.  Rosco is a small API which manages the state of packer jobs and their executions so that it can report to other sub-systems. Make sure to read up on [Understanding Bake Scripts (Packer scripts)]({% link _install_guide/packer.md %}).
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+
+## Configurations for Baking
+{:.no_toc}
+
+
+### Templates Location
+The default location is `/opt/spinnaker/config/packer` for Armory Spinnaker, however this can be changed.
+You can specify the following in  
+`/opt/spinnaker/config/rosco-local.yml`:
+```
+rosco:
+  configDir: ${services.rosco.configDir:/opt/rosco/config/packer}
+```
+
+![baking templates](/images/Image 2017-04-17 at 7.06.45 AM.png)
+
+
+### Region Templates
+
+In some cases you'll want to bake in multiple multiple regions but in order to do so you'll need to create variable files that tell packer where and how to bake the image.  You can do this using [Packer's template variables from a file](https://www.packer.io/docs/templates/user-variables.html#from-a-file).  You can configure your bake stage to use the region template you need by using the `${region}` variable and selecting the regions where would like the bake to occur.  This is a _much_ faster process than copying the AMIs across regions because the bakes happen in parallel.
+
+
+### Using Templates
+When selecting a **Base OS**, the default template will be used. The default is **Base OS** is `Ubuntu 12.04/14.0`, which uses `aws-ebs.json` and `install_package.sh`. See [Setting Up Base OS Defaults for Baking](#setting-up-base-o-s-defaults-for-baking) on how to change the defaults.
+
+You can also specify a template in the bake stage.  The example below shows the template being set to `mycompany-ebs.json` using the **Template File Name** setting for the stage. Spinnaker allows variables so you can even make each template dynamic.  
+![bake configuration](/images/Image 2017-08-07 at 12.45.20 PM.png)
+
+Example of baking `armory-spinnaker` in CentOS (without defining the correct Base OS):
+![img](/images/Screen Shot 2017-09-07 at 5.40.01 PM.png)
+
+
+
+### Getting to Know Packer
+[Packer's documentation can be found here](https://www.packer.io/docs/index.html). In brief, Spinnaker will execute `packer build` with the provided json, which then will execute the `packer_script.sh`.
+
+
+
+### Dynamically Generating Base AMI
+
+In some cases you'll want to dynamically generate a Base AMI for all deployments of Spinnaker instead of using the `Find Images` stage to determine the latest base AMI to use.  This effectively saves a step for every deployment.  You can [specify a  source_ami_filter](https://www.packer.io/docs/builders/amazon-ebs.html#source_ami_filter) in your packer template which is run before the packer instance is created to find the base AMI to use.
+
+```
+{
+  "source_ami_filter": {
+    "filters": {
+      "virtualization-type": "hvm",
+      "name": "mycompany-base-security-patched-*",
+      "root-device-type": "ebs"
+    },
+    "owners": ["099720109477"],
+    "most_recent": true
+  }
+}
+```
+
+
+
+### Working on Packer Scripts
+There's a few options on getting a config change out.
+1. Make a change to `spinnaker-config` repo and wait for a redeploy.  
+This method is useful for minor changes and to keep Spinnaker highly available with less downtime. However a bake and deploy will take on a minimum of 5-10 minutes.
+
+2. Make changes on a Spinnaker instance itself, then commit the changes later. See [Making Config Changes on Spinnaker](#making-config-changes-on-spinnaker).
+This method will scale down Spinnaker to one instance, and allow for a quick development cycle. Keep in mind that if there's anyone using Spinnaker, this will have a drastic, noticeable effect.
+
+It's best to iterate packer scripts by:
+1. Copy steps from your app's current deployment into your new packer script.  
+This might come from your chef, puppet, ansible, or shell scripts. For the first iteration, it's helpful to imagine it like setting up a brand new instance for an environment. Ex: copying all the `apt-get install` commands, dependencies (like nginx, pm2, gunicorn, ...) and dependency configs. Make sure to double check for secrets or environment variables that are injected (`ENV=production`, `DB_URI=localhost:3389`, `DB_USER_NAME=user`, ...).
+
+2. Make sure the app is deployed and working like the old style.  
+
+3. Start simplifying the script. Check out [Things to keep in mind](#things-to-keep-in-mind) for tips.
+
+
+### Making Config Changes on Spinnaker
+
+1. **Scale down all Spinnaker instances except 1 polling instance** :
+Armory Spinnaker is set to spin up in high availability mode, this means there's a potential for a pipeline to execute on one instance and bake on another instance.
+![gif](/images/Screen Recording 2017-09-05 at 06.12 PM.gif)
+
+2. **Set the healthcheck for Spinnaker to be EC2** :
+If we're making changes to **rosco**, this will require you to restart Armory Spinnaker (`service armory-spinnaker restart`). This will prevent the ASG healthchecks from destroying your instance while you're working on it.
+
+3. **SSH into the Spinnaker instance**
+
+4. **sudo su** :
+Spinnaker runs in root and all the files are owned by root.
+
+5. **`cd /opt/spinnaker`** :
+This is the home for Spinnaker
+
+6. (optional) `export GIT_DIR=/opt/spinnaker/.git ; git init && git add . && git commit -m "init" ; unset GIT_DIR`  
+Initialize `/opt/spinnaker` as a git repo. It's helpful to see what exactly is changed throught the process.
+
+7. **`cd config/packer`**
+
+
+### Modifying Packer Templates and Install Scripts
+
+If your organization uses different repositories between groups or if you need some additional custom logic run when baking images it is possible to customize the files that Rosco uses to drive Packer. As mentioned in the Template Files section above, those templates are normally stored in `/opt/spinnaker/config/packer`. The easiest way to get customizations working is to copy an existing example and add it to your spinnaker config.
+
+
+#### Example: Installing Docker before Each Bake
+Lets install Docker and make sure we get add the GPG key for their repo.
+
+- Let's start by copying [`aws-ebs.json`](https://github.com/spinnaker/rosco/blob/master/rosco-web/config/packer/aws-ebs.json) to `my-custom-baker.json`.
+- Let's start by copying [`install_packages.sh`](https://github.com/spinnaker/rosco/blob/master/rosco-web/config/packer/install_packages.sh) to `my-custom-install_packages.sh`.
+
+In the `my-custom-baker.json`, modify the **provisioners** section so that the script entry points to our custom installer script:
+```
+{% raw %}
+"script": "{{user `configDir`}}/my-custom-install_packages.sh",
+{% endraw %}
+```
+
+In `my-custom-install_packages.sh` script, add the logic you need to have run when a bake instance starts up.
+```
+{% raw %}
+# Add the docker gpg key
+curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -
+
+# Add the docker repo to the sources list
+echo "deb https://apt.dockerproject.org/repo/ ubuntu-$(lsb_release -cs) main" \
+      | sudo tee -a /etc/apt/sources.list
+{% endraw %}
+```
+
+Once you have the custom template and script deployed onto your Spinnaker cluster you can now set **Template File Name** in Bake Configuration to `my-custom-baker.json`.
+
+
+
+### Setting Up Base OS Defaults for Baking
+
+The default configurations use `Ubuntu 12.04/14.0` as the default choices for Base OS - these are configurable by adding the configurations below to your `rosco-local.yml`.   You can specify a different `templateFile` per base image which should save time from a user perspective so they don't have to specify an additional parameter.  You can specify multiple base images and visualization settings for each region you need to process bakes.
+
+> **Note** There's currently a bug in the YAML merge that if you specify less than 3 `baseImages` (listed in `rosco.yml`), Spinnaker will show `null null` in the drop down for **Base OS**.
+
+
+Here's a simple version of `rosco-local.yml`. See [Full Version](https://github.com/spinnaker/rosco/blob/master/rosco-web/config/rosco.yml)
+```
+aws:
+  enabled: true
+  bakeryDefaults:
+    awsAssociatePublicIpAddress: true
+    templateFile: aws-ebs.json
+    defaultVirtualizationType: hvm
+    baseImages:
+    - baseImage:
+        id: ubuntu
+        shortDescription: v12.04
+        detailedDescription: Ubuntu Precise Pangolin v12.04
+        packageType: deb
+        # You can specify the templateFile used for this baseImage.
+        # If not specified, the default templateFile will be used.
+        templateFile: aws-ebs.json
+      virtualizationSettings:
+      - region: us-east-1
+        virtualizationType: hvm
+        instanceType: t2.micro
+        sourceAmi: ami-d4aed0bc
+        sshUserName: ubuntu
+        spotPrice: 0
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
+      - region: us-west-1
+        virtualizationType: hvm
+        instanceType: t2.micro
+        sourceAmi: ami-4f285a2f
+        sshUserName: ubuntu
+        spotPrice: 0
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
+    - baseImage:
+        id: trusty
+        shortDescription: v14.04
+        detailedDescription: Ubuntu Trusty Tahr v14.04
+        packageType: deb
+        # The following AMI ID's were retrieved from here:
+        # https://cloud-images.ubuntu.com/locator/ec2/
+      virtualizationSettings:
+      - region: us-east-1
+        virtualizationType: hvm
+        instanceType: t2.micro
+        sourceAmi: ami-9d751ee7
+        sshUserName: ubuntu
+        spotPrice: 0
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
+      - region: us-east-2
+        virtualizationType: hvm
+        instanceType: t2.micro
+        sourceAmi: ami-7960481c
+        sshUserName: ubuntu
+        spotPrice: 0
+        spotPriceAutoProduct: Linux/UNIX (Amazon VPC)
+```
+
+
+### Things to keep in mind
+#### Try to use only 1 packer script across an organization
+* Otherwise this can lead to packer script explosion and splits the ownership of the app.
+* There's going to be a lot of changes to the `spinnaker-config` which will become a nightmare.
+* Checkout [`install_package.sh`](https://github.com/spinnaker/rosco/blob/master/rosco-web/config/packer/install_packages.sh) to get an idea.
+
+#### Avoid install secrets during bake time
+* A potential security issue.
+* Instead, on boot time of the image, an machine  should pull the secret from a secret store.
+
+#### Avoid adding all the dependencies into the packer script
+* This will slow the the bake times because bake will be downloading and installing on each new app change.
+* Instead, use a prebake stage or prebaked image to speed up deploy times. Spinnaker will cache an existing bake if no changes have been made.
+
+#### Avoid having too many prebaked images.
+* After a while, we run into versioning and update issues with the images across multiple apps.
+* Instead, have a single base image, (potentially a security hardened) image, shared across the entire organization. Here's some ways to accomplish this:
+  - Fill the **Base AMI** section for a Bake
+  - Have a `Find Image` stage which would pick the latest base image.
+  - [Allow packer to find the latest image](#dynamically-generating-base-a-m-i).

--- a/content/en/docs/_admin_guides/shared_configuration_repo.md
+++ b/content/en/docs/_admin_guides/shared_configuration_repo.md
@@ -1,0 +1,54 @@
+---
+layout: post
+title: Shared Configuration Repositories
+order: 101
+---
+
+{% include components/legacy_documentation.html %}
+
+## What to expect
+{:.no_toc}
+
+This guide will walk you through setting up a shared configuration repository between multiple Spinnaker installations, and using multiple AWS accounts.
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## What you will need
+Here is an [example configuration repository](https://github.com/armory/spinnaker-config-deb) to start with.
+
+
+## Create a new env file
+In your configuration repo, use an existing env file (ex: `env/ha.env`) to create a new [`env/staging.env`](https://github.com/armory/spinnaker-config-deb/tree/master/deb-config/spinnaker/env). Update the values in `env/staging.env` appropriately.
+
+To allow Spinnaker to pull in configs, we'll need to update the env variable `SPRING_PROFILES_ACTIVE`, add the following below
+```bash
+# by default, its set to
+# SPRING_PROFILES_ACTIVE=local
+# To pick up new staging ymls, we'll change it to:
+SPRING_PROFILES_ACTIVE=staging
+```
+
+
+## `env/default.env`
+Armory Spinnaker installs some settings in `env/default.env`
+
+
+## Setup a new `-staging.yml`
+You may want to change some yml files for a specific configurations. For example, lets create a [`config/clouddriver-staging.yml`](https://github.com/armory/spinnaker-config-deb/tree/master/deb-config/spinnaker/config) and update it accordingly.
+
+
+## Secrets
+Secrets should be different for each environment, we provide an entrypoint script that runs during startup of Spinnaker [`bin/secrets`](https://github.com/armory/spinnaker-config-deb/blob/master/deb-config/spinnaker/bin/secrets). You can use this file to customize your secrets fetch.
+
+
+## Deploying
+Now that we have our configs setup for both `ha` and `staging`, we can use the same debian generated in both [Spinnaker Deploy Spinnaker pipelines](https://docs.armory.io/install-guide/spinnaker-deploy-spinnaker/)
+
+
+
+## Additional Links
+[Information on the Debian configuaration repository](https://github.com/armory/spinnaker-config-deb)
+
+[More about env files](https://github.com/armory/spinnaker-config-deb/tree/master/deb-config/spinnaker/env)
+

--- a/content/en/docs/_admin_guides/spinnaker-on-redhat.md
+++ b/content/en/docs/_admin_guides/spinnaker-on-redhat.md
@@ -1,0 +1,73 @@
+---
+layout: post
+title: Spinnaker on Redhat/Centos
+order: 150
+---
+{% include components/legacy_documentation.html %}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Using CentOS or Redhat for Armory Spinnaker
+After setting up Spinnaker through the [Spinnaker-Terraform](#spinnaker-terraform) method, change or add the bake stage in the "Spinnaker deploy Spinnaker" pipeline to the following.
+
+**Note**:
+- Any selection of `Base OS` will work, it'll be used for AMI naming. Changes can be made through the `spinnaker-local.yml`.
+- `Show Advance Options` needs to be checked for the following.
+
+![screenshot of bake stage](/images/Screen Shot 2017-07-24 at 4.39.17 PM.png)
+
+
+#### CentOS
+```
+Package: armoryspinnaker
+
+Extended Attributes:
+    repository: https://yum.dockerproject.org/repo/main/centos/7/; https://dl.bintray.com/armory/rpms
+    package_type: rpm
+    aws_ssh_username: centos
+    aws_instance_type: m4.large
+
+Base AMI: ami-bec022de (a base CentOS 7.1704)
+AMI Name: centos-armoryspinnaker
+```
+
+
+#### Redhat
+```
+Package: armoryspinnaker
+
+Extended Attributes:
+    repository: https://yum.dockerproject.org/repo/main/centos/7/; https://dl.bintray.com/armory/rpms
+    package_type: rpm
+    aws_ssh_username: ec2-user
+    aws_instance_type: m4.large
+
+Base AMI: ami-b55a51cc (a base Redhat 7.3)
+AMI Name: redhat-armoryspinnaker
+```
+
+
+## Armory Spinnaker AMI & Debian Distribution
+When significant updates are available we distribute a new version of Armory Spinnaker that includes updated components from the OSS community edition as well.  We release minor patches every few days for priority fixes.  You can find more under release management.
+
+
+### Using A Release Candidate Build
+
+1. Update your `armoryspinnaker` bake stage with our release candidate Debian repository.  You'll need to add a new `extended attribute` with the following:
+
+```
+Key: repository
+Value: https://dl.bintray.com/armory/internal trusty main
+```
+
+![bake stage](/images/Image 2017-08-16 at 3.31.06 PM.png)
+
+2. Update `Package` field
+
+Update the package field with the new version given to you by Armory, for example:
+
+`armoryspinnaker=1.8.48`
+
+![edit package field](/images/Image 2017-08-16 at 3.36.36 PM.png)

--- a/content/en/docs/_admin_guides/spinnaker-permissions.md
+++ b/content/en/docs/_admin_guides/spinnaker-permissions.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: Spinnaker Permissions
+order: 110
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+# Spinnaker Permissions

--- a/content/en/docs/_admin_guides/spinnaker_ha_setup.md
+++ b/content/en/docs/_admin_guides/spinnaker_ha_setup.md
@@ -1,0 +1,70 @@
+---
+layout: post
+title: Spinnaker HA Setup
+order: 15
+---
+<!-- {% include components/legacy_documentation.html %} --> 
+
+> The information on this page is deprecated. If you want to configure your Spinnaker to be more resilient, Armory recommends configuring Clouddriver and Orca to use relational databases instead of Redis. For more information, see  [Clouddriver with RDBMS](/spinnaker-install-admin-guides/clouddriver-sql/) and [Orca with RDBMS](/spinnaker-install-admin-guides/orca-sql/).
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+### Setting up Polling and Nonpolling
+For certain components you’ll only want a single instance running on an ASG on “polling” mode. Namely Igor and Echo which need to run on a single instance so that multiple trigger events are not sent to Spinnaker and issuing multiple events for the same build.
+
+To set this up, edit your Armory Spinnaker deploy pipeline so it looks like this.
+![](/images/Image 2018-05-16 at 14.39.40.png)
+
+> Note, the cloud_details set to `nonpolling` is required. On boot, Armory Spinnaker will use [/etc/default/server-env](https://kb.armory.io/aws/18-what-is-server-env/) to determine which group this instance belongs to.
+
+#### "Disable Poller" stage
+Armory includes a service (Lighthouse) that will wait for existing jobs to complete before shutting itself down.
+If Fiat is enabled, make sure that you have [configured a service account](https://docs.armory.io/install-guide/authz/#configure-a-service-account).
+![](/images/Image 2018-05-16 at 14.35.42.png)
+
+#### "Deploy to Prod nonpolling"
+Setup your deploy stage to deploy a nonpolling cluster. You can scale this cluster up to as needed.
+![](/images/Image 2018-05-16 at 14.31.14.png)
+
+
+#### "Deploy to Prod Polling"
+Deploy only **1 instance**.
+![](/images/Image 2018-05-16 at 14.37.01.png)
+
+
+
+### Using a isolated Redis for each subservice
+Spinnaker subservices can share a single Redis. However here are some reasons why you may want to have separate Redis's:
+- Subservice isolation
+- Redis performance issues, which allows you to scale each Redis individually
+
+
+Here's an example for Clouddriver, it's the same pattern for other subservices:
+```bash
+$ cat /opt/spinnaker/env/prod.env
+...
+SPRING_PROFILES_ACTIVE=armory,local,redis
+CLOUDDRIVER_REDIS_URL=redis://YOUR_SPECIAL_REDIS_FOR_CLOUDDRIVER_HERE:6379
+...
+
+
+$ cat /opt/spinnaker/config/clouddriver-redis.yml
+redis:
+  connection: ${CLOUDDRIVER_REDIS_URL:redis://localhost:6379}
+```
+
+
+### Validate the setup is correct
+Look through your logs for to make sure the nonpolling instances don't poll any resources. Here's some examples:
+
+For `igor`, only the polling instance should have log lines like:
+```
+INFO 1 --- [readScheduler-2] c.n.s.igor.jenkins.JenkinsBuildMonitor   : Polling cycle started: Fri Jun 08 18:15:35 GMT 2018
+INFO 1 --- [readScheduler-2] c.n.s.igor.jenkins.JenkinsBuildMonitor   : Polling cycle done in 1359ms
+```
+
+For `echo`, only the polling instance should have this line:
+```
+INFO 1 --- [pool-5-thread-1] .s.e.s.a.p.i.PipelineConfigsPollingAgent : Running the pipeline configs polling agent...
+```

--- a/content/en/docs/_admin_guides/subservices.md
+++ b/content/en/docs/_admin_guides/subservices.md
@@ -1,0 +1,50 @@
+---
+layout: post
+order: 20
+---
+
+{% include components/legacy_documentation.html %}
+
+Spinnaker is the composition of a few sub-services for resiliency
+and follows the single-responsibility principle.  It allows for faster iteration on each
+individual component and a more pluggable architecture for custom components.
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+### Orca
+
+Orca is responsible for the orchestration of pipelines, stages and tasks within Spinnaker.  It acts as the "traffic cop" within Spinnaker making sure that sub-services, their executions and states are passed along correctly.
+
+The smallest atomic unit within Orca is a task - stages are composed of tasks and pipelines are composed of stages.  
+
+### Clouddriver
+
+Clouddriver is a core component of Spinnaker which facilitates the interactions between a given cloud provider such as AWS, GCP or Kubernetes.  There is a common interface that is used so that additional cloud providers can be added.  
+
+### Gate
+
+Gate is the front-end API that is exposed to the users of your Spinnaker instance.  It also manages authentication and authorization for sub-service APIs and resources with Spinnaker.  All communication between the UI and the back-end services happen through Gate.  You can find a list of the endpoints available through Swagger:  `http://${GATE_HOST}:8084/swagger-ui.html`
+
+### Rosco
+
+Rosco is the "bakery" service.  It is a wrapper around Hashicorp's Packer command line tool which bakes images for AWS, GCP, Docker, Azure, and [other builders](https://www.packer.io/docs/builders/index.html).
+
+### Deck
+
+Deck is the UI for interactive and visualizing the state of cloud resources.  It is written entirely in Angular and depends on Gate to interact with the cloud providers.
+
+### Igor
+
+Igor is a wrapper API which communicates with Jenkins.  It is responsible for kicking-off jobs and reporting the state of running or completing jobs.
+
+### Echo
+
+Echo is the service for Spinnaker which manages notifications, alerts and scheduled pipelines (Cron).  It can also propagate these events out to other REST endpoints such as an Elastic Search, Splunk's HTTP Event Collector or a custom event collector/processor.
+
+### Front50
+Front50 is the persistent datastore for Spinnaker. Most notabily pipelines, configurations, and jobs.
+
+### Armory Lighthouse
+
+Lighthouse is a small, lightweight service which is written by Armory and made part of Armory Spinnaker's distribution.  Its job is to monitor the health of the a Spinnaker instance.  It is also responsible for monitoring Orca on its own instance and terminating the instance once there are no jobs running.

--- a/content/en/docs/_admin_guides/troubleshooting.md
+++ b/content/en/docs/_admin_guides/troubleshooting.md
@@ -1,0 +1,133 @@
+---
+layout: post
+title: Troubleshooting
+order: 200
+---
+{% include components/legacy_documentation.html %}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+#### I upgraded Spinnaker and it is no longer responding, how do I rollback?
+
+If you deploy a configuration or a change that takes down Spinnaker it'll be impossible to rollback since Spinnaker would not be available.  In order to manually to deploy back you'll have to do the following:
+
+1.  Look for an existing deployment with the `armoryspinnaker` prefix.  
+
+1.  Find the ASGs of Armory Spinnaker that were deployed.  Typically it should be `armoryspinnaker-ha-polling-v${VER}` where `${VER}` is something like `023`.  You should see 2 ASGS, one that is active instead and the older version should be disabled. ![armory spinnaker ASGs](/images/Image 2017-02-02 at 11.57.41 AM.png)
+
+1. Edit the older ASG and remove any suspended processes that are listed
+ ![remove suspended process](/images/admin-user-guide-1.png)
+
+1.  Increase the number of instances for the `armoryspinnaker-ha-polling` ASG to just 1 and set the other ASG `armoryspinnaker-ha`, the non-polling ASG back to atleast 2.
+![ASG upping desired capacity count](/images/admin-user-guide-2.png)
+
+1.  Reduce the latest ASGs down to 0 so that they're no longer behind the ELB
+
+1.  Check the Armory Spinnaker ELB.  Make sure all instances are attached to the user-facing and internal-services ELB and are healthy.
+
+1.  Go back to your Armory Spinnaker URL and make sure all is back to a working state.
+
+#### How can I debug Armory Spinnaker?
+
+You'll need to SSH into a box running Armory Spinnaker.  You can find an active node by going to clusters view and selecting a node.
+![selecting a node](/images/Screen Recording 2017-09-14 at 04.18 PM.gif)
+
+Once you have SSH'ed into a box you'll need to find which sub-service is unhealthy:
+```sh
+curl localhost:5000/healthcheck
+```
+
+This should return a response similar to:
+```json
+{
+   "healthy":true,
+   "systems":{
+      "gate":true,
+      "clouddriver":false,
+      "echo":true,
+      "igor":true,
+      "orca":true,
+      "rosco":true,
+      "front50":true,
+      "deck":true,
+      "host":{
+         "diskUsage":65.7
+      }
+   }
+}
+```
+
+In the example above `clouddriver` is `false` so it's likely unhealthy.  To check for exceptions or errors tail the logs:
+
+```sh
+docker logs -f clouddriver
+```
+
+This should stream all the `clouddriver` logs to your terminal.  You'll want to look for any obvious exceptions or stack-traces to share with the Armory Support team.
+
+#### How can I flush the Redis cache?
+**NOTE: When using Docker or Jenkins triggers, Redis's `FLUSHALL` could leave you vulnerable to extraneous pipeline runs, which could affect production piplines.** 
+
+<br/>
+1.  SSH into an active Armory Spinnaker node
+1.  Install redis server which comes with the cli tool. `apt-get install redis-tools`
+1.  Flush all content.  This will remove old executions.
+
+```sh
+. /opt/spinnaker/env/resolved.env redis-cli -h ${REDIS_HOST} FLUSHALL
+```
+
+#### How do I remove hung operations in the tasks view?
+
+From time-to-time you might have hung tasks.  In order to clear them out you'll have to use Redis you'll have to remove the key from the server.
+
+1.  SSH into an active Armory Spinnaker node
+1.  Install redis server which comes with the cli tool. `apt-get install redis-tools`
+1.  Find the host of the Armory Spinnaker Redis server.  This is typically kept in `/opt/spinnaker/env/resolved.env` under the key `REDIS_HOST`.
+1.  Find the key of the task you want to delete.
+![alt text](/images/[8c4dbdb8b3942adf28094343663d5588]_Image+2017-08-01+at+11.37.03+AM.png)
+You can then grab the ID from the url:
+`https://${YOURSPINNAKER_INSTANCE}:8084/applications/armoryspinnaker/tasks/bf06a51c-083f-40f0-964a-71314c97ae17`
+
+4.  Delete the orchestration keys from redis:<br/>
+`. /opt/spinnaker/env/resolved.env && redis-cli -h ${REDIS_HOST} DEL orchestration:${TASK_KEY}`<br/> <br/>
+`. /opt/spinnaker/env/resolved.env && redis-cli -h ${REDIS_HOST} DEL  orchestration:bf06a51c-083f-40f0-964a-71314c97ae17:stageIndex`
+
+
+#### How do I add DEBUG level logging?
+
+You can specify logging levels based on the package that you're trying to debug or reduce messaging by adding the following to `/opt/spinnaker/config/spinnaker-local.yml`
+
+```yaml
+logging:
+  level:
+    # turn on request logging
+    org.springframework.web.servlet.DispatcherServlet: DEBUG
+
+    # turn on logging for the service
+    com.netflix.spinnaker.gate: DEBUG
+    com.netflix.spinnaker.clouddriver: WARN
+
+    # if you want all the debug logs, be warned, there's a lot here
+    root: DEBUG
+```
+
+#### Accessing a service's `/resolvedEnv` endpoint
+Spinnaker uses Spring underneath the covers.  Spring has a sophisticated property file system which merges property files based on profiles, environment variables, and variable substitution. To see how Spring has resolved a final property set you'll need to disable security before issuing a GET request to the `/resolvedEnv` endpoint of the service.
+
+>Note:  Disabling security will leave secrets exposed through the `resolvedEnv` endpoint and should only be used for debugging purposes
+
+```yaml
+security:
+  basic:
+    enabled: false
+
+management:
+  security:
+    enabled: false
+```
+
+#### I can't see recently deployed server groups in the infrastructure view with the V2 Kubernetes provider
+
+This is typically a lack of permissions on Kubernetes service account which Spinnaker uses to deploy.  Make sure that you give the service account access to other namespaces in the cluster where you want Spinnaker to deploy to.

--- a/content/en/docs/_admin_guides/userdata.md
+++ b/content/en/docs/_admin_guides/userdata.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: User Data
+order: 100
+---
+{% include components/legacy_documentation.html %}
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+# Modify Global User-Data For All Deployments
+
+When new server-groups are deployed Spinnaker attaches a global [user-data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)  script/file that is prepended to any application specific user-data configured in a server Spinnaker pipeline. By default Armory Spinnaker comes with a user-data file which is placed in `/opt/spinnaker/config/udf/udf0`.  This can be modified and overwritten to your specific needs.
+
+To modify the location of the `udf0` template file update your `clouddriver-local.yml` file and add the following:
+```
+udf:
+  udfRoot: /opt/spinnaker/config/udf
+```
+
+See [udf0 docs](https://www.spinnaker.io/setup/features/user-data/), which by default Spinnaker will create an [`/etc/default/server-env`](https://kb.armory.io/aws/18-what-is-server-env/) file which contain cluster and server group information.
+
+### Related Guides
+
+- [Dynamically defining User-Data]({% link _spinnaker_user_guides/expression-language.md %}#dynamically-defining-user-data)

--- a/content/en/docs/_install_guide/_index.md
+++ b/content/en/docs/_install_guide/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Install Guides (Legacy)"
+linkTitle: "Install-Legacy"
+weight: 20
+---

--- a/content/en/docs/_install_guide/adding_accounts.md
+++ b/content/en/docs/_install_guide/adding_accounts.md
@@ -1,0 +1,232 @@
+---
+layout: post
+title: Adding Accounts
+order: 70
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+# Adding A Kubernetes Account
+
+Spinnaker supports deploying to multiple cloud environments. If you're using Kubernetes you'll need to [follow this guide]({% link _admin_guides/configure_kubernetes.md %})  
+
+# Adding Additional AWS Accounts
+
+Spinnaker supports adding multiple AWS accounts with some users reaching 100s of accounts in production.  Spinnaker uses AWS assume roles to create resources in the target account and then passes the role to a target instance profile if it's creating an instance resource.
+
+
+## Spinnaker's Account Model
+In AWS, Spinnaker relies on IAM policies to access temporary keys into configured accounts by [assuming a role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html). This allows an administrator to limit and audit the actions that Spinnaker is taking in configured accounts.
+
+![spinnaker assume role](/images/Image 2017-04-17 at 8.32.48 AM.png)
+
+## Clouddriver Configuration
+
+For adding additional accounts into Spinnaker you'll need to extend Clouddriver by adding your configuration into `clouddriver-local.yml`.  Here is an example of a Clouddriver configuration file that has 3 accounts as described above.
+
+```yaml
+aws:
+  defaultAssumeRole: role/SpinnakerManagedProfile
+  accounts:
+
+    - name: prod-account
+      accountId: "198765432101"
+      regions:
+        - name: us-east-1
+        - name: us-east-2
+        - name: us-west-1
+
+    - name: staging-account
+      accountId: "123456789012"
+      regions:
+        - name: us-east-1
+        - name: us-west-2
+
+    - name: service-account
+      accountId: "987654321123"
+      regions:
+        - name: us-east-1
+```
+
+You'll also have to set your default account in your `spinnaker-local.yml` file:
+
+```yaml
+providers:
+  aws:
+    primaryCredentials:
+      name: prod-account
+```
+
+## Assume Roles in IAM
+
+You will need to create a `SpinnakerManagedProfile` role in the target AWS account (prod-account, staging-account, service-account) and give it the
+correct trust policy in IAM.  Below is the trust policy you give the `SpinnakerManagedProfile` in the target account to allow the `SpinakerInstanceProfile`.
+
+```yaml
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::987654321123:role/SpinnakerManagedProfile"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::987654321123:role/SpinnakerInstanceProfile"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+Now that the target account has a `SpinnakerManagedProfile`, you will need to update the Managing account `SpinnakerInstanceProfile` `SpinnakerAssumePolicy` to add each managed account.
+
+```yaml
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Resource": [
+        "arn:aws:iam::987654321123:role/SpinnakerManagedProfile",
+        "arn:aws:iam::123456789012:role/SpinnakerManagedProfile"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+```
+
+Below is the latest EC2 policy to use for allowing `SpinnakerInstanceProfile`.
+
+<script src="https://gist-it.appspot.com/https://github.com/Armory/spinnaker-aws-policy/blob/master/policies/latest/SpinnakerInstanceProfile.json"></script>
+
+
+# Adding Artifact Accounts
+
+Artifacts are a main driver behind the Kubernetes V2 provider. They allow you to store Kubernetes manifests in external repositories such as Github or S3 and then deploy those artifacts with Spinnaker. There are many different artifact providers and they are all configured in a similar fashion.
+
+To configure an artifact account, add any of the following snippets to `clouddriver-local.yml` under the top level `artifacts` key. For example, if you wanted to configure 2 artifact accounts, S3 and Github, you would configure them as follows:
+
+```yaml
+# clouddriver-local.yml
+artifacts:
+  s3:
+    enabled: true
+    accounts:
+      - name: s3
+        region: us-west-2
+  github:
+    enabled: true
+    accounts:
+      - name: github
+        token: personalAccessToken
+```
+
+Some providers allow a `usernamePasswordFile` which looks like:
+```
+username:password
+```
+
+Below are example configuration for all available artifact providers.
+
+## Bitbucket
+
+```yaml
+artifacts:
+  bitbucket:
+    enabled: true
+    accounts:
+      - name: bitbucket-account-name
+        username: armory-bot
+        password: supersecretpassword
+        # usernamePasswordFile should only be used if username and password are not used
+        usernamePasswordFile: /passwords/bitbucketCreds.txt
+```
+
+
+## Github
+
+```yaml
+artifacts:
+  github:
+    enabled: true
+    accounts:
+      - name: github-account-name
+        username: armory-bot
+        password: supersecretpassword
+        # usernamePasswordFile should only be used if username and password are not used
+        usernamePasswordFile: /passwords/githubCreds.txt
+        # token can be used instead of a username/password
+        token: personalAccessToken
+        # tokenFile can be used instead of a token or username/password
+        tokenFile: /passwords/githubToken.txt
+```
+
+## Gitlab
+
+```yaml
+artifacts:
+  gitlab:
+    enabled: true
+    accounts:
+      - name: gitlab-account-name
+        token: gitlabApiToken
+        # tokenFile can be used instead of a token
+        tokenFile: /passwords/gitlabToken.txt
+```
+
+## GCS
+
+```yaml
+artifacts:
+  gcs:
+    enabled: true
+    accounts:
+      - name: gcs-account
+        # optional, jsonPath is the path to GCP credentials file
+        jsonPath: /passwords/gcpServiceAccount.json
+```
+
+## S3
+
+```yaml
+artifacts:
+  s3:
+    enabled: true
+    accounts:
+      - name: s3-account
+        # if using AWS S3, use the region where your bucket lives
+        region: us-west-2
+        # apiEndpoint and apiRegion are used if you're using Minio or another S3 compatible solution
+        apiEndpoint: https://my-minio:9000
+        apiRegion: us-east-1
+```
+
+## HTTP
+
+```yaml
+artifacts:
+  http:
+    enabled: true
+    accounts:
+      - name: http-account-name
+        username: armory-bot
+        password: supersecretpassword
+        # usernamePasswordFile should only be used if username and password are not used
+        usernamePasswordFile: /passwords/httpCreds.txt
+```

--- a/content/en/docs/_install_guide/application_pipeline.md
+++ b/content/en/docs/_install_guide/application_pipeline.md
@@ -1,0 +1,136 @@
+---
+layout: post
+title: Application Deployment Pipeline
+order: 90
+# Migrated to spinnaker-user-guides/application-pipeline
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+# What To Expect
+{:.no_toc}
+
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Creating A Pipeline
+
+We'll be creating a pipeline that takes the Debian package produced by a Jenkins job and uses it to create an Amazon Machine Image (AMI) before deploying that image to a server group.
+
+
+Things you should already have prepared beforehand for this example:
+
+- A Jenkins Master configured
+- A Jenkins job that archives a Debian package
+- A security group within AWS with appropriate permissions
+
+#### Step 1: After selecting your Application, click the Pipelines category.
+
+![](/images/Image 2017-03-24 at 3.42.34 PM.png)
+
+#### Step 2: On this page, click the “+” icon.
+
+
+#### Step 3: Input a name for your new pipeline
+
+_Note_: Strategy will be covered in a separate guide.
+
+#### Step 4: On this page you will see
+
+- A visual representation of your pipeline and its stages
+- Concurrent Executions
+- Automated Triggers
+- Parameters
+- Notifications
+- Description
+
+![](/images/Image 2017-03-24 at 3.45.55 PM.png)
+
+#### Step 5: The first thing you should do is set up how your pipeline will be triggered. Scroll down to the Automated Triggers sub section. This section will allow you to select a Type first, looking like this.
+
+![](/images/Image 2017-03-24 at 3.49.39 PM.png)
+
+#### Step 6: For this example we will select Jenkins. By adding a trigger we are defining how our pipeline will be initiated.
+
+![](/images/Image 2017-03-24 at 3.50.27 PM.png)
+
+_Note_: The Property File is an important topic that will be [covered in a separate guide](https://docs.armory.io/spinnaker-user-guides/working-with-jenkins/#property-file).
+
+#### Step 7: Before you test your pipeline, you may want to consider enabling or disabling the trigger via the checklist at the bottom.
+
+#### Step 8: Add a new stage.
+Click the add stage button in the visual representations section.
+
+![](/images/Image 2017-03-24 at 4.19.38 PM.png)
+
+#### Step 9: Select Bake from the different types category.
+
+![](/images/Image 2017-09-05 at 4.47.51 PM.png)
+
+#### Step 10: Select the region you want to bake in.
+Enter the name of the package that was archived by the Jenkins job.
+
+- _Note_: The package name should not include any version numbers. (e.g.: If your build produces a deb file named `myapp_1.27-h343`, you would want to enter `myapp` here.)
+
+- _Note_: If you would like to configure your own Base AMI under the Advanced Options, the Base OS configuration will be ignored.
+
+![](/images/Image 2017-03-24 at 4.26.08 PM.png)
+
+#### Step 11: Now add a Deploy stage by clicking Add Stage again. In the Type category select Deploy. Deploy’s configuration settings should pop up on the screen.
+
+![](/images/Image 2017-03-24 at 4.27.55 PM.png)
+
+_Note_: If we want to reorganize the order that the stages execute in the pipeline, we can add or remove precursor stages in the Depends On category.
+
+#### Step 12: In the Deploy Configuration, click on the “Add server group” button. Pick your provider. For our example it will be AWS.
+
+#### Step 13: Select “Continue without a template”.
+Since this is a new application we will not choose to copy a configuration from a template.
+
+![](/images/Image 2017-03-24 at 4.32.05 PM.png)
+
+#### Step 14: Set up the Deploy Strategy.
+We will use the Highlander strategy for this example, which will ensure that only one server group for our application exists at a time.
+
+![](/images/Image 2017-03-24 at 4.35.23 PM.png)
+
+_Note_: Different deployment strategies are important and there will be a separate guide for those.
+
+#### Step 15: Select a security group
+The security group will define the access rights to your resource.
+
+#### Step 16: Select Instance Type.
+Make sure to select the right instance type for your application, perferrably the one that is running in production currently.
+
+#### Step 17: Select the Capactity
+Select how many instances you want in your server group on deploy. For our example, we will set it at 1.
+
+![](/images/Image 2017-03-24 at 4.39.12 PM.png)
+
+#### Step 18: Add the server group.
+Click "Add" and you'll be brought back to your Application and to see your new Deploy Configuration.
+
+![](/images/Image 2017-03-24 at 4.42.09 PM.png)
+
+#### Step 19: Save the changes
+Press “Save Changes” at the bottom right of your window.
+
+#### Step 20: Go back to the Pipeline Overview.
+You should see your new pipeline. Click on “Start Manual Execution”.
+
+![](/images/Image 2017-03-24 at 4.43.15 PM.png)
+
+#### Step 21: Select the build to run.
+You will be able to select a Build for your Jenkins job from a drop down menu. By default, Spinnaker will not recreate an AMI unless the underlying package has changed. If you would like to force it, you may use the checkbox for “Rebake”.
+
+![](/images/Image 2017-03-24 at 4.44.32 PM.png)
+
+#### Step 22: Run
+You should see a progress bar where blue represents running and green represents complete. Gray represents not ran or canceled. Red is a failed task.
+
+![](/images/Image 2017-03-24 at 4.45.33 PM.png)
+
+If your pipeline does not succeed, refer to one of the troubleshooting sections in the [pipelines]({% link _spinnaker_user_guides/pipelines.md %}#troubleshooting), [baking]({% link _spinnaker_user_guides/baking-images.md %}#troubleshooting), or [deploying]({% link _spinnaker_user_guides/deploying.md %}#common-errors-and-troubleshooting) guides.

--- a/content/en/docs/_install_guide/auth.md
+++ b/content/en/docs/_install_guide/auth.md
@@ -1,0 +1,319 @@
+---
+layout: post
+title: Authentication
+order: 110
+published: True
+---
+
+{% include components/legacy_documentation.html %}
+
+Refer to the Spinnaker documentation for configuring authentication at
+[https://www.spinnaker.io/setup/security/authentication/](https://www.spinnaker.io/setup/security/authentication/)
+
+<div class="deprecation-warning">
+  The information below has been deprecated.
+</div>
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+
+
+> *Note*: If you are going to use authentication with your Spinnaker instance you will no longer be able to use the API without setting up x509 authentication
+
+
+## Basic Auth
+
+- Add the following to `/opt/spinnaker/config/gate-local.yml`:
+
+```
+security:
+  basic:
+    enabled: true
+  user:
+    name: example-username
+    password: example-password
+```
+
+- This will allow you to call the Spinnaker API using basic auth:
+
+```
+curl --user example-username:example-password --header 'Accept: application/json' http://spinnaker-host.example.com:8084/applications
+```
+
+- [Enabling Sticky Sessions](#enabling-sticky-sessions)
+
+
+
+## LDAP Authentication
+
+Add the following to `/opt/spinnaker/config/gate-local.yml`:
+
+```
+ldap:
+  enabled: true
+  url: ldaps://ldap.mycompany.com/dc=mycompany,dc=com
+  userDnPattern: uid={0},ou=users
+```
+
+- You should adjust `mycompany` and `com` to match your organization.
+See the [Spinnaker LDAP Documentation](https://www.spinnaker.io/setup/security/authorization/ldap/#user-dns)
+for more options.
+- [Enable Sticky Sessions](#enable-sticky-sessions)
+- Add the following to your environment file, typically `/opt/spinnaker/env/ha.env`
+
+```
+AUTH_ENABLED=true
+```
+
+- Restart Spinnaker `service armory-spinnaker restart`
+
+
+
+## Google
+- Jump to section [Configuring OAuth for Gate](#configuring-oauth-for-gate) to configure gate.
+- Add the following to `/opt/spinnaker/config/gate-local.yml`:
+
+```
+security:
+  oauth2:
+    enabled: true
+    client:
+      clientId: ################################
+      clientSecret: ################################
+      userAuthorizationUri: https://accounts.google.com/o/oauth2/v2/auth  # Used to get an authorization code
+      accessTokenUri: https://www.googleapis.com/oauth2/v4/token          # Used to get an access token
+      scope: profile email
+    resource:
+      userInfoUri: https://www.googleapis.com/oauth2/v3/userinfo          # Used to the current user's profile
+    userInfoMapping:  # Used to map the userInfo response to our User
+      email: email
+      firstName: given_name
+      lastName: family_name
+    userInfoRequirements: # Used to filter access by userInfo attributes
+      email: /^.*@armory.io$/ # Accepts a Java regular expression or string to match against
+```
+
+- Fill in the values for `clientID` and `clientSecret` generated in the previous step.
+- Add the following to your environment file, typically `/opt/spinnaker/env/ha.env`
+
+```
+AUTH_ENABLED=true
+```
+
+- Restart Spinnaker `service armory-spinnaker restart`
+- [Enable Sticky Sessions](#enable-sticky-sessions)
+
+*A full list of user attributes can be found [here](https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo). Any of these properties can be used as `userInfoRequirements`.*
+
+
+## Github
+- Go to [https://github.com/organizations/YOUR_ORG_HERE/settings/applications/new](https://github.com/organizations/YOUR_ORG_HERE/settings/applications/new)
+- Set it up to look like:
+![](/images/Image 2018-01-16 at 2.47.43 PM.png)
+  * Armory's Logo: [http://go.Armory.io/shield-white](http://go.Armory.io/shield-white)
+  * Fill in `Homepage URL`
+  * Fill in `Authorization callback URL`
+  * **Make sure to use HTTPS for both URLs above.**
+- Add the following to `/opt/spinnaker/config/gate-local.yml`:
+
+```
+security:
+  oauth2:
+    enabled: true
+    client:
+      clientId: ###############
+      clientSecret: #############################
+      userAuthorizationUri: https://github.com/login/oauth/authorize  # Used to get an authorization code
+      accessTokenUri: https://github.com/login/oauth/access_token     # Used to get an access token
+      scope: read:org,user:email
+    resource:
+      userInfoUri: https://api.github.com/user  # Used to the current user's profile
+    userInfoMapping:  # Used to map the userInfo response to our User
+      email: email
+      firstName: name
+      lastName:
+      username: login
+```
+
+- Fill in the values for `clientID` and `clientSecret` generated in the previous step.
+- Add the following to your environment file, typically `/opt/spinnaker/env/ha.env`
+
+```
+AUTH_ENABLED=true
+```
+
+- Restart Spinnaker `service armory-spinnaker restart`
+- [Enable Sticky Sessions](#enable-sticky-sessions)
+
+
+### Github Organization Restriction
+
+By default Github OAuth only requires that a user has a Github account without any restrictions on that account. Many installations will also want to require the user belong to a company organization to be authenticated successfully. When using the organization restriction members must have their visibility set to `Public`. You can view the visibility setting for members on the `People` tab of your organization.
+
+- Ensure that everyone in your organization has their visibility set to Public if they plan to login to Spinnaker:
+![Armory People Screen](/images/Image 2018-04-09 at 10.30.55.png)
+- Add a `providerRequirements` section to the file at `/opt/spinnaker/config/gate-local.yml` under **security.oauth2** so that your configuration looks like the following:
+
+```
+security:
+  oauth2:
+    providerRequirements:
+      type: github
+      organization: ########
+```
+The `organization` field should be the name of the github organization you want to use to restrict membership.
+
+- Restart Spinnaker `service armory-spinnaker restart`
+
+
+
+## Configuring Other OAuth providers
+The configuration below is shown for [Github](#github), however the process is similar with Azure OAuth, Okta, Google or Facebook.
+
+- Add the following to `/opt/spinnaker/config/gate-local.yml`:
+
+```
+security:
+  oauth2:
+    enabled: true
+    client:
+      clientId: #################################
+      clientSecret: #############################
+      userAuthorizationUri: #####################  # Used to get an authorization code
+      accessTokenUri: ###########################  # Used to get an access token
+      scope: ####################################
+    resource:
+      userInfoUri: ################  # Used to the current user's profile
+    userInfoMapping:  # Used to map the userInfo response to our User
+      email: ######################
+      firstName: ##################
+      lastName: ###################
+      username: ###################
+```
+
+- Fill in the values for marked with `#####....`
+- Add the following to your environment file, typically `/opt/spinnaker/env/ha.env`
+
+```
+AUTH_ENABLED=true
+```
+
+- Restart Spinnaker `service armory-spinnaker restart`
+- [Enable Sticky Sessions](#enable-sticky-sessions)
+
+
+
+
+## SAML
+See [Spinnaker's docs](https://www.spinnaker.io/setup/security/authorization/saml/) for more information.
+
+
+
+## x509
+
+x509 certificates are typically used to allow users to connect to the Spinnaker API.  This is especially helpful if you want different groups within your organization to maintain different keys.  You can re-use the same certificate as you used in the previous step but might want to maintain different certificates for groups within your organization.
+
+In order to enable x509 certificates we'll need to add an additional trust certificate to the keystore.
+
+In your `/opt/spinnaker/config/gate-local.yml` file add the following:
+
+```
+x509:
+  enabled: true
+  subjectPrincipalRegex: EMAILADDRESS=(.*?)(?:,|$)
+
+server:
+  ssl:
+    enabled: true
+    keyStore: /opt/spinnaker/config/keystore.jks
+    keyStorePassword: ${YOUR_PASSWORD}
+    keyAlias: server
+    trustStore: /opt/spinnaker/config/keystore.jks
+    trustStorePassword: ${YOUR_PASSWORD}
+    clientAuth: want
+
+default:
+  apiPort: 8085
+```
+
+The configuration adds an additional port for x509 certificates. This is so you can terminate HTTPS to end-users of the UI on the ELB and continue using API on a different port with x509 client certificates.
+
+We'll need to create an additional key for the client/server to use for authentication.  The example below is for self signed certificates:
+
+Generate Certificate Authority
+
+```
+openssl genrsa -des3 -out ca.key 4096
+```
+
+Self-sign a certificate with the key that was created in the previous step
+```
+openssl req -new -x509 -days 365 -key ca.key -out ca.crt
+```
+
+Create a client key
+```
+openssl genrsa -des3 -out client.key 4096
+```
+
+Generate a new Certificate Signing Request (CSR) from the client key used in the previous step.
+```
+openssl req -new -key client.key -out client.csr
+```
+
+Next, we'll self-sign the certificate to use on the server
+```
+openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt
+```
+
+Import the root CA into the keystore
+```
+keytool -importcert -file ca.crt -keystore keystore.jks -alias ca
+```
+
+Import the client certificate into the keystore
+```
+keytool -importcert -file client.crt -keystore keystore.jks -alias client
+```
+
+Then restart Armory:
+```
+service armory-spinnaker restart
+```
+
+In order for your client to communicate with the API you'll need to a `PEM` formatted file which contains both the cert and key.
+```
+cat client.crt client.key > client.pem
+```
+
+To test the certificate you can use curl directly from the host. It should return a JSON list of applications:
+```
+curl https://localhost:8085/applications --cert client.pem -k
+```
+
+### x509 and Fiat
+If you're running fiat you'll need to tell Spinnaker which groups are associated with your certificate.  x509 provides a field called `1.2.840.10070.8.1` which can be embedded in the client certificate to assign groups to the certificate.  The [Spinnaker OSS documentation provides a guide](https://www.spinnaker.io/setup/security/authentication/x509/#creating-an-x509-client-certificate-with-user-role-information) on how to generate a client certificate with the `1.2.840.10070.8.1` field.
+
+You'll also need to update your `/opt/spinnaker/config/gate-local.yml` file add the following:
+
+```
+x509:
+  enabled: true
+  subjectPrincipalRegex: EMAILADDRESS=(.*?)(?:,|$)
+  roleOid: 1.2.840.10070.8.1
+```
+
+Then restart Armory
+`service armory-spinnaker restart`
+
+## Enable Sticky Sessions
+
+Before you configure authentication you'll need to enable sticky sessions for the external ELB for port `8084` (Gate).  This must be done through the AWS console.  
+- For an infinite session leave the `Expiration Period` blank.
+- *Note* Make sure to use load balancer generated cookies.
+![Adding Sticky Sessions](/images/Image 2017-10-11 at 9.26.58 AM.png)

--- a/content/en/docs/_install_guide/authz.md
+++ b/content/en/docs/_install_guide/authz.md
@@ -1,0 +1,172 @@
+---
+layout: post
+title: Authorization
+order: 120
+published: True
+---
+
+{% include components/legacy_documentation.html %}
+
+Refer to the Spinnaker documentation for configuring authorization at
+[https://www.spinnaker.io/setup/security/authorization/](https://www.spinnaker.io/setup/security/authorization/)
+
+<div class="deprecation-warning">
+  The information below has been deprecated.
+</div>
+
+# Turning on Fiat
+{:.no_toc}
+
+Authorization is handled by a micro-service called `Fiat`.  Fiat is responsible for access control for both applications and accounts.  It's also responsible for executing triggers with service accounts. Fiat authorization model is open by default, read more about authorizations [here](https://www.spinnaker.io/setup/security/authorization).
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+
+## Open Port
+
+On the internal ELB make sure port 7003 is open. If there's no listener for 7003 then add it, copying the configuration used for the listener on port 7002.
+
+## Enabling Fiat
+
+To enable fiat, set the following: `FIAT_ENABLED=true` in your environment variable.  This is
+typically stored at `/opt/spinnaker/env/` with a correlated environment file.  You'll also have to make sure that [authentication
+is setup first](https://docs.armory.io/install-guide/auth/).  Next steps are to configure an authorization provider (see below) which will inform Fiat
+about users and their group membership.
+
+## LDAP
+
+Consider the following sample ldap database:
+
+```yml
+### Users group
+
+dn: ou=users,dc=mycompany,dc=com
+objectClass: organizationalUnit
+ou: users
+description: generic users branch
+
+### Container for groups which users belong to
+
+dn: ou=groups,dc=mycompany,dc=com
+objectClass: organizationalUnit
+ou: groups
+description: generic groups branch
+
+### A sample group
+
+dn: cn=eng,ou=groups,dc=mycompany,dc=com
+objectClass: groupOfNames
+cn: eng
+description: Engineering group
+member: cn=isaac,ou=users,dc=armory,dc=io
+member: ...
+
+### First user
+
+dn: uid=isaac,ou=users,dc=mycompany,dc=com
+objectClass: posixAccount
+cn: isaac
+uid: isaac
+uidNumber: 16000
+gidNumber: 100
+homeDirectory: /home/isaac
+loginShell: /bin/bash
+```
+
+This sample data could be handled by adding the following configuration to the
+file `/opt/spinnaker/config/fiat-local.yml`:
+
+```yml
+auth:
+  groupMembership:
+    service: ldap
+    ldap:
+      url: ldaps://ldap.mycompany.com
+      managerDn: cn=admin,dc=mycompany,dc=com
+      managerPassword: myPassword
+      groupSearchBase: ou=groups,dc=mycompany,dc=com
+      groupSearchFilter: member={0},dc=mycompany,dc=com
+      groupRoleAttributes: cn
+      userDnPattern: uid={0},ou=users
+      userSearchBase: dc=mycompany,dc=com
+      userSearchFilter: ''
+```
+
+You must tailor this configuration to match your ldap database.
+* adjust `mycompany` and `com` to match your organization.
+* adjust `managerDn` and `managerPassword` on lines 8 & 9.
+* adjust `groups` to be the parent DN of your groups.
+* replace `member` with the key that you use when you add a user to a group. In the sample data, 'member' is used to add isaac and don to the eng group.
+
+
+## Github
+
+Fiat supports application and AWS account access based on [Github teams](https://help.github.com/articles/about-teams/). Fiat will poll Github to find changes to teams in Github.
+
+You'll need to generate a personal API access token here: [https://github.com/settings/tokens](https://github.com/settings/tokens). It only needs to have `read:org` permissions.
+> *Note*: You might want to create a GitHub Bot account for this and add it to your organization
+
+![](/images/Image 2017-01-06 at 5.23.33 PM.png)
+
+Add the configuration below to: `/opt/spinnaker/config/fiat-local.yml`:
+
+```yml
+auth:
+  groupMembership:
+    service: github
+    github:
+      organization: YOUR_ORGANIZATION
+      baseUrl: https://api.github.com
+      access_token: YOUR_ACCESS_TOKEN  # access token handled by secret store
+```
+
+## OKTA
+
+OKTA has its own [separate guide](/spinnaker-install-admin-guides/okta/) due to its lengthy configuration
+
+## Application Access
+
+To modify an application's access go to `application -> config > edit application attributes -> permissions`
+
+![application permissions](/images/Image 2017-08-09 at 12.34.13 PM.png)
+
+Once you have your authorization provider configured you should be able to see available groups for your user.  For each group that is added to the list you can select "Read-Only" or "Read/Write" Permissions.  Once groups are added to the list no other users will be able to access that application.
+
+![application permissions](/images/Image 2017-08-09 at 12.35.25 PM.png)
+
+## Account Access
+
+To restrict access to an account based on group membership add you'll need to add
+the `permissions` field to your accounts which is configured in
+`/opt/spinnaker/config/clouddriver-local.yml`.
+
+```yml
+aws:
+  accounts:
+    - name: mobile-apps-account
+      accountId: "111111111111"
+      permissions:
+        read:
+          - mobile-team-devs
+          - mobile-team-qa
+        write:
+          - mobile-team-qa
+```
+
+then restart armory-spinnaker:
+```
+service armory-spinnaker restart
+```
+
+# Configure a Service Account
+When fiat is enabled, some Spinnaker operations require [adding a service account](https://www.spinnaker.io/setup/security/authorization/service-accounts/).  The service
+account should be a `memberOf` of `armoryspinnaker`'s permission groups.
+
+This account will be used to shutdown old instances when you re-deploy `armoryspinnaker`. To configure the service account, edit `spinnaker-local.yml` to include:
+```yml
+services:
+  lighthouse:
+    # Put your service account here;
+    defaultServiceAccount: armory-lighthouse
+```

--- a/content/en/docs/_install_guide/config_repo.md
+++ b/content/en/docs/_install_guide/config_repo.md
@@ -1,0 +1,140 @@
+---
+layout: post
+title: Storing Configurations
+order: 40
+---
+
+{% include components/legacy_documentation.html %}
+
+Refer to the Spinnaker documentation for storing configurations at
+[https://www.spinnaker.io/setup/install/backups/](https://www.spinnaker.io/setup/install/backups/)
+
+<div class="deprecation-warning">
+  The information below has been deprecated.
+</div>
+
+## What to expect
+{:.no_toc}
+By storing configuration in source control we get all of the benefits that go along with it (versioning, change history, etc.) We provide 2 methods for storing configurations for Armory Spinnaker:
+- [Packaged Configurations](#packaged-configurations)
+  + stored in github 
+  + Package (Debians) using Jenkins 
+  + Storing the artifact in Bintray, deb-s3, nexus ...
+- [S3 Configurations](#s3-configurations)
+  + stored in a versioned, encrypted s3 bucket
+  + simple revision history
+
+
+## Overview
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+
+# Understanding config files
+See the example files here: [https://github.com/Armory/spinnaker-config-deb/tree/master/deb-config/spinnaker](https://github.com/Armory/spinnaker-config-deb/tree/master/deb-config/spinnaker)
+
+Spinnaker uses Spring's configuration ymls located in `/opt/spinnaker/config/`. Files are merged in top down order.  
+Example:
+```
+spinnaker.yml
+spinnaker-armory.yml  overrides spinnaker.yml
+spinnaker-local.yml   overrides spinnaker-armory.yml, spinnaker.yml
+spinnaker-secrets.yml overrides spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+ENVIRONMENT_VARIABLES overrides spinnaker-secrets.yml, spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+```
+
+A subservice will also include `spinnaker` configuration files, for example `igor`:
+```
+spinnaker.yml
+spinnaker-armory.yml  overrides spinnaker.yml
+spinnaker-local.yml   overrides spinnaker-armory.yml, spinnaker.yml
+spinnaker-secrets.yml overrides spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+igor.yml              overrides spinnaker-secrets.yml, spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+igor-armory.yml       overrides igor.yml, spinnaker-secrets.yml, spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+igor-local.yml        overrides igor-armory.yml, igor.yml, spinnaker-secrets.yml, spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+igor-secrets.yml      overrides igor-local.yml, igor-armory.yml, igor.yml, spinnaker-secrets.yml, spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+ENVIRONMENT_VARIABLES overrides igor-secrets.yml, igor-local.yml, igor-armory.yml, igor.yml, spinnaker-secrets.yml, spinnaker-local.yml, spinnaker-armory.yml, spinnaker.yml
+```
+
+
+
+# Secrets
+After choosing any configuration store, secrets should be handled by a secrets store. `bin/secrets` will run at runtime to fetch secrets from where ever your secrets are stored. Armory provides you a namespace `-secrets.yml` to store secret ymls. You edit [`bin/secrets`](https://github.com/Armory/spinnaker-config-deb/blob/master/deb-config/spinnaker/bin/secrets) to fetch and populate secrets by:
+- using secret ymls (ex: `igor-secrets.yml`) stored in `/opt/spinnaker/config/`
+- using password files stored in `/opt/spinnaker/secrets/`
+- set ENV variables
+
+
+
+
+# Packaged Configurations
+
+## GitHub Repo
+
+We'll start by forking the example repo from the Armory GitHub organization here: [`https://github.com/Armory/spinnaker-config-deb`](https://github.com/Armory/spinnaker-config-deb). After forking, you can find the Spinnaker configuration `-local.yml` files in `./deb-config/spinnaker/config`.
+
+
+
+## Packaging
+
+The forked repo is set up to build a deb package out of the configuration files. You can see how this works in `/bin/build.sh`. If you are using Jenkins then you can look at `./Jenkinsfile` as an example. This is the flow you need to create in the build system:
+
+- `bin/build.sh` executes and creates an artifact in `build/distributions/*.deb`
+- The `deb` file is uploaded to a central artifact store.
+
+If you are using Jenkins, make sure to artifact the deb package. This is what tells Spinnaker which version of your package to use.
+
+
+### Alternatives
+
+If you do not already have a central artifact repository system you might want to check out [Deb S3](https://github.com/krobertson/deb-s3). You may want to setup IAM permissions, but this is left as an exercise for the reader, however PRs are welcomed!
+
+
+
+## Validation
+
+After the deb package is built and published to your central artifact repository you should verify that Spinnaker will be able to download it. To do this, SSH to one of the Spinnaker instances using the keys you provided during the installation. While connected, try to pull the artifact manually.
+
+
+
+# S3 Configurations
+Armory includes a configurator that will store configurations in s3. This uses the bucket created during the installation of Armory to store configurations. You'll need to:
+- [turn on s3 versioning](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html)
+- (optional) [turn on default bucket encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html)
+- [Turn on the Configurator](#turning-on-the-configurator)
+
+
+## Turning on the Configurator
+- edit your env file (`ha.env`) and add:
+```
+CONFIGURATOR_ENABLED=true
+```
+
+- restart armory spinnaker
+```
+service armory-spinnaker restart
+```
+
+- visit [http://your.spinnaker.elb/armory/config/](http://your.spinnaker.elb/armory/config/)
+- edit a file and hit `save` to persist the local version to s3
+
+
+
+## Using the Configurator
+The Configurator will make edits to one of Armory Spinnaker's machines, then uploads the files to s3.
+Configurations are locked to a server group at runtime, so you must redeploy it to see changes. This allows you to rollback to an existing OK Armory Spinnaker.
+
+### For big config changes (ex: initial setup) or fast dev cycle time:
+- Scale down to 1 polling ArmorySpinnaker
+- Edit the config on the machine
+- Restart ArmorySpinnaker
+- Verify changes are live
+- After you've finished, load the Configurator [http://your.spinnaker.elb/armory/config](http://your.spinnaker.elb/armory/config) 
+- Hit save to persist the config
+- Redeploy ArmorySpinnaker
+
+### For smaller changes, make the change on the Configurator:
+- Hit save to persist the config
+- Redeploy ArmorySpinnaker

--- a/content/en/docs/_install_guide/dinghy.md
+++ b/content/en/docs/_install_guide/dinghy.md
@@ -1,0 +1,75 @@
+---
+layout: post
+title: Pipelines as Code
+order: 130
+---
+
+<div class="deprecation-warning">
+  The information below was written for a previous version of Armory Spinnaker
+  (v1.13 and earlier).  Please look <a href="/spinnaker/install_dinghy">here</a> for
+  documentation on the latest version.
+</div>
+
+# What To Expect
+This guide should include:
+- Configurator changes needed before enabling Armory's "Pipelines as code" feature
+- Setting up GitHub or Stash webhooks to work with the "Pipelines as code" feature
+
+## Overview
+To get an overview of Pipelines as code, check out the [user guide](http://docs.armory.io/user-guides/dinghy)
+
+
+## Steps to follow to configure Pipelines as code:
+
+- Create a personal access token (in either [GitHub](https://github.com/settings/tokens) or Stash) that has read access to all repos where `dinghyfile`s and `module`s reside. Place this token in a file called `github-creds.txt` (or `stash-creds.txt`). The contents of this file should be of the format: `username:token`. Place this file in your secrets management system. By default, this will be the S3 bucket where the other credentials for spinnaker are pulled from.
+
+> Note: All the below config file changes are either done in the configurator UI `https://your.spinnaker.installation/#/platform/config` or wherever spinnaker configs are stored in your installation.
+
+- Add a line to `/bin/secrets` to copy the credentials created in the previous step to the instance where spinnaker will run. e.g.: `aws s3 cp s3://your-s3-bucket/aws/spinnaker/${ENV}/github-creds.txt "${SPINNAKER_SECRETS_DIR}"`
+
+- Create a new file: `config/dinghy-local.yml` with the following contents:
+
+```
+templateOrg:       armory-io  # github or stash "org" where the app repos and templates reside
+dinghyFilename:    dinghyfile # name of the file which describes pipelines
+templateRepo:      dinghy-templates # name of the repo containing modules
+autoLockPipelines: true # whether or not to lock pipelines in the UI before updating them
+spinAPIUrl:        https://spinnaker.your-company.com:8085
+spinUIUrl:         https://spinnaker.your-company.io
+githubCredsPath:   /path/to/github-creds # credentials for github api (username:token)
+stashCredsPath:    /path/to/github-creds # credentials for stash api (username:token)
+stashEndpoint:     http://stash.mycompany.com/rest/api/1.0", # url where stash is running
+logging:
+    level: INFO  # one of: (DEBUG, INFO, WARN, ERROR, FATAL, PANIC)
+    # file: /var/log/dinghy.log  (This is optional, default is stdout i.e., goes to docker logs, remove comment if you want to log to a file)
+orca:
+    enabled: true
+    baseUrl: http://orca:8083
+front50:
+    enabled: true
+    baseUrl: http://front50:8080
+fiat:  # if you have fiat enabled
+    enabled: true
+    baseUrl: http://fiat:7003
+    authUser: your-service-account
+```
+
+> Note: If you have fiat enabled, set the authUser to your service account which is in a group that has read/write access to the pipelines you will be updating. If you have app specific permissions configured in your spinnaker application, make sure the service account is added. If you need to create a new service account, here are the [instructions](https://www.spinnaker.io/setup/security/authorization/service-accounts/#creating-service-accounts)
+
+- Edit the file `config/echo-local.yml` and add the following contents to it:
+```
+armorywebhooks:
+    enabled: true
+    forwarding:
+      baseUrl: http://${DEFAULT_DNS_NAME:dinghy}:8081  # dinghy
+      endpoint: v1/webhooks
+```
+- Edit the file: `prod.env` (or `dev.env` if in dev environment) and set the following environment variable `DINGHY_ENABLED=true`
+
+- If you're using GitHub, setup webhooks at the organization level for Push events. You can do that by going to: [](https://github.com/organizations/your_org_here/settings/hooks). Set the `Payload URL` to: `https://spinnaker.your-company.com:8084/webhooks/git/github`. You’ll need to have github’s webhooks IP whitelisted. You can find their IPs here: [](https://api.github.com/meta), you can read [github's docs here](https://help.github.com/articles/about-github-s-ip-addresses/).
+
+- If you're using Stash, you'll need to setup webhooks for each project that has the dinghyfile or module separately. Make the webhook POST to: `https://spinnaker.your-company.com:8084/webhooks/git/stash`. If you're using stash `<v3.11.6`, you'll need to install the following [webhook plugin](https://marketplace.atlassian.com/plugins/com.atlassian.stash.plugin.stash-web-post-receive-hooks-plugin/server/overview) to be able to setup webhooks.
+
+- Configure your spinnaker installation's _internal load balancer_ to forward all traffic on port 8081. Here's a [video](https://marketplace.atlassian.com/plugins/com.atlassian.stash.plugin.stash-web-post-receive-hooks-plugin/server/overview) that walks you through the process.
+
+Now that all the configs are in place, upgrade to the release you recieved from Armory and the "Pipelines as Code" feature should be up and running. Refer to the [user guide](http://docs.armory.io/user-guides/dinghy) on how to use this feature!

--- a/content/en/docs/_install_guide/dns-and-ssl.md
+++ b/content/en/docs/_install_guide/dns-and-ssl.md
@@ -1,0 +1,95 @@
+---
+layout: post
+title: DNS and SSL
+order: 100
+# This page should not be redirected to a new page, as it is significantly different from the Kubernetes DNS-SSL page.
+redirect_from:
+  - /install_guide/dns_and_ssl/
+  - /install-guide/dns_and_ssl/
+---
+
+{% include components/legacy_documentation.html %}
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Create a DNS Entry for your Load Balancer
+
+Add a DNS Entry to your DNS management system.  You should only need to add a DNS entry for the user-facing ELB which is what you use to currently access Spinnaker.   It typically has a name such as the one below
+
+```
+armoryspinnaker-prod-external-123456789.us-west-1.elb.amazonaws.com
+```
+
+Add a CNAME entry for the given ELB to create a simple name you will use to access your instance of Spinnaker, e.g. `spinnaker.armory.io`.
+
+## Update Spinnaker Configuration
+
+Update the values for `DECK_HOST` and `API_HOST` in your environment file in the `/opt/spinnaker/env` directory.
+
+```
+DECK_HOST=http://spinnaker.mydomain.com
+API_HOST=http://spinnaker.mydomain.com:8084
+```
+
+## SSL Termination at the ELB
+
+For SSL, it can be beneficial to terminate SSL at the Elastic Load Balancer (ELB) whenever feasible. Amazon has the [Key Management Service (KMS)](https://aws.amazon.com/kms/) for this purpose. If you need to handle certificate management at the application level, you might want to check out [Netflix's Lemur](http://techblog.netflix.com/2015/09/introducing-lemur.html) project.
+
+> Note: Even if you terminate SSL at the ELB, you must still give Spinnaker a certificate due to workflow bugs between Spring and Tomcat.  This certificate is only used between the ELB and Spinnaker.
+
+## Enabling HTTPS/SSL in Spinnaker
+
+In order to enable SSL we'll need to provide Gate (and thus Java) with certificates in a java keystore (JKS) _and_ terminate at the ELB.  This will ensure secure communication between your browser/clients and Spinnaker Deck & Gate
+
+> Note: Even if you terminate SSL at the ELB, you must still give Spinnaker a certificate due to workflow bugs between Spring and Tomcat.  This certificate is only used between the ELB and Spinnaker.
+
+For the following example we're going to create self-signed certificates although for production use you will want to have an official certificate authority (CA) sign your certificate.
+
+You can **either** import your own cert **or** create a self signed cert:
+
+ - Importing **your own Certificate**.
+```
+export YOUR_KEY_PASSWORD=""
+export YOUR_KEYSTORE_PASSWORD=""
+keytool -importkeystore -srckeystore server.p12 -srcstoretype pkcs12 -srcalias spinnaker -srcstorepass ${YOUR_KEY_PASSWORD} -destkeystore keystore.jks -deststoretype jks -destalias server -deststorepass ${YOUR_KEY_PASSWORD} -destkeypass ${YOUR_KEYSTORE_PASSWORD}
+```
+
+- Creating a **self-signed CA (EXPIRES IN 360 DAYS)** with java keystore.
+```
+apt-get install -y openjdk-7-jre-headless
+export YOUR_KEYSTORE_PASSWORD="someRandomPa33W0rdForKeystoreForELBtoGateCommunication"
+echo -e "\n\n\n\n\n\ny\n" | keytool -genkey -keyalg RSA -alias server -keystore keystore.jks -storepass ${YOUR_KEYSTORE_PASSWORD} -validity 360 -keysize 2048
+mv keystore.jks /opt/spinnaker/config/
+```
+
+In `/opt/spinnaker/config/gate-local.yml` add the following, making sure to replace the password with your own that you provided in the previous step:
+
+```
+server:
+  ssl:
+    enabled: true
+    keyStore: /opt/spinnaker/config/keystore.jks
+    keyStorePassword: ${YOUR_KEYSTORE_PASSWORD}
+    keyAlias: server
+```
+
+Update our API_HOST and DECK_HOST environment variables to now have `https`. Add the following into `default.env` or if your environment specific env file place it in there: `${CLOUD_STACK}.env`:
+
+```
+API_HOST=https://spinnaker.example-domain.com:8084
+DECK_HOST=https://spinnaker.example-domain.com
+```
+
+Update your ELB to contain the following port mappings:
+
+![elb](/images/Image 2017-12-18 at 10.36.37 AM.png)
+
+
+Now you can restart Armory Spinnaker by doing
+```
+service armory-spinnaker restart
+```

--- a/content/en/docs/_install_guide/initial_setup.md
+++ b/content/en/docs/_install_guide/initial_setup.md
@@ -1,0 +1,91 @@
+---
+layout: post
+title: Initial Setup
+order: 1
+published: false
+---
+{% include components/legacy_documentation.html %}
+
+# Setting Up Armory Spinnaker
+{:.no_toc}
+
+The [installation guide]({% link _spinnaker_install_admin_guides/aws-subnets.md %}) described how to install Armory Spinnaker for the first time. Once it is installed you will need to configure your environment in order to fully utilize Spinnaker.
+
+An ideal EC2 based deployment has the following workflow:
+1. A change is made to master in your code repository.
+2. Jenkins builds the repo and archives a artifact.
+3. Jenkins uploads the artifact to an artifact repository.
+4. Spinnaker triggers a pipeline based on the Jenkins job completing.
+5. Spinnaker downloads the artifact from the central artifact repository.
+6. Spinnaker creates and AMI with the artifact installed.
+7. Spinnaker deploys the AMI to an environment.
+
+This guide will outline the steps necessary to configure Spinnaker for the above workflow.
+
+While configuring Spinnaker for the first time you should scale down your Spinnaker cluster to one instance. You will also need to change the Autoscaling Group healthcheck type from ELB to EC2. This will allow you to restart Armory Spinnaker without the ASG terminating the instance.
+
+Start by SSH'ing to the single instance of Armory Spinnaker. Throughout this guide you will be making changes to the `.yml` files in `/opt/spinnaker/config/`. In order for the changes to take affect you will need to restart Armory Spinnaker. To restart run the following:
+```
+$ sudo service armory-spinnaker restart
+```
+
+It will take a moment for the services to come back online. You can check its status by running:
+```
+$ watch curl http://localhost:5000/healthcheck
+```
+Then `ctrl+c` to exit watch once it is healthy.
+
+## Adding AWS Accounts
+The first thing you need to do is configure the AWS accounts you would like to use as deploy targets. Check out the instructions [here]({% link _install_guide/adding_accounts.md %}). Restart Spinnaker. You can verify the accounts are registered by SSHing to the Spinnaker instance and running:
+```
+$ curl http://localhost:8084/credentials
+```
+You should see something like this:
+```
+[
+  {
+    "accountId": "315216489504",
+    "name": "default-aws-account",
+    "requiredGroupMembership": [],
+    "type": "aws"
+  },
+  {
+    "accountId": "025174528366",
+    "name": "aws-dev",
+    "requiredGroupMembership": [],
+    "type": "aws"
+  }
+  {
+    "accountId": "136468154731",
+    "name": "aws-staging",
+    "requiredGroupMembership": [],
+    "type": "aws"
+  }
+]
+```
+Verify that the `accountId`s match what you intended.
+
+## Subnets
+After you have your accounts added to Spinnaker, you will need to configure the tags on the subnets. Only configured subnets can be deployed to by Spinnaker. Spinnaker would like you to categorize your subnets so that it knows which ones are similar enough to deploy to for different purposes. There is a seperate guide on configuring your subnets that you can find [here]({% link _spinnaker_install_admin_guides/aws-subnets.md %})
+
+
+## Jenkins
+You can add a Jenkins master to Spinnaker by following [this guide]({% link _install_guide/jenkins.md %}). Once the master is added you will need to restart your Spinnaker instance. You can verify that the master has been added correctly by running the following form the instance:
+```
+$ curl http://localhost:8084/v2/builds
+```
+You can expect a response similar to:
+```
+["Prod Jenkins Master", "Dev Jenkins Master"]
+```
+You should also double check that the Spinnaker instance can access the Jenkins master by running:
+```
+$ curl http://<your-jenkins-hostname>/api/xml
+```
+Note: you may need to specify a username and password with your curl command.
+
+
+## Artifact Repository
+You will need to make sure you can communicate the with the artifact repository. This is usually more an excercise in networking and permissions. To double check, you can run curl in a similar fasion to the Jenkins setup above. 
+
+If you are using a deb or RPM repository then you will need to create a base AMI that has your repo's source list and GPG keys installed. Then Spinnaker should use that base AMI in a bake stage.

--- a/content/en/docs/_install_guide/install.md
+++ b/content/en/docs/_install_guide/install.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title: Installation
+order: 20
+# This has been redirected to spinnaker/install
+---
+{% include components/legacy_documentation.html %}
+
+# Installing Armory Spinnaker
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Installing Armory Spinnaker In Kubernetes
+
+Armory Spinnaker can now be installed in Kubernetes. Please [answer these questions about your environment](go.armory.io/needs-analysis) so we can help you install Armory.
+
+[Learn more here](https://www.armory.io/pricing).
+
+## Installing Armory Spinnaker In EC2 on AWS
+
+*We highly recommend using the Kubernetes installer, above. This installer will be deprecated on 12/31/2018.*
+
+The installer is a script that is responsible for asking the user for customer specific inputs like AWS keys, VPC, subnets and S3 buckets. These inputs are kept locally on your system and then passed to Terraform.  You can also install Armory Spinnaker directly from the Debian or RPM package if you don't need the additional resources (S3/ElastiCache/IAM roles) created for you.  Before getting started you'll want to review the [architecture](https://docs.armory.io/admin-guides/architecture/#high-availability-ha) guide, it'll give you an overview of Armory Spinnaker.
+
+Armory Spinnaker comes with an installer that walks you through deploying Spinnaker in your AWS account.  It should only take 15 minutes to have an instance of Armory Spinnaker up and running.  To get started, open up a terminal and execute the following:
+
+`bash -c "$(curl -sS https://get.armory.io)"`
+
+You will need a AWS user/profile with permission to create the following resources:
+
+- Autoscaling group and launch configuration
+- Elastic Load Balancer
+- Security group for the ELB
+- Security group for the Spinnaker stack
+- Elastic Cache (Redis)
+- IAM Role for Spinnaker instances
+- IAM Role for Spinnaker managed account
+- IAM Policy Spinnaker S3 Access
+- IAM Policy Spinnaker assume role permissions
+- IAM Policy Spinnaker ECR read access
+
+If you want to learn more about what is happening behind the scenes, you can go through the components below.
+
+### Continuing From A Previous Install
+![previous](/images/Image 2017-04-14 at 9.15.55 AM.png)
+
+### Terraform Templates
+
+The installation of Armory Spinnaker relies on Terraform templates to create the infrastructure described above.  The `tfstate` file is created and backed by S3 for record keeping.
+Note: You do not have to have Terraform installed for this as the dependency is managed with Docker. All you need is Docker installed to deploy Spinnaker for the first time.
+
+Once you have Spinnaker deployed, you can then use Spinnaker to deploy itself.
+
+#### Spinnaker-Terraform
+Configuration(s) to set Spinnaker up for the first time.
+
+`ha` - Configuration for a highly available setup.
+
+`stand-alone` - Configuration for a development setup.
+
+`modules` - Common configuration shared by both setups.
+
+The installer will download the latest stable version of the Terraform files and place them in `~/armory/`. - If you want to customize how the bootstrapped version of Spinnaker is installed, make changes to the template files in `~/armory/` and run the installer again.
+
+### Validating Your Spinnaker Install
+
+![hello](/images/98c70de3cd1c9778e50d5aa0e4db15f6_Image 2017-09-13 at 4.10.04 PM.png)
+
+### Uninstall Armory Spinnaker
+
+To uninstall Armory Spinnaker, run the install script again with the following environment variable set: `UNINSTALL_ARMORY_SPINNAKER=uninstall`. 
+
+```
+UNINSTALL_ARMORY_SPINNAKER=uninstall bash -c "$(curl -sS https://get.armory.io)"
+```

--- a/content/en/docs/_install_guide/jenkins.md
+++ b/content/en/docs/_install_guide/jenkins.md
@@ -1,0 +1,83 @@
+---
+layout: post
+title: Jenkins
+order: 50
+---
+
+{% include components/legacy_documentation.html %}
+
+Refer to the Spinnaker documentation for configuring Jenkins at
+[https://www.spinnaker.io/setup/ci/jenkins/](https://www.spinnaker.io/setup/ci/jenkins/)
+
+<div class="deprecation-warning">
+  The information below has been deprecated.
+</div>
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+# Continuous Integration (CI)
+Spinnaker's goal is to leverage existing CI solutions to build and produce an artifact that can be deployed.
+
+## Enabling Spinnaker to Communicate with Jenkins
+
+To enable Spinnaker to communicate with your Jenkins instance you will need to edit your `spinnaker-local.yml` file.
+First prepare to configure Jenkins by finding your password or API Token.  You can find your token here: `http://${YOUR_JENKINS_URL}/me/configure`.
+
+Then configure your `/opt/spinnaker/config/spinnaker-local.yml` file and add the following:
+
+```
+services:
+  igor:
+    enabled: true
+  jenkins:
+    enabled: true
+    defaultMaster:
+      name: Name-of-Jenkins-Service
+      baseUrl: http://${YOUR_JENKINS_URL}
+      username: ${YOUR_USERNAME}
+      password: ${API_TOKEN}
+```
+
+Make sure to restart the Igor service: `sudo docker restart igor`
+
+## Multiple Jenkins Masters
+
+If you have more than one Jenkins master, you'll need to edit your `igor-local.yml`.
+
+```
+
+jenkins:
+  enabled: ${services.jenkins.enabled:false}
+  masters:
+    - name: First-Master
+      address: http://firstmaster.example.com:8080
+      username: first-master-username
+      password: first-master-password
+    - name: Second-Master
+      address: http://second-master.example.com
+      username: second-master-username
+      password: second-master-password
+```
+
+## Purpose
+Igor is an API that is responsible for executing and reading the state of jobs from Jenkins.
+
+
+## Verify Your Jenkins Configuration
+You can see if you've configured your jenkins master correctly by querying `Gate`:
+```
+curl localhost:8084/v2/builds
+```
+
+You should see a response similar to:
+```
+[
+  "Armory Jenkins",
+  "First-Master",
+  "Second-Master"
+]
+```

--- a/content/en/docs/_install_guide/logging.md
+++ b/content/en/docs/_install_guide/logging.md
@@ -1,0 +1,248 @@
+---
+layout: post
+title: Logging And Monitoring
+order: 130
+---
+
+{% include components/legacy_documentation.html %}
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Armory Spinnaker's Application Logs with Docker
+Pushing your logs to a distributed service is as simple as using one of the logging drivers provided by Docker.   All logging comes from `STDOUT` inside of Docker and can be pushed to various endpoints.
+
+
+## Enabling A Logging Profile
+
+Armory Spinnaker exposes control over logging through Docker compose. The configuration is made available by files placed in `/opt/spinnaker/compose` and selected by setting the `LOGGING_PROFILE` environment variable.  For example, if you want to create a syslog logging profile you would create the file `/opt/spinnaker/compose/logging-syslog.yml` and set `LOGGING_PROFILE=syslog`.
+
+You can set a logging profile by changing the variable per environment.  You can find the environment file that is used at startup at `/opt/spinnaker/env`.
+
+
+## Logging Drivers for Docker
+
+You can use any of the available logging drivers for Docker.  At the time of this writing below are the supported drivers from Docker:
+
+![supported docker drivers](/images/Image 2017-04-13 at 11.22.03 AM.png)
+
+
+## Example: Logging to Splunk
+
+Below is a sample logging-splunk.yml file that can be used to **extend Armory Spinnaker to log to Splunk**.  As there are [many configuration options](https://docs.docker.com/engine/admin/logging/splunk/#usage) for Splunk and Docker. The one below is just a simple example of how to log to Splunk HTTP Event Collector. Place this file at `/opt/spinnaker/compose/logging-splunk.yml` and set `LOGGING_PROFILE=splunk` in your environment file located at `/opt/spinnaker/env`.
+
+```
+version: "2.1"
+services:
+  lighthouse:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+  clouddriver:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+  orca:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+  rosco:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+  deck:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+  gate:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+  gate:
+    logging:
+      driver: splunk
+      options:
+          splunk-token: ${YOUR_SPLUNK_TOKEN}
+          splunk-url: https://${YOUR_SPLUNK_HOST}:8088
+          splunk-insecureskipverify: "true"
+```
+
+## Example: Logging to Syslog
+
+Below is a sample logging-syslog.yml file that can be used to **extend Armory Spinnaker to log to syslog**. This example sends just clouddriver and lighthouse logs to syslog, but you can add the additional services as well by copying the configuration and changing the service name.  Place this file at `/opt/spinnaker/compose/logging-syslog.yml` and set `LOGGING_PROFILE=syslog` in your environment file located at `/opt/spinnaker/env`.
+```
+version: "2.1"
+services:
+  lighthouse:
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://192.168.0.42:123"  
+
+  clouddriver:
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://192.168.0.42:123"  
+```
+
+## Example: Logging to Sumo Logic
+
+Sumo Logic uses a different mechanism than Splunk and syslog. The preferred method is to run the sumologic-collector container (provided by Sumo Logic) alongside the default logging settings. To do this add/edit the `/opt/spinnaker/compose/docker-compose.override.yml` file and set `DOCKER_COMPOSE_OVERRIDE=true` in your environment file located at `/opt/spinnaker/env`. This is an example of **a fresh docker-compose.override.yml that runs the Sumo Logic collector to send all Spinnaker logs**:
+
+```
+version: "2.1"
+services:
+  sumologic-collector:
+    container_name: sumologic-collector
+    hostname: sumologic-collector
+    image: sumologic/collector:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: ["${ACCESSID}", "${ACCESSKEY}"]
+```
+
+Note that `${ACCESSID}` and `${ACCESSKEY}` in the example above should be replaced with your actual Sumo Logic acceess keys. If this is your first Docker source configured through Sumo Logic you may have to configure the source on the Sumo Logic side. Please see the [Docker Collector documentation from Sumo Logic](https://help.sumologic.com/Send-Data/Data-Types/Docker/01_Collect_Events_and_Statistics_for_the_Docker_App) for info about configuring a source.
+
+## Example: Logging to Datadog
+
+In a similar fashion to Sumo Logic, Datadog uses an agent running on the host to collect and ship logs. To use the Datadog agent with your Armory Spinnaker installation, add/edit `/opt/spinnaker/compose/docker-compose.override.yml` and set `DOCKER_COMPOSE_OVERRIDE=true` in `/opt/spinnaker/env`. If you've created `/opt/spinnaker/componse/docker-compose.override.yml`, you would add the following content to the file:
+
+```
+version: "2.1"
+services:
+  datadog-agent:
+    container_name: dd-agent
+    hostname: dd-agent
+    image: datadog/agent:latest
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_LOGS_ENABLED=true
+      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /opt/datadog-agent/run:/opt/datadog-agent/run:rw
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+```
+
+You should replace `DD_API_KEY` with you Datadog API Key. For more information about configuring the Datadog agent, checkout their docs [here](https://app.datadoghq.com/logs/onboarding/container).
+
+
+
+## Validate Log Delivery
+
+After configuring distributed logging make sure logs are arriving before moving on. If this is the first time you're setting up logging just searching for the Spinnaker services such as clouddriver or front50 should be enough. If you need to test a more complicated setup sometimes it's best to run a manual execution for a pipleline or wait for a new pipeline to run, and then use the execution ID from the run to make sure all the parts are appearing that you expect.
+
+If not all the logs are showing up you can get info about the logging setup from the Docker daemon. For example to **see information about where clouddriver logs are going** you can use this command:
+
+```
+{% raw %}
+docker inspect -f '{{.HostConfig.LogConfig}}' clouddriver
+{% endraw %}
+```
+
+If the log config isn't what you expect then something is wrong in the Armory Spinnaker config, and if the config is what you expect the problem is likely in your distributed logging setup.
+
+## Monitoring Spinnaker With Datadog
+
+Spinnaker provides a monitoring container which exports metrics from the core sub-services. We'll need to add two additional containers to our docker-compose setup: `datadog` and `spinnaker-monitoring`.
+
+First, ensure the the metrics endpoint is enabled by adding the following configuration to `spinnaker-local.yml` if it isn't already present.
+
+```
+services:
+  spectator:
+    webEndpoint:
+      enabled: true
+```
+
+Add the following to `/opt/spinnaker/compose/docker-compose.override.yml`
+```
+version: "2.1"
+services:
+  datadog:
+    container_name: datadog
+    hostname: datadog${HOSTNAME_SUFFIX}
+    env_file: /opt/spinnaker/config/datadog_api_token.txt
+    environment:
+      - "SD_BACKEND=docker"
+    image: datadog/docker-dd-agent:latest
+    ports:
+      - "8125:8125"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+  spinnaker-monitoring:
+    container_name: spinnaker-monitoring
+    hostname: spinnaker-monitoring${HOSTNAME_SUFFIX}
+    image: armory/spinnaker-monitoring:version-0.1.0
+    ports:
+      - "8008:8008"
+    volumes:
+      - /opt/spinnaker/config/monitoring/registry/:/opt/spinnaker-monitoring/registry/
+      - /opt/spinnaker/config/:/opt/spinnaker-monitoring/config/
+```
+
+In the configuration above `/opt/spinnaker/config/datadog_api_token.txt` is a [secrets file](https://docs.armory.io/install-guide/config_repo/#secrets) which contains your Datadog API key
+
+```
+API_KEY=${YOUR_DATADOG_API_KEY}
+```
+
+Add a registry entry for each service you wish to monitor in `/opt/spinnaker/config/monitoring/registry`. You'll need to create 1 file per service. The filename should correspond to the service being monitored and the contents should contain a `metrics_url` of the service. For example, an entry for monitoring Clouddriver would have a filename such as `clouddriver.yml` and the contents would be:
+
+```
+# /opt/spinnaker/config/monitoring/registry/clouddriver.yml
+metrics_url: http://clouddriver:7002/spectator/metrics
+```
+
+Add the Spinnaker monitoring configuration file in `/opt/spinnaker/config/spinnaker-monitoring-local.yml`:
+```
+registry_dir: /opt/spinnaker-monitoring/registry
+
+server:
+  host: 0.0.0.0
+  port: 8008
+
+monitor:
+  period: 30
+
+  metric_store:
+    - datadog
+
+datadog:
+  api_key: ${API_KEY}
+```
+
+
+We'll then need to enable Armory to look for the override file.  Add the following in your env file which is located at `/opt/spinnaker/env/${STACK}.env`
+
+```
+DOCKER_COMPOSE_OVERRIDE=true
+```
+
+Then restart Armory Spinnaker:
+`service armory-spinnaker restart`

--- a/content/en/docs/_install_guide/oneclick.md
+++ b/content/en/docs/_install_guide/oneclick.md
@@ -1,0 +1,86 @@
+---
+layout: post
+title: 1-Click App Creation
+order: 125
+---
+
+{% include components/legacy_documentation.html %}
+
+# What To Expect
+This guide should include:
+- Configuration changes needed to configure the 1-click app/resource provisioning feature
+
+## Overview
+Armory's 1-click app/resource provisioning feature allows you to bootstrap a brand new application and provision the following resources for the app with the click of a button:
+- Github Repo
+- Spinnaker application
+- Loadbalancer (service) in the Kubernetes cluster where the app will be deployed
+- DNS name for the app
+
+The above is just a sample list of steps that will happen during  app provisioning. This list is extensible through configuration (explained later).
+
+## Steps to follow to configure 1-click app creation:
+
+- Enable the *Armory Platform*, by setting the following feature flags in `spinnaker-local.yml`:
+```
+features:
+    armoryPlatform:
+      enabled: true
+      uiEnabled: true
+```
+
+- If this is on the AWS EC2 installation of spinnaker, set the following environment variables in your `prod.env` (or `preprod.env` or `dev.env` depending on where you are running the platform):
+```
+PLATFORM_ENABLED=true
+PLATFORM_UI_ENABLED=true
+```
+
+- Create a new file: `config/platform-local.yml` with the following contents:
+```
+github:
+    apiCredentialsPath: /opt/spinnaker/credentials/github-creds.txt
+    organization: armory-io  # your github Org
+oneClick:
+    templatesConfigPath: /config/oneclick-local.yml  # the config file for the oneclick template (optional)
+    lbNamespace: default   # The K8s namespace where the Loadbalancer is created
+```
+
+> Note: The contents of the file `/opt/spinnaker/credentials/github-creds.txt` should be of the format: `username:token` for the github API. You can create a personal access token (in  [GitHub](https://github.com/settings/tokens)) that has read/write access in the org where the new application will be created.
+
+
+With the above config changes, once you redeploy Armory spinnaker, you should see a navbar on top that looks like this:
+
+![navbar](/images/navbar.png)
+
+Clicking on the `Create App` button on the top right corner should bring up a modal that will allow you to select a template, enter an application name to provision the app:
+
+![modal](/images/1-click-modal.png)
+
+By default, the 1-Click App Creation performs the following tasks:
+- `createPipeline` : This step creates a Deploy pipeline in spinnaker for the new app. If the spinnaker application doesn't exist, it creates the application first before creating the pipeline. This pipeline is copied over from a template pipeline that is already in spinnaker and defaults to `oneclickgotemplate` app in spinnker. The default app to copy from can be overwritten in the configs (explained below)
+  
+- `createLoadBalancer` : This step creates a load balancer in the Kubernetes cluster where the app will be deployed. (If deploying to a non-Kubernetes cloud provider, this step should be disabled in the configs)
+
+- `createGithubRepo` : This step creates a repo in github to bootstrap the app. Ideally this repo follows a widly adopted project structure (such as [this](https://github.com/golang-standards/project-layout) for Golang). It has a `Jenkinsfile` which triggers of a build of the repo on every check-in. That build can push an artifact to a repository (like docker hub), which can be the trigger for the Deploy pipeline created above (in the `createPipeline` step). Additionally, this repo can also have a `dinghyfile` [Pipelines-as-code](http://docs.armory.io/user-guides/dinghy) to create a custom pipeline instead of using the one created above.
+
+- `createGoogleDNSEntry` : This step creates a DNS entry (in GCP for the alpha version) for the app that is deployed.
+
+The follwing is a sample `config/oneclick-local.yml` template that can be used to customize/override defaults. Points to note:
+- We're skipping the `createLoadBalancer` _action_ in the yaml file.
+- The `basePipelineApp` is the app in spinnaker where the deploy pipeline is copied over from (the dashes `-` in the name are ignored since spinnaker doesn't allow them in app names).
+- The `repoURL` field is the template repo on which the app is based.
+- The `name` field is used for the name of the template to copy from (usually same as `basePipelineApp`)
+- The `image` field controls what image is displayed in the modal while choosing templates. (leave it as `gopher` in the alpha version)
+
+```{% raw %}
+templates: 
+  - actions: 
+      - createPipeline
+      - createGithubRepo
+      - createGoogleDNSEntry
+    basePipelineApp: oneclick-go-template
+    image: gopher
+    name: oneclick-go-template
+    repoURL: "https://github.com/armory-io/oneclick-go-template"
+    githubOrg: "armory-io"
+{% endraw %}```

--- a/content/en/docs/_install_guide/packer.md
+++ b/content/en/docs/_install_guide/packer.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: Understanding Bake Scripts (Packer templates)
+order: 80
+# Do not redirect; substantially different from new version.
+---
+
+{% include components/legacy_documentation.html %}
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+**Note** If you're using Kubernetes, you can skip this section.
+
+
+# What exactly is the packer script?
+Spinnaker works best when deploying immutable artifacts to immutable machine images. The packer script is used during the **Bake Stage** to create a immutable machine image.
+
+Spinnaker knows which packer script to use by specifying the packer's configuration json in the **Bake Stage**, in the **`Template File Name`**.
+The default is `aws-ebs.json`, which sources `install_package.sh` for debians.
+
+The provided way to do this is by debian/rpm packages stored into a artifact repository (Bintry, Nexus, Artifactory, etc.). The packer script will  pull from the artifact repository and install it onto the machine. Spinnaker will then package up the image and make it available in the next stage of a pipeline.
+
+If your app is using zip, tarballs or you'll need some customization, you'll need to create a new packer script. See [Rosco/Baking Configuration](http://docs.armory.io/admin-guides/rosco/) for steps on how to do this.
+
+
+# Where the packer scripts are stored
+- On a spinnaker instance: `/opt/spinnaker/config/packer/`  
+- In the configuration repo: [`spinnaker-config/deb-config/spinnaker/config/packer/`](https://github.com/Armory/spinnaker-config-deb/tree/master/deb-config/spinnaker/config/packer)
+
+
+
+# Using and Verifying The Packer Script
+This is is for Ubuntu, with minor changes for Redhat and CentOS.
+The default template used is `aws-ebs.json` and `install_package.sh`.
+
+**Bake Configuration** in Spinnaker
+Spinnaker can send pipeline variables such as `repository` to the packer script by adding it in the extended attributes. Some attributes are prefilled because of selecting `trusty` as the base OS.
+![example](/images/Screen Shot 2017-09-05 at 4.34.58 PM.png)

--- a/content/en/docs/_install_guide/spinnaker-deploy-spinnaker.md
+++ b/content/en/docs/_install_guide/spinnaker-deploy-spinnaker.md
@@ -1,0 +1,142 @@
+---
+layout: post
+title: Spinnaker Deploy Spinnaker
+order: 60
+---
+
+{% include components/legacy_documentation.html %}
+
+
+# What To Expect
+{:.no_toc}
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+The installer scripts setup an initial Spinnaker environment. To keep Spinnaker up to date and to release changes to configuration, we'll teach Spinnaker how to redeploy itself. We call this the "Spinnaker deploy Spinnaker" pipeline.
+
+This is a step by step guide to creating the pipeline.
+
+Once the pipeline is fully configured it should look like this:
+
+![Redeploy Overall](/assets/images/redeploy-overall.png)
+
+
+
+## Create the Pipeline
+
+Create a pipeline and attach it to Jenkins so that it runs automatically whenever config changes are made.
+
+- Go into the armoryspinnaker application and **create a new pipeline** called "Deploy Production"
+- In the configuration click on **Add Trigger**
+  - Set the **Type** to `Jenkins`
+  - Set the Master to the Jenkins machine that builds your configuration package
+
+Once configured the trigger should look like this:
+
+![Trigger](/assets/images/redeploy-trigger.png)
+
+
+
+## Bake armoryspinnaker Stage
+
+Steps to create an AMI that pulls in the Armory package:
+
+- Add a **Bake stage** and set the Stage Name to `Bake Armory Spinnaker`
+- Make sure to check the `region` where your Armory Spinnaker instance runs
+- Set the **Package** select a version of [Armory](https://docs.armory.io/release-notes/)
+```
+docker-engine armoryspinnaker=SELECT_A_VERSION
+```
+- Set the **Base OS** to `trusty (v14.04)`
+- Check the **Show Advanced Options** box to see additional fields
+- Set the **Template File Name** to `aws-ebs.json`
+- Click **Add Extended Attribute** to create a new attribute
+  - Set `aws_instance_type` to `m4.large`
+  - Set `repository` to
+  ```
+  https://apt.dockerproject.org/repo/ ubuntu-trusty main; https://dl.bintray.com/armory/debians trusty main;
+  ```
+  - (optional) If AWS doesn't add new instances to a subnet, set `aws_subnet_id` to `subnet-11111`.
+- Set `AMI Name` to `armoryspinnaker`
+
+Once configured the stage should look like this:
+
+![Bake armoryspinnaker](/images/Image 2017-12-26 at 11.22.55 AM.png)
+
+
+
+## Find the Baked armoryspinnaker Image
+
+In this stage we'll look up the AMI id for the image we just baked so we can feed it into the next stage.
+
+- Add a "Find Image from Tags" stage and set the Stage Name to `Find armoryspinnaker`
+- Set the **Package** field to `armoryspinnaker`.
+- Check the region that matches where your Spinnaker instance runs
+
+Once configured the stage should look like this:
+
+![Find armoryspinnaker](/assets/images/redeploy-find-armoryspinnaker.png)
+
+
+
+## Bake with Custom Config
+
+In this stage we'll create another AMI, this time including any site specific config. By doing a 2 part bake, configuration changes is a bit quicker. 
+
+- Add a Bake stage and set the Stage Name to `Bake config`
+- Check the region where your Spinnaker instance runs
+- Set the **Package** field to the name of your configuration package, default:`spinnaker-config`.
+- Check the **Show Advanced Options** box
+- Set the **Template File Name** to `aws-ebs.json`
+- Click **Add Extended Attribute**
+  - Set **key** to `repository`
+  - Set the **value** to the repository that houses your config (ie `https://apt.company.com/repo/ ubuntu main`)
+- Set the Base AMI field to the pipeline expression
+```
+${#stage('Find armoryspinnaker')['context']['amiDetails'][0]['imageId']}
+```
+
+Once configured the stage should look like this:
+
+![Bake config](/assets/images/redeploy-bake-config.png)
+
+
+
+## Deploy the armoryspinnaker Image with Custom Config
+
+In this stage we'll take the image, which now contains both armoryspinnaker and any custom config, and deploy it to the server groups necessary to have Spinnaker replace itself.
+
+- Add a Deploy stage and name it `Deploy Production`
+- Click **Add server group** and add an AWS deployment using the armoryspinnaker-prod-polling template
+  - Set the Strategy to `Red/Black`
+  - Turn on the **Scale down replace server groups to zero instances** option
+  - Keep a **maximum of 3 server groups**
+  - Make sure the **Capacity** is set to "Copy the capacity from the current server group"
+  - Save the server group details
+- Click **Add server group** and add an AWS deployment, but using the armory-prod-nonpolling group as a template
+  - Make the same set of changes (strategy, scale down, keep 3 groups, and copy capacity)
+
+Once the stage is configured it should look like this:
+
+![Deploy](/assets/images/redeploy-deploy.png)
+
+
+## Add more confidence
+To add more confidence to your upgrade path consider creating
+a [stage environment and integration tests]({% link _admin_guides/preprod_environment.md %}).
+
+
+## Verify with a Manual Run
+
+To make sure that everything is working well you can manually run the pipeline. If all goes well the execution should show green for all stages. And you should be able to see multiple server groups in the custer view for the armoryspinnaker application. It should look something like the following:
+
+![Redeploy Clusters](/assets/images/redeploy-clusters.png)
+
+Check to make sure that:
+
+- all the instances are green for both polling and nonpolling groups
+- that only the most recent group for each cluster has instances in it
+- that the polling group always has only one active instance per group
+
+If all those things are true, congratulations! You have a Spinnaker cluster that's capable of redeploying itself.

--- a/content/en/docs/_install_guide/subnets.md
+++ b/content/en/docs/_install_guide/subnets.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: Subnets
+order: 20
+published: false
+# This has been redirected to spinnaker-install-admin-guides/aws-subnets
+---
+{% include components/legacy_documentation.html %}
+
+# VPCs & Subnets
+{:.no_toc}
+
+Subnets determine where and how you can deploy AWS resources such as EC2 machines, ELBs and Security Groups.  Configuring your Subnets correctly the first time means you won't have to update your pipelines later with changes.
+
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Configuring Subnets
+Spinnaker groups subnets into a single subnet name across multiple availability zones.  This makes it simpler for end-users of Spinnaker to choose a group of subnets within a VPC that have a given purpose such as `ec2-subnets`, `elb-subnets` or `public-subnets`.  This allows Spinnaker to place the machines within that group and ensure equal redundancy across zones. Below is a logical representation of how Spinnaker groups multiple subnets together.  If you want to **make a subnet accessible to Spinnaker** you'll have to add a tag and value to the subnet with the following: `immutable_metadata={"purpose":"example-purpose"}`
+
+![subnet tags in AWS console](/images/Image 2017-10-05 at 3.53.35 PM.png)
+
+Conceptually, this is how Spinnaker groups subnets logically.
+![subnets groups](/images/Image 2017-04-18 at 4.07.10 PM.png)
+
+
+## Verifying Subnet Configuration
+Once you configured the purpose of your subnets you can use the Spinnaker API to double check that settings have been noticed. It will take between 30 seconds and 2 minutes for the changes to be picked up. After that time period you can run:
+```
+$ curl http://localhost:8084/subnets/aws
+```
+You can expect to receive a response similar to:
+```[
+  {
+    "account": "default-aws-account",
+    "availabilityZone": "us-west-1b",
+    "availableIpAddressCount": 4088,
+    "cidrBlock": "172.31.0.0/20",
+    "deprecated": false,
+    "id": "subnet-7bd69322",
+    "purpose": "external",
+    "region": "us-west-1",
+    "state": "available",
+    "target": null,
+    "type": "aws",
+    "vpcId": "vpc-63327b06"
+  }
+]
+```
+If the `purpose` field is non-null then things are configured correctly.
+
+## I Don't See My Subnets or VPCs
+Spinnaker caches as much as possible to keep performance through the UI responsive.  If you don't see the subnets and you believe you configured them correctly, then make sure to refresh the cache.  You can find the cache going to the _config_ section of your application and clicking _refresh all caches_.  You should also make sure to refresh your browswer cache by using your browser's development tools and deleting any browser databases.
+
+![refresh all caches](/images/[75a6d5a8966231fe9cfeba7a14d57864]_Image+2017-04-13+at+1.59.38+PM.png)

--- a/content/en/docs/_user_guides/_index.md
+++ b/content/en/docs/_user_guides/_index.md
@@ -1,0 +1,5 @@
+---
+title: "User Guides (Legacy)"
+linkTitle: "UserGuides-Legacy"
+weight: 20
+---

--- a/content/en/docs/_user_guides/application-screen.md
+++ b/content/en/docs/_user_guides/application-screen.md
@@ -1,0 +1,84 @@
+---
+layout: post
+order: 10
+published: false
+# migrated to spinnaker-user-guides/application-screen
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+An application within Spinnaker is a combination of clusters and load balancers. 
+
+To get to the application details screen, select the 'Applications' tab on the top navigation bar in Spinnaker. Then pick an application from the list. It should load to a screen that looks like:
+
+![](/images/Image 2017-04-03 at 12.49.10 PM.png)
+
+This is a view of all of the server groups (which make up your cluster), grouped by stack. In the image above, I have three server groups. Two server groups are in the 'hellodeploy-cron' stack, namely V948 and V947. Notice that V947 is greyed out and doesn't contain any instances. In other words, it is disabled and scaled down to zero. The last server group, V013, is in the 'hellodeploy-preprod' stack. It has one instance.
+
+From here, we can click on different things:
+
+## Cluster tab
+Active Server group selected:
+
+![](/images/Image 2017-03-30 at 5.48.23 PM.png)
+
+
+Disabled server group selected:
+
+![](/images/Image 2017-03-30 at 5.50.26 PM.png)
+
+
+Instance selected:
+
+![](/images/Image 2017-03-30 at 5.49.21 PM.png)
+
+
+Load balancer selected:
+
+![](/images/Image 2017-03-30 at 5.49.37 PM.png)
+
+
+## Load balancer tab
+
+Load balancer selected:
+
+![](/images/Image 2017-03-30 at 5.51.44 PM.png)
+
+## Pipelines
+
+If you select the 'Pipelines' tab, you will see something like:
+
+![](/images/Image 2017-04-03 at 12.57.39 PM.png)
+
+This page shows two pipelines, 'Deploy' and 'Cron Deploy'. The 'Deploy' pipeline shows two executions, both labeled 'BUILD #5', this indicates that they were triggered by Jenkins' build #5. Clicking on the build number will take you to the Jenkins job. The red block on the second execution indicates that it has failed. If I click on the red part of the execution, it will expand into:
+
+![](/images/Image 2017-04-03 at 1.05.01 PM.png)
+
+Now I can see that the execution failed because of a subnet issue.
+
+
+For more information about pipelines, check out the [pipeline guide]({% link _spinnaker_user_guides/pipelines.md %})
+
+
+## Deleting an application
+
+To delete an application, first click on the 'Applications' tab on Spinnaker's top navigation bar. Select the application you would like to delete and enter its application detail page. Now select the 'Config' tab. Scroll all the way down to the 'Delete Application' section. 
+
+Example:
+![](/images/Image 2017-04-03 at 1.09.20 PM.png)
+
+You can see that in order to delete the application, you first need to delete its server groups. To delete its server groups, select the 'Clusters' tab. Now select a server group to delete by clicking on it. 
+
+Example of V952 selected:
+![](/images/Image 2017-04-03 at 1.10.34 PM.png)
+
+Now press the 'Server Group Actions' from the bar on the right hand side and press 'Destroy'. Spinnaker will always ask you to confirm that you are going to delete this server group. 
+
+Once all of the server groups have been deleted, navigate back to the 'Config'->'Delete Application' section and press "Delete Application'. 
+
+![](/images/Image 2017-04-03 at 1.15.56 PM.png)

--- a/content/en/docs/_user_guides/baking-images.md
+++ b/content/en/docs/_user_guides/baking-images.md
@@ -1,0 +1,211 @@
+---
+layout: post
+order: 30
+published: false
+# migrated to spinnaker-user-guides/baking-images
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+Definition: The term 'Baking' is used within Spinnaker to refer to the process of creating machine images.
+
+
+Preprequisites and assumptions:
+
+- You are familiar with creating [applications]({% link _overview/your-first-application.md %}) and [pipelines]({% link _overview/your-first-pipeline.md %})
+- You are deploying to Amazon Web Services (AWS)
+
+
+## Baking in a Pipeline
+
+First let's go through an example of baking, then we can go into some details and information sharing.
+
+## Example
+
+In this example we will bake an image containing a Debian package created by a Jenkins' job. If you like, you can check out the [working with Jenkins guide]({% link _spinnaker_user_guides/working-with-jenkins.md %}) for more information on how Jenkins and Spinnaker can work together. We also have a guide on [creating debian packages]({% link _spinnaker_user_guides/debian-packages.md %}).
+
+
+First let's look at the the Jenkins job that builds our package.
+
+![](/images/Image 2017-03-29 at 12.43.31 PM.png)
+As you can see, the last run archived a package named `armory-hello-deploy_0.5.0-h5.c4baff4_all.deb`
+
+
+Now let's go to Spinnaker and create a new pipeline. I named mine `bake-example`.
+
+On the configuration stage, I scroll down and add a new Jenkins automated trigger. Select my master, and then select the Jenkins job shown above (`armory/job/armory-hello-deploy/job/master`). For this example, there is no need to worry about setting a properties file.
+
+Next I add a bake stage (add stage -> Type: Bake)
+
+Select the `us-west-2` region. For the Package field, I enter the base name of my package. In my case, the entire package filename is `armory-hello-deploy_0.5.0-h5.c4baff4_all.deb` so I will input `armory-hello-deploy`. Also, I know that my package is created for Ubuntu 14, so I make sure to select the 'trusty (v14.04)' option.
+
+![](/images/Image 2017-03-29 at 1.35.13 PM.png)
+
+like:
+
+![](/images/Image 2017-03-29 at 1.45.09 PM.png)
+
+At this point if I want to see more details about my bake, I can click the 'View Bakery Details' box. A new window will open up with the bakery logs. In my case, the first few lines look like:
+
+{% highlight shell %}
+==> amazon-ebs: Prevalidating AMI Name...
+    amazon-ebs: Found Image ID: ami-3d50120d
+==> amazon-ebs: Creating temporary keypair: packer_58dc1ccb-b936-7104-ebe0-0984e888ca78
+==> amazon-ebs: Creating temporary security group for this instance...
+==> amazon-ebs: Authorizing access to port 22 the temporary security group...
+==> amazon-ebs: Launching a source AWS instance...
+    amazon-ebs: Instance ID: i-08327d863d1911675
+==> amazon-ebs: Waiting for instance (i-08327d863d1911675) to become ready...
+==> amazon-ebs: Adding tags to source instance
+==> amazon-ebs: Waiting for SSH to become available...
+==> amazon-ebs: Connected to SSH!
+==> amazon-ebs: Pausing 30s before the next provisioner...
+==> amazon-ebs: Provisioning with shell script: /opt/spinnaker/config/packer/install_packages_armory.sh
+    amazon-ebs: repository=
+    amazon-ebs: package_type=deb
+    amazon-ebs: packages=armory-hello-deploy=0.5.0-h5.c4baff4
+...
+{% endhighlight %}
+
+Under the hood, Spinnaker is leveraging [HashiCorp's Packer](https://www.packer.io/) tool to create images. The above is a Packer log file.
+
+The thing I wanted to point out here is that the correct version of the package is getting passed down to the bakery.
+
+
+After the bake is successful, I see:
+
+![](/images/Image 2017-03-29 at 1.49.44 PM.png)
+
+
+Notice that the AMI name and ID are shared in the lower right's blue box - in this example it is "armory-hello-deploy-all-20170329204459-trusty (ami-c78410a7)".
+
+
+If I press 'Start Manual Execution' again, since the package version hasn't changed, it will reuse the same image rather than rebaking. The screen for that looks like:
+
+![](/images/Image 2017-03-29 at 1.55.52 PM.png)
+
+Notice the whole pipeline only ran for '00:00' and in the lower right Spinnaker says 'No changes detected; reused existing bake'
+
+## Advanced Options
+
+You can do additional things like use a specific base AMI, specify your baked AMI's name, use a custom packer script, or pass variables to a packer script.
+
+If you would like to change the name in AWS of your AMI, you can do so by selecting the 'Show Advanced Options' checkbox in the Bake Stage Configuration. Continuing from our example above, when I see:
+
+![](/images/Image 2017-03-29 at 2.29.08 PM.png)
+
+What do all of these fields mean? Great question!
+
+
+### Changing an AMI's name
+
+If I were to instead input 'mycustomname' into the 'AMI Name' field, like:
+
+![](/images/Image 2017-03-29 at 2.55.24 PM.png)
+
+After re-running the pipeline, I see that Spinnaker named the AMI `mycustomname-all-20170329220104-trusty`
+
+![](/images/Image 2017-03-29 at 3.05.57 PM.png)
+
+Then I add 'mycustomsuffix' to the 'AMI Suffix' field:
+
+![](/images/Image 2017-03-29 at 3.14.07 PM.png)
+
+Repeating the bake, I see that Spinnaker named the AMI `mycustomname-all-mycustomsuffix-trusty`
+
+### Base AMIs
+
+Often you will want to specify a base image for use in your bake. In that case you will use the 'Base AMI' field, not to be confused with the 'Base Name' field. As an example, I have specified `ami-4d78c02d`:
+
+![](/images/Image 2017-03-29 at 4.06.24 PM.png)
+
+
+In this situation, the base OS selection (ubuntu/trusty/windows) will be ignored.
+
+You can also select a base AMI more dynamically by combing the 'Bake' stage type with the 'Find Image' stage type. For more details check out the [Find Images Guide]({% link _spinnaker_user_guides/find-images.md %})
+
+
+### Adding Debian Repositories
+
+It is common practice to use a base image throughout your team or organization. Usually this base image will be kept up to date with security patches and will contain common tools (DataDog, Splunk, etc.). It is also a good place to register your Debian repository's GPG keys.
+
+If you need to add repositories on a per bake basis, you can use the 'Extended Attributes' within the 'Advanced Options' section. You can add a key/value pair where the key is labeled 'repository' and the value is a space separated list of repository URLs. For example:
+
+![](/images/Image 2017-04-17 at 10.41.20 AM.png)
+
+This will add Armory's bintray debian repository to the bake.
+
+## Regions
+
+By selecting a region, you are selecting which region the bake will take place. When a bake happens, an instance is spun up, the desired packages are installed, and then a snapshot is taken. The location where the instances spin up is determined by which region you select. Multiple regions may be selected at once.
+
+## Rebaking
+
+When a bake step executes, Spinnaker looks for a previously created image before baking a new one. It uses the set of packages (and their versions) that users specify in the bake stage configuration to determine if the bake is neccessary.
+
+You can force Spinnaker to always bake by selecting the 'Rebake: Rebake image without regard to the status of any existing bake' checkbox on the bake stage configuration screen. You also have the option to force rebaking when manually executing a pipeline.
+
+
+## Bake and Copy vs Multi-Region Bake
+
+There are two options for getting an image to multiple regions in AWS. A common practice outside of Spinnaker is to create your AMI and then copy it to the regions you need. However, Spinnaker by default will do a multi-region bake. This means if you select more than one region it will go through the process of creating an image in each region (spin up an instance, install the packages, etc).
+
+There are trade-offs to each approach. Generally, Spinnaker's default multi-region bake approach is faster than the bake and copy approach. However, if you need to limit all baking activities to one region then there isn't much of a choice.
+
+
+## Custom Bake Scripts
+
+If you would like to use a custom Packer script to bake your AMI you will need to contact your Spinnaker Administrator. The script will have to be installed on your Spinnaker instances.
+
+
+## Baking Using `chroot`
+
+Baking using the `chroot` builder for packer allows you to bake an AMI without having to spin up a new instance.  Instead, a new EBS volume is mounted to the running Spinnaker instance, `chroot` is executed on the new volume, packer installs the required packages on the volume, a snapshot is taken, and then volume is cleanly detached.  To enable `chroot` style baking, we'll need to configure `rosco` with some additional properties.  Add the following to `/opt/spinnaker/compose/docker-compose.override.yml`:
+
+```yaml
+version: "2.1"
+services:
+  rosco:
+    privileged: true
+    volumes:
+      - /dev:/dev
+```
+
+Armory Spinnaker comes with a [default chroot template](https://github.com/armory-io/rosco/blob/master/rosco-web/config/packer/aws-chroot.json) which is named `aws-chroot.json` and stored your other packer templates in `/opt/spinnaker/config/packer`. Make sure to use this template (or a user provided template) when configuring your bake stage.  
+
+> Note: There are a few ["gotchas"](https://www.packer.io/docs/builders/amazon-chroot.html#gotchas) with chroot builders.  
+
+
+## Caching Bakes
+
+Spinnaker will cache bakes and not re-run a bake to save time if it finds the bake key in its cache.
+When Spinnaker bakes a package it creates a unique key based on the following components:
+Cloud Provider Type, Base OS, Base AMI, AMI Name, Packer Template Filename, Var Filename, Package Name and Package Version. If any of those components change at the time of bake it will rebake otherwise it'll use the cached AMI.
+
+#### Package Name and Version
+
+By default, Spinnaker looks for an artifact from the Jenkins build that triggered the bake to [parse out version information](https://github.com/spinnaker/rosco/blob/ddd6ed4689b8a769e4b7331acdca2c0ba1b29a66/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/util/PackageNameConverter.groovy#L54).  Below are valid names to packages:
+
+```
+subscriberha-1.0.0-h150
+subscriberha-1.0.0-h150.586499
+subscriberha-1.0.0-h150.586499/WE-WAPP-subscriberha/150
+```
+
+This allows you to just specify `subscriberha` as the `package` in your bake stage and Spinnaker will handle which version to bake based on the Jenkins trigger that was chosen at execution time.
+
+## Troubleshooting
+When you have a failing bake step and you do not know why, a good place to start is with the bakery log. You can find a link to the bakery log in the Detail of your bake step on the pipeline execution screen
+
+![](/images/Image 2017-03-29 at 1.59.18 PM.png)
+
+Click the link that says 'View Bakery Details'. It can be helpful to track down the last command that the bakery executed.
+
+
+Another source of information is the pipeline's source link. You can find this link in small writing in the far bottom right of the pipeline execution detail screen. The 'source' is a JSON representation of the data generated by Spinnaker when running your pipeline (not just the bake step).

--- a/content/en/docs/_user_guides/barometer.md
+++ b/content/en/docs/_user_guides/barometer.md
@@ -1,0 +1,134 @@
+---
+layout: post
+title: Barometer
+order: 75
+published: False
+# this only applies to ec2 installer, I think.
+---
+
+{% include components/legacy_documentation.html %}
+
+# What is Barometer
+
+Barometer is an automated canarying analysis (ACA) service that is provided through Armory Spinnaker. The goal of Barometer is to provide the end user with confidence that a deployment is safe through automation and intelligence.
+
+Barometer uses real-time data sources to validate that a canary is good or bad. Today, Barometer supports the following real-time data sources:
+
+* Elastic Search
+* DataDog
+
+## Overview
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Configuring A Canary Stage
+
+If canarying is enabled for your instance, you should be able to see a stage for canarying:
+
+![Canary Stage](/images/Image 2017-08-07 at 10.57.58 AM.png)
+
+The canary stage starts by deploying 2 new server-groups: a `baseline` and `canary`.   The `baseline` server group is deployed with the AMI that was most recently deployed for the chosen template server-group.  The `canary` server group is deployed with release candidate AMI which is pull from a previous `Bake` or `Find Image` stage in the pipeline.  Once both server groups are up and "in service" the analysis will be begin.  The analysis is based on additional configuration below.
+
+Once the canary stage has completed, _both_ the `canary` and `baseline` server group will be destroyed and the pipeline will continue, likely to a standard deployment stage.  By not including the canary as part of the production deployment stage it adds safety and isolation to the canary.  You can still choose to have your deployment to have a more sophisticated deployment which is completed in phases. 
+
+### Deployment
+
+![Canary Deployment](/images/Image 2017-08-07 at 11.01.19 AM.png)
+
+`Canary Lifetime` - The total time period that the canary & baseline server will live and continue analysis before moving onto the next stage.
+
+
+`Terminate unhealthy canary` - If the canary is unhealthy based on analysis it'll continue to collect and analyze information for this period of time until it considers the overall result of the canary a failure.
+
+
+`Baseline version - Account & Clusters` - This is the baseline cluster to use for the canary analysis.  The Canary stage will find the AMI id from the latest deployed cluster and use this for the baseline server group.  In our screenshot above, the canary stage would deploy 2 new server groups: `armoryhellodeplloy-nightly-baseline` and `armoryhellodeplloy-nightly-canary`.
+
+
+### Baseline/Canary Cluster Pair
+
+This configuration determines how the canary will be deployed.  This looks similar to a server group deployment. The difference is that it is managed by Canary stage and has a limited lifespan as defined by `Canary Lifetime` above.  In most cases you'll want to put the canary behind the existing production load balancer which will drive a small percentage of traffic to your new canary and baseline server group.  You can specify a different load balancer but you'll be responsible for creating a different mechanism for traffic shaping.  
+
+
+![Canary Pair Configuration](/images/Image 2017-08-07 at 11.39.16 AM.png)
+
+## DataDog
+
+If your Administrator has configured DataDog in your Barometer instance you'll be able to use the metrics and monitors stored in DataDog to inform Barometer on the health of your service.
+
+### Metrics
+
+The metrics stored in DataDog are compared between the canary and baseline using statistical analysis. Once the service determines that the canary is behaving abnormally it'll mark it as unhealthy. You can specify the metric name, tags, and allowed deviation. The name and tags correspond to metric names and tags within DataDog. The `deviation` is the number of standard deviations the canary must be to the baseline.
+
+Consider this example:
+
+![DataDog Metrics](/images/Image 2017-08-24 at 1.59.03 PM.png)
+
+There are two metrics being considered.
+- `system.net.bytes_sent` must be within `1.0` standard deviation of the baseline.
+- `system.disk_used` limited to the tag `region:us-west-2` must be with half of a deviation.
+
+### Metrics Dashboard
+
+Barometer can automatically generate a DataDog dashboard showing the metrics you specify for all server groups involved in the canary. Just check the appropriate box under the DataDog section while configuring your canary stage.
+
+### Monitors
+
+You can use pre-existing monitors to fail the canary regardless of how it compares to its `baseline`.  This is good if you have absolute business rules such as "response times can't go over 50ms" or "Number of exceptions must be below 10 per minute".  Barometer does this by periodically checking the event stream for monitors that have failed and match the canary autoscaling group name.
+
+#### Enabling the monitor
+
+In your DataDog monitor you'll need to aggregate the metric by autoscaling group:
+![ASG Metrics](/images/Image 2017-08-07 at 12.04.54 PM.png)
+
+You'll also need to include the autoscaling group name in the monitor message by checking the box `Include Triggering tags in notification title`:
+
+
+![include asg](/images/Image 2017-08-07 at 1.23.30 PM.png)
+
+
+You can enable/disable this behavior by checking the box below.
+![Disable monitor](/images/Image 2017-08-07 at 11.53.07 AM.png)
+
+**Note:** If you aren't able to aggregate by autoscaling group this means either you're not logging through the DataDog agent that is usually placed on the instance or you need to enable `Auto Scaling` and `EC2` integrations from the DataDog integrations screen.
+
+![enabling ec2 and autoscaling](/images/Image 2017-08-07 at 12.10.12 PM.png)
+
+## Elastic Search
+
+If ElasticSearch is configured by your Spinnaker Administrator you can take advantage of using ES queries to further analyze your canary deployments.
+
+Barometer has the ability to run queries and compare the number of hits to constraints. You can set a maximum and/or minimum number of hits allowed by a query. Besides min and max, you can compare results between queries. A baseline query can be compared to a canary query. The `Deviation` field represents the percentage of difference allowed between the baseline and canary queries.
+
+Consider this example:
+
+![ElasticSearch configuration](/images/Image 2017-08-23 at 3.16.01 PM.png)
+
+There are two checks being done here:
+- The first check runs a single query. Specifically, it looks for a log line that reads, "Server Started." By setting `Min` to `1`, we are requiring that log line to appear at least once. Also note that this sort of check should be using in conjunction with the 'Warm-up period` settings to ensure that the application starts before the analysis begins.
+- The second check compares the canary query to the baseline query. In this case, the canary query looks for errors involving the git hash of our deployment. The baseline query looks for errors that do not involve the git hash of our deployment. By settings `Deviation` to `5%`, we are requiring the difference between the canary and baseline queries to be less than 5%.
+
+
+## Viewing A Canary Stage
+
+Once a canary stage has been configured you can run the pipeline. You can select the stage in the pipeline execution to view the results.
+
+Here is an example of a successful canary:
+
+![successful canary](/images/Image 2017-08-24 at 2.05.41 PM.png)
+
+If you select `History` you can expect to see something like:
+
+![successful canary history](/images/Image 2017-08-24 at 2.07.18 PM.png)
+
+Where `Type` represents whether or not the check was against a DataDog metric, a DataDog monitor, or an ElasticSearch query.
+
+Alternatively, here is an example of a failed canary:
+
+![failed canary](/images/Image 2017-08-24 at 2.09.38 PM.png)
+
+We can see by the message that `system.net.bytes_sent` metric on the canary was `46.36` deviations away from the baseline.
+
+Clicking on `History` for the failure also gives more details on the results:
+
+![failed canary history](/images/Image 2017-08-24 at 2.15.26 PM.png)

--- a/content/en/docs/_user_guides/best-practices.md
+++ b/content/en/docs/_user_guides/best-practices.md
@@ -1,0 +1,71 @@
+---
+layout: post
+order: 70
+published: false
+# migrated to spinnaker-user-guides/best-practices
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Configuration Management
+{:.no_toc}
+
+### Baking Configuration
+
+It is common practice to bake the bulk of your application's configuration into your AMI. Secrets should not be included. Configurations that frequently change and service discovery is often managed by another system. Some common system choices include but are not limited to: [Consul](https://www.consul.io/), [Archaius](https://github.com/Netflix/archaius), [Zookeeper](https://zookeeper.apache.org/), and [etcd](https://github.com/coreos/etcd).
+
+If you are running the default installation of Armory Spinnaker, then every AWS instance will have details about its environment/stack stored in `/etc/default/server-env`. This can be used to load the correct configuration.
+
+
+### Service Discovery
+
+While it is not feasible for every type of application, using a load balancer can greatly simplify things. Spinnaker gives load balancers first-class citizenship and will not need additional integrations to work right out of the box.
+
+For applications and workloads that cannot utilize a load balancer, the tools listed above may help.
+
+
+## Secret Management
+
+Managing Secrets is a major part of deploying software. Spinnaker does not directly do this for you. However, there are still some guiding principles to help you along the way.
+
+It would be best not to bake Secrets into your images. If you have the default installation of Armory Spinnaker then you can find `/etc/default/server-env` on your instance. This file will have information (in the format of key-value pairs) about the environment and stack you are running on. You can use this to load the correct Secrets.
+
+Loading Secrets will have to be done at runtime since Secrets are not baked into images.
+
+Specifically for Secure Sockets Layer (SSL), it can be beneficial to terminate SSL at the Elastic Load Balancer (ELB) whenever feasible. Amazon has the [Key Management Service (KMS)]() for this purpose. If you need to handle certificate management at the application level, you might want to check out [Netflix's Lemur](http://techblog.netflix.com/2015/09/introducing-lemur.html) project.
+
+Some other general purpose Secret Management tools include:
+- [HashiCorp's Vault](https://www.vaultproject.io/)
+- [Nike's Cerberus](http://engineering.nike.com/cerberus/)
+
+
+### Using Vault With Spinnaker on AWS
+
+Issuing a Vault token with AWS is an automated process that uses AWS as a [trusted third party to initiate authorization](https://www.vaultproject.io/docs/auth/aws-ec2.html).
+
+One piece of "dynamic metadata" available to the EC2 instance, is the instance identity document, a JSON representation of a collection of instance metadata. AWS also provides PKCS#7 signature of the instance metadata document, and publishes the public keys (grouped by region) which can be used to verify the signature.
+
+You can issue an authentication by issuing the following:
+
+```
+$ vault auth-enable aws-ec2
+```
+
+And then proceeding with any additional vault commands and execution that needs to happen.  These steps need to happen at startup you'll want add this script as a [base 64 encoded users-data in your deployment steps](http://docs.armory.io/user-guides/deploying/).
+
+### Isolate Delivery Pipelines from Integration
+
+There are several ways to trigger a deployment pipeline. However, depending on the asset you are delivering, some methods are easier to work with than others.
+
+*Docker Images*
+
+It is best to have Spinnaker trigger off of a push to a Docker registry instead of triggering off of a GitHub push or Jenkins job. Doing so frees up the development teams to restructure their build systems and validation as they desire because everything in the delivery process can remain the same as long as the Docker image makes it up to the repo.
+
+Sometimes you may need extra information if you're triggering off of Docker images. For instance you might want to release anything on the master branch to production, but release any other branch to the staging area. In order to do so, put the extra information into the tag, and the pipeline triggers in Spinnaker can use regular expression matches on the tag name in Docker to determine which pipeline to execute. Here is an example:
+
+![](/images/Image 2017-04-17 at 4.35.46 PM.png)

--- a/content/en/docs/_user_guides/debian-packages.md
+++ b/content/en/docs/_user_guides/debian-packages.md
@@ -1,0 +1,79 @@
+---
+layout: post
+order: 90
+# migrated to spinnaker-user-guides/debian-packages
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Why Use Debian Packages
+
+While Spinnaker is flexible to use any dependency management system, it is predisposed to manage Debian packages due to its default settings with Rosco, Orca and Jenkins.  
+
+- Out-of-the-box settings for Spinnaker look for an archived package with a `.deb` suffix within Jenkins.  It also grabs the version from the package and automatically appends it to the package name within Rosco.  This makes it easy to specify your package in Rosco without the version number, `mycompany-app` but during the bake provisioning process it will install the version that was specified by the Jenkins build: `mycompany-app.3.24.9-3`.  
+
+- Debian packaging allows service teams to easily add their app specific configuration to common packer templates.  If you're using any Debian linux based system (Ubuntu, DSL, Astra, etc) you'll likely be using Debian packages for your system configuration and dependency management so it's a natural extension to use it for your own applications.  Using Debian packages will help reduce the variations in packer templates or variables passed to packer templates during the bake process.
+
+
+## Creating Debian Packages
+
+Creating a Debian package can be done through various open-source packaging tools.  If you're using Java, using the `OS Package` library is a good place to start.  Of course you can always use the [packaging tools provided by Debian](https://www.debian.org/doc/manuals/maint-guide/build.en.html).  Here is a good example of using a Debian package for a [Spinnaker configuration repo](https://github.com/armory-io/spinnaker-config).
+
+| Language | Tool | Package Types |
+|---|---|---|
+| Java    | [OS Package](https://github.com/nebula-plugins/gradle-ospackage-plugin)  | deb/rpm |
+| Python  | [stdeb](https://pypi.python.org/pypi/stdeb/0.8.5) | deb |
+| Node    | [node-deb](https://www.npmjs.com/package/node-deb) | deb |
+| PHP     | [php-deb-packager](https://github.com/wdalmut/php-deb-packager) | deb |
+| Any     | [pkgr](https://github.com/crohr/pkgr) | deb/rpm |
+| Any     | [fpm](https://github.com/jordansissel/fpm/wiki) | deb/rpm/others |
+
+
+### Example: Debian Package with OSPackage Gradle Plugin
+
+Begin by creating a `build.gradle`.  Below is an example of what a gradle file might look like for a application that builds a war.
+
+{% highlight javascript %}
+buildscript {
+  repositories {
+    jcenter()
+    maven { url "https://plugins.gradle.org/m2/" }
+  }
+  dependencies {
+       classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.3.0'
+   }
+}
+
+apply plugin: 'nebula.ospackage'
+
+ospackage {
+  packageName = "mycompanyname-service"
+  version = "1.10.3"
+
+  requires('nginx')
+
+  postInstall file('config/scripts/post-install.sh')
+
+  from('build/application.war') {
+    into '/opt/application/'
+  }
+}
+{% endhighlight %}
+
+Then build your Debian package based on your gradle build file:
+{% highlight shell %}
+$ gradle buildDeb
+{% endhighlight %}
+
+If the build succeeds then you should find a Debian package in the following path:
+
+{% highlight shell %}
+./build/distributions/mycompanyname-service.1.10.3_all.deb
+{% endhighlight %}

--- a/content/en/docs/_user_guides/deploying.md
+++ b/content/en/docs/_user_guides/deploying.md
@@ -1,0 +1,267 @@
+---
+layout: post
+order: 40
+# migrated to spinnaker-user-guides/deploying
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Prerequisites and Assumptions:
+
+- You are deploying to Amazon Web Services (AWS)
+- You know how to create pipelines and utilize the [Bake stage]({% link _spinnaker_user_guides/baking-images.md %})
+- You understand Spinnaker's [naming conventions]({% link _overview/naming-conventions.md %})
+- You are familiar with ELB configuration
+- You have already created a security group to use in your application
+
+
+The primary objective of Spinnaker is to deploy your software. It would like you to [Bake an image]({% link _spinnaker_user_guides/baking-images.md %}) and use that same image to deploy to all of your environments.
+
+The typical type of distributed application that Spinnaker deploys is one with a cluster of homogeneous instances behind a load balancer. The load balancer is responsible for detecting healthy and unhealthy instances.
+
+To start off, let's go through an example. This example continues from the example in the [Baking an image guide]({% link _spinnaker_user_guides/baking-images.md %}).
+
+
+## Example
+
+In this example we are going to deploy a simple web server that serves a page with details about its environment.
+
+First I go to the application screen to create a load balancer. Select the 'Load Balancers' tab:
+
+![](/images/Image 2017-03-30 at 12.33.45 PM.png)
+
+Press the '+' on the right to create a new load balancer. The screen that pops up looks like:
+
+![](/images/Image 2017-03-30 at 12.46.05 PM.png)
+
+I input 'example' into the 'Stack' field, set my [VPC Subnet Type]({% link _spinnaker_install_admin_guides/aws-subnets.md %}), use my pre-created security group, forward the correct ports and most importantly set my healthcheck. Finally, I press 'Create'.
+
+
+Now to create the Deploy stage in our pipeline,  I navigate to the configuration screen of the previously created pipeline from the [Baking guide]({% link _spinnaker_user_guides/baking-images.md %}).
+
+Select 'Add Stage' and select 'Deploy' from the 'Type' dropdown menu.
+
+![](/images/Image 2017-03-30 at 12.17.51 PM.png)
+
+Now, I press the 'Add server group' option in the 'Deploy Configuration'
+
+You'll be given the option to copy a configuration from a currently running server group if a server group for this application already exists. In my case, I select 'None' and continue. Now I see:
+
+![](/images/Image 2017-03-30 at 2.44.53 PM.png)
+
+I select the same 'VPC Subnet' type as the ELB I just made. Remember to input 'example' to the 'Stack' field since that is what was used when creating the ELB.
+
+For this example, I'm going to use a Red/Black (also known as Blue/Green) deployment strategy. Then I scroll down and select the load balancer that I just created from the list and select my pre-created security group.
+
+Under the 'Instance Type' section, select 'Micro Utility'. I scroll all the way down to the 'Advanced Settings' section and change the 'Health Check Type' from 'EC2' to 'ELB'. I then erase the 'IAM Instance Profile' field. We do so in our example because we don't need access to any other AWS resources and the field may be filled in by default.
+
+![](/images/Image 2017-03-30 at 3.15.18 PM.png)
+
+Then press 'Add' to complete this step. After returning to the Deploy Stage Configuration screen, the Deploy Configuration section looks like:
+
+![](/images/Image 2017-03-30 at 3.17.25 PM.png)
+
+Finally, I press 'Save Changes' and select the 'Pipelines' tab to return to the Pipeline Executions screen.
+
+I press 'Start Manual Execution' on my pipeline. This is what I see:
+
+![](/images/Image 2017-03-30 at 3.19.57 PM.png)
+
+As this deploy is happening, I can click on the 'Clusters' tab to see a new server group come up.
+
+![](/images/Image 2017-03-30 at 3.23.24 PM.png)
+
+For more information about the details of this screen, check out the [application screen description guide]({% link _spinnaker_user_guides/application-screen.md %})
+
+I can see here that a new server has indeed come up and is healthy. Healthy in this case means that it has passed the ELB healthcheck. If you are having problems with your instances not passing the healthcheck, check out the [common errors section](#common-errors).
+
+Now, to demonstrate the Blue/Green, I go back to the Pipeline Executions screen and press 'Start Manual Execution' again. Then I go back to the 'Clusters' tab to watch the execution process.
+
+First I see that a new server group named `v001` is being created. It doesn't have any instances in it yet:
+![](/images/Image 2017-03-30 at 3.46.44 PM.png)
+
+After a few moments an instance is created and is initially 'unhealthy':
+![](/images/Image 2017-03-30 at 3.47.16 PM.png)
+
+Once it passes its healthchecks and becomes healthy, it will visually indicate so by turning green. At this point Spinnaker will add the server group to the load balancer.
+![](/images/Image 2017-03-30 at 3.50.01 PM.png)
+
+Immediately after that, the old server group is removed from the load balancer. Spinnaker will turn the old server group's instances blue. This means that they are disabled and no longer receiving traffic.
+
+![](/images/Image 2017-03-30 at 3.50.18 PM.png)
+
+Because of how I configured my deploy stage, the old Blue server group will stick around until I either manually scale it down or destroy it. If you like, you can configure your deploy stage to automatically scale down the old server group after the new one is healthy.
+
+
+## Common errors and troubleshooting
+
+If you are having trouble try checking out some of these topics:
+
+### Deploy times out
+
+Often when your deploy stage is timing out, it is because your instances are never becomming healthy. In this case, Spinnaker will keep terminating and replacing the instances.
+
+### Investigating red instances
+
+Select your red instance and hover your cursor over the red triangle next to the load balancer under the 'Status' section. This should display some helpful information for understanding why your instance is not deploying correctly.
+
+![](/images/Image 2017-03-30 at 3.29.02 PM.png)
+
+### Incorrect Healthcheck
+
+You have the option when deploying a new server group to use either EC2 or ELB healthchecking. When instances aren't passing this healthcheck they will be terminated and replaced. If you are experiencing strange behavior, double check that the correct healthcheck is selected.
+
+### Deploy AZs vs ELB AZs
+
+It is possible to set your ELB to work with certain AZs but then deploy your server group to another AZ. If you have your healthcheck set to ELB, then your instances will never become healthy. You can tell when this happens by hovering you mouse over the red triangle [described above](http://docs.armory.io/user-guides/deploying/#investigating-red-instances).
+
+### Unknown errors
+
+Sometimes you may encounter an 'Unknown Error' message when executing your deploy. Something like, "Shrink cluster: Exception: No reason provided." These errors are almost always caused by a field having an incorrect value in the deploy configuration. This particular "Shrink cluster" error was caused by the server group's region being invalid.
+
+
+## Deployment strategies
+
+### Red/Black (also known as Blue/Green)
+
+This strategy will deploy a fresh server group and add it to the load balancer. The older server group will then be [disabled](#what-does-disabled-mean).
+
+![](/images/Image 2017-03-30 at 5.23.57 PM.png)
+
+When you configure this stragey you can choose to scale down the old server group. You can always scale it back up if you need it for a rollback. Also, you can choose how many old server groups to leave in the cluster.
+
+### Highlander
+
+This strategy will create a new server group and add it to the load balancer. Once everything is healthy, the old server group(s) will be destroyed.
+
+### None
+
+This strategy will deploy a new server group. It won't do anything about the older server groups. They will just all be in the load balancer together like one big happy family!
+
+
+## What does disabled mean?
+
+When an instance is disabled within Spinnaker, it is removed from all load balancers. Depending on how your application receives work, this may or may not stop your application from doing work. If your application receives work via the load balancer - like a web application - then it should actually be disabled. However, if you have an application that works similarly to pulling workloads off of a distributed queue (SQS, Kafka, etc), then removing it from a load balancer won't change anything. In fact, it was probably never in a load balancer.
+
+You can re-enable a server group by selecting it from the 'Cluster' screen, click the 'Server Group Actions' button on the right panel and click 'Enable'.
+
+## UserData
+
+You can pass custom information to your deployed instances through the 'User Data' field under the 'Advanced Settings' section of the deploy stage configuration.
+
+![](/images/Image 2017-03-30 at 4.30.36 PM.png)
+
+Make sure to base64 encode the content before putting it into the field in the options.
+
+### UserData issues
+
+If the default Armory Spinnaker UserData doesn't work with your instance launch sequence, there are two work-arounds you can use.
+
+* If the UserData you want to use is bash-compatible and will fit after that existing chunk of variables that Spinnaker puts in, you can just put your base64 encoded UserData into the cluster config.
+
+* Adjust the UserData template used by Spinnaker.  There is a writeup by the Spinnaker Folks [here](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md). When we use that option we normally point udfRoot at something like /opt/spinnaker/config/custom-udf, and then add the custom-udf directory to the config package we release Spinnaker from. If you want to turn it off completely that means just adding the udfRoot option to clouddriver-local.yml, and putting a blank file at /opt/spinnaker/config/custom-udf/udf0 .
+
+## Passing environment data to your deployed instances
+
+The default configuration of ArmorySpinnaker creates a file `/etc/default/server-env` on every instance with information about its environment. In the example above, `server-env` looks like:
+{% highlight shell %}
+CLOUD_ACCOUNT="default-aws-account"
+CLOUD_ACCOUNT_TYPE="default-aws-account"
+CLOUD_ENVIRONMENT="default-aws-account"
+CLOUD_SERVER_GROUP="test-example-v001"
+CLOUD_CLUSTER="test-example"
+CLOUD_STACK="example"
+CLOUD_DETAIL=""
+EC2_REGION="us-west-2"
+LAUNCH_CONFIG="test-example-v001-03302017224619"
+{% endhighlight %}
+
+
+## Rolling back
+
+Yup. Sometimes you need to rollback to a known previously working state.
+
+### Automatically
+
+From the 'Cluster' tab, select a server group. Click the button on the right pane labeled 'Server Group Actions' and press 'Rollback'
+
+![](/images/Image 2017-03-30 at 5.14.14 PM.png)
+
+In the window that pops up, you can select which server group to rollback to.
+
+![](/images/Image 2017-03-30 at 5.15.27 PM.png)
+
+The server group that you select will re-enabled and scaled up to the necessary number of replicas. Then the rolled back server group will be disabled.
+
+### Manually
+
+If you are ever in a situation where you need to roll back without Spinnaker, you can do so from the AWS console. You will basically run through the process that Spinnaker would do automatically:
+- Scale up the older Auto Scaling Groups (ASG)
+- Add those instances to the ELB
+- Remove the newer ASG's instances from the ELB
+- Scale down or delete the new ASG
+
+
+## Additional Launch Block Devices
+
+If you want additional block devices or a larger root partition you'll need to
+add an a new list to the pipeline JSON.  Unfortunately at this time there is no
+UI to add block devices.
+
+1.  [Edit Your Pipelines JSON](http://docs.armory.io/user-guides/pipelines/#pipeline-json)
+2.  Find your deployment dictionary.  You'll need to add the object of pairs for each cluster definition.
+3.  Add your custom block devices for launch under the key `blockDevices`.
+
+### Block Devices Definition
+
+```
+"blockDevices": [
+  {
+    "deleteOnTermination": [true|false],
+    "deviceName": "[device string]",
+    "iops": [integer ranging from 100-20000],
+    "size": [integer, size in GB, range from 1GB-64TB],
+    "volumeType": "[st1|io1|gp2|sc1]"
+  }
+]
+```
+### Example of Additional Block Devices
+```
+"clusters": [
+        {
+          "account": "my-aws-account",
+          "application": "myapplication",
+          "blockDevices": [
+            {
+              "deleteOnTermination": true,
+              "deviceName": "/dev/sda1",
+              "size": 32,
+              "volumeType": "gp2"
+            }
+          ]
+        },
+        ...
+]
+```
+
+
+## VPC Subnet Type
+
+Throughout Spinnaker, Subnet Type is an abstraction of subnets within AWS.
+
+You can find fields that you use to specify VPC Subnet type when creating load balancers, deploying server groups, etc.
+
+In order to use a subnet within Spinnaker, you will need to tag it in AWS a certain way.
+
+There are two ways you can tag them. One option is to use the convention `spinnaker.<internal|external>.<region>` for the subnet's name. In the screenshot below, you can see that is what I have done on my subnets.
+
+![](/images/Image 2017-03-30 at 1.48.35 PM.png)
+
+Another option is to create a tag named `immutable_metadata` with value `{"purpose": "MySubnetNameInsideSpinnaker"}`

--- a/content/en/docs/_user_guides/dinghy.md
+++ b/content/en/docs/_user_guides/dinghy.md
@@ -1,0 +1,419 @@
+---
+layout: post
+title: Pipelines as Code
+order: 108
+redirect_from:
+  - /user-guides/pipeline-templates/
+---
+
+<div class="deprecation-warning">
+  The information below was written for a previous version of Armory Spinnaker
+  (v1.13 and earlier).  Please look <a href="/spinnaker/using_dinghy">here</a> for
+  documentation on the latest version.
+</div>
+
+Armory's Pipelines As Code feature provides a way to specify pipeline definitions in source code repos (like GitHub & BitBucket).
+
+The Armory Spinnaker installation provides a service called "Dinghy" which will keep the pipeline in Spinnaker in sync with what is defined in the GitHub repo. Also, users will be able to make a pipeline by composing other pipelines, stages, or tasks and templating certain values.
+
+> NOTE: before you can use this feature, please ensure you have [configured it](http://docs.armory.io/install-guide/dinghy/) correctly.
+
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## How it works in a nutshell
+
+GitHub (or BitBucket) webhooks are sent off when either the Templates or the Module definitions are modified. The Dinghy service looks for and fetches all dependent modules and parses the template and updates the pipelines in Spinnaker. The pipelines get automatically updated whenever a module that is used by a pipeline is updated in VCS. This is done by maintaining a dependency graph.  Dinghy will look for `dinghyfile`s in all directories not just the root path. Unless otherwise configured, Dinghy will process changes found in the master branch. For more information on how to configure branches, see [Custom branch configuration](http://docs.armory.io/spinnaker/install_dinghy/#custom-branch-configuration)
+
+## Primitives
+
+- **Modules**: These are templates that define a Stage/Task in the pipeline. They are kept in a single GitHub repo that is configurable when the dinghy service starts. eg:
+
+![](/images/dinghy-template-repo.png)
+
+ They are JSON files with replacable values in them. e.g., a module that defines a wait stage in a pipeline might look like:
+```
+{
+    "name": "Wait",
+    "refId": "1",
+    "requisiteStageRefIds": [],
+    "type": "wait",
+    "waitTime": 42
+}
+```
+- **Pipeline definitions**: These define a pipeline for an application in a file called `dinghyfile`. The `dinghyfile` usually resides at the root level of the application repo. eg:
+
+![](/images/dinghyfile.png)
+
+You can compose stage/task templates to make a full definition. e.g., a Pipeline definition that has a single wait stage might look like:
+```
+{
+  "application": "yourspinnakerapplicationname",
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "keepWaitingPipelines": false,
+      "limitConcurrent": true,
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {
+          "name": "Wait",
+          "refId": "1",
+          "requisiteStageRefIds": [],
+          "type": "wait",
+          "waitTime": 10
+        }
+      ],
+      "triggers": []
+    }
+  ]
+}
+```
+
+## Template variables and substitution
+
+Pipeline definitions can include Modules defined in another GitHub Repo. e.g.:
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "keepWaitingPipelines": false,
+      "limitConcurrent": true,
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {{ module "wait.stage.module" }} // Module created in dinghy-templates repo
+      ],
+      "triggers": []
+    }
+  ]
+}
+{% endraw %}```
+
+The `{% raw %}{{ module "wait.stage.module" }}{% endraw %}` takes the wait.stage.module file inside the dinghy-templates repo, and includes it in the current template.
+
+We can also pass variables to our modules like so:
+
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "keepWaitingPipelines": false,
+      "limitConcurrent": true,
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {{ module "wait.stage.module" "waitTime" 200 }} // Pass the "waitTime" variable with value 200 to wait.stage.module
+      ],
+      "triggers": []
+    }
+  ]
+}
+{% endraw %}```
+
+Any number of variables can be passed to a module by simply specifying them as arguments, e.g.: `{% raw %}{{ module "wait.stage.module" "waitTime" 100 "name" "simpleWait" }}{% endraw %}`.
+
+Inside wait.stage.module, we can then include these variables inline:
+
+```{% raw %}
+{
+  "waitTime": {{ var "waitTime" ?: 10 }}
+  "name": "{{ var "name" ?: "defaultname" }}",
+}
+{% endraw %}
+```
+
+The `{% raw %}{{ var }}{% endraw %}` function is used to access variables passed to the `{% raw %}{{ module }}{% endraw %}` call.
+The first parameter is the variable name: `{% raw %}{{ var "waitName" }}{% endraw %}`
+Optionally, you can include a default parameter: `{% raw %}{{ var "waitName" ?: "defaultValue" }}{% endraw %}`.
+
+Let us create a more realistic pipeline using templates. One that would look like this:
+
+![](/images/Screen Shot 2018-03-12 at 11.18.38 AM.png)
+
+You would use the following JSON to create such. Note that any of the stages could have come from an imported module, but we show the full JSON here for readability:
+
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "keepWaitingPipelines": false,
+      "limitConcurrent": true,
+      "name": "step1",
+      "stages": [
+        {
+          "continuePipeline": false,
+          "failPipeline": true,
+          "isNew": true,
+          "job": "armory/job/armory-hello-deploy/job/master",
+          "master": "Armory Jenkins",
+          "name": "Jenkins",
+          "parameters": {},
+          "refId": "105",            // a unique id that's unique between pipelines.stages[*].refId
+          "requisiteStageRefIds": [],
+          "type": "jenkins"
+        },
+        {
+          "baseLabel": "release",
+          "baseOs": "ubuntu",
+          "cloudProviderType": "aws",
+          "extendedAttributes": {},
+          "isNew": true,
+          "name": "bake in eu-central-1",
+          "package": "myapp_1.27-h343",
+          "refId": "101",
+          "regions": [
+             "eu-central-1"
+          ],
+          "requisiteStageRefIds": [
+            "105"      // this means: stage "105" comes before this stage
+          ],
+          "storeType": "ebs",
+          "type": "bake",
+          "user": "LeSandeep",
+          "vmType": "hvm"
+        },
+        {
+          "failPipeline": true,
+          "isNew": true,
+          "name": "run tests",
+          "refId": "102",
+          "requisiteStageRefIds": [
+            "101"
+          ],
+          "type": "script",
+          "user": "LeSandeep",
+          "waitForCompletion": true
+        },
+        {
+          "isNew": true,
+          "name": "canary",
+          "refId": "103",
+          "requisiteStageRefIds": [
+            "101"
+          ]
+        },
+        {{ module deploy.stage.module "requisiteStageRefIds" ["102", "103"] }}
+      ],
+      "triggers": []
+    }
+  ]
+}
+{% endraw %}```
+
+The file `deploy.stage.module` would look like this:
+```{% raw %}
+{
+  "clusters": [],
+  "isNew": true,
+  "name": "deploy to stage",
+  "refId": "104",
+  "requisiteStageRefIds": {{ var "requisiteStageRefIds" ?: [] }},
+  "type": "deploy"
+}
+{% endraw %}```
+
+## Multiple level inheritance:
+
+In the below example, we show a pipeline that is created with multiple levels of module inheritance. The application's dinghyfile looks like this:
+
+```{% raw %}
+{
+  "application": "dinghytest",
+  "pipelines": [
+    {{ module "simple.pipeline.module" "application" "dinghytest" }}
+  ]
+}
+{% endraw %}```
+The dinghyfile inherits its pipeline from a _module_ named `simple.pipeline.module` that looks as shown below. Note that it also overrides the application name in the module to avoid conflict.
+
+> It is worth noting in the below example, where we are substituting a string variable, the call to {% raw %}{{ var ... }}{% endraw %} is also surrounded by quotes, unlike when substituting non-string variables (ie, int, array, json...)
+
+```{% raw %}
+{
+  "application": "{{ var "application" ?: "yourspinnakerapplicationname" }}",
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "name": "Made By Armory Pipeline Templates",
+  "stages": [
+    {{ module "wait.stage.module" "waitTime" 200 }},
+    {{ module "deploy.stage.module" "requisiteStageRefIds" ["1"] }}
+  ],
+  "triggers": []
+}
+{% endraw %}```
+
+This module inherits two stages and overrides variables within them. The `wait.stage.module` is same as the one shown above. The `deploy.stage.module` looks like this:
+
+```{% raw %}
+{
+  "clusters": [],
+  "isNew": true,
+  "name": "deploy to stage",
+  "refId": "104",
+  "requisiteStageRefIds": {{ var "requisiteStageRefIds" ?: [] }},
+  "type": "deploy"
+}
+{% endraw %}```
+
+Note how the `requisiteStageRefIds` is overwritten while calling the module so that the deploy stage _depends on_ the wait stage. This pipeline would look like this in the spinnaker UI:
+
+![](/images/Screen_Shot_2018-03-26_at_5_06_25_PM.png)
+
+## Deleting stale pipelines
+
+If you want any pipelines in the spinnaker application that are not part of the `dinghyfile` to be deleted automatically when the `dinghyfile` is updated, then you can set `deleteStalePipelines` to `true` in the JSON like so:
+
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "deleteStalePipelines": true
+  "pipelines": [
+  ]
+}
+{% endraw %}```
+
+## Triggering other pipelines from within a stage
+
+The spinnaker `pipeline` stage allows you to trigger other pipelines. However, typically you need the UUID of the pipeline to be triggered. To make it easier to write dinghy templates, we have a `pipelineID` function which can be used in dinghyfiles to trigger pipelines. Consider the below example (`pipeline.stage.module`):
+
+```{% raw %}
+{
+		"application": "pipelineidexample",
+		"failPipeline": true,
+		"name": "Pipeline",
+		"pipeline": "{{ pipelineID "default-app" "default-pipeline" }}",
+		"refId": "1",
+		"requisiteStageRefIds": [],
+		"type": "pipeline",
+		"waitForCompletion": true
+}
+{% endraw %}```
+
+In the above example, we are triggering a pipeline by the name `default-pipeline` under `default-app` spinnaker application. The app name and the pipeline name can be overwritten when calling this module. At any higher level, simply pass in `"triggerApp"` and `"triggerPipeline"` like so: `{% raw %}{{ module "pipeline.stage.module" "triggerApp" "pipelineidtest" "triggerPipeline" "testpipelinename" }}{% endraw %}`
+
+
+## Advanced features:
+
+### Monorepo
+Dinghy supports multiple spinnaker applications under the same git repo. eg:
+```{% raw %}
+monorepo/
+├── app1
+│   ├── bin
+│   ├── lib
+│   ├── pkg
+│   └── src
+│       ├── app1.go
+│       └── dinghyfile
+└── app2
+    ├── bin
+    ├── lib
+    ├── pkg
+    └── src
+        ├── app2.go
+        └── dinghyfile
+{% endraw %}```
+
+Notice both `app1` and `app2` are under the same repo, each app has its own `dinghyfile` and its own spinnaker application that can be referenced in the `dinghyfile`.
+
+### Template validation
+If, while rendering a `dinghyfile`, a malformed JSON file is encountered, the logs should indicate the line number and the column number of the error. The `arm cli` can be used to validate `dinghyfile`s and `module`s locally without having to put them in source control.
+
+### Newlines
+For ease of readablilty, you can split a single call to `module` across multiple lines. For example, the following two `dinghyfile`s are both valid & produce identical pipelines in spinnaker:
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {{ module "wait.stage.module" "name" "wait-for-cache-warm-up" "waitTime" 42 }}
+      ]
+    }
+  ]
+}
+{% endraw %}```
+
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {{
+           module "wait.stage.module"
+           "name" "wait-for-cache-warm-up"
+           "waitTime" 42
+        }}
+      ]
+    }
+  ]
+}
+{% endraw %}```
+
+### Top-level variables in dinghyfiles
+When passing in variables to modules, you have the option of defining variables at the top-level `dinghyfile` like so:
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "globals": {
+      "waitTime": "42",
+      "name": "default-name"
+  },
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {{ module "wait.stage.module" }}
+      ]
+    }
+  ]
+}
+{% endraw %}```
+In the above example, the variables `waitTime` and `name` (used inside `wait.stage.module`) are defined at the top level, and not explicitly defined when the call to `wait.stage.module` is made.
+
+Note that top-level variables are overwritten by variables in the call to module if both are present. For instance, in the below example, the `waitTime` after the `dinghyfile` is rendered would be `43`:
+```{% raw %}
+{
+  "application": "yourspinnakerapplicationname",
+  "globals": {
+      "waitTime": "42",
+      "name": "default-name"
+  },
+  "pipelines": [
+    {
+      "application": "yourspinnakerapplicationname",
+      "name": "Made By Armory Pipeline Templates",
+      "stages": [
+        {{ module "wait.stage.module" "waitTime": "43" }}
+      ]
+    }
+  ]
+}
+{% endraw %}```
+
+### Nested variables
+Another neat little trick with variables is support for nested variables. Consider the following variable usage in a module:
+```{% raw %}
+"name": "{{ var "name" ?: "some-name" }}"
+{% endraw %}```
+Here, if the variable `"name"` was passed in, or is a top-level variable in the `dinghyfile`, then use that value, or else _default to_ `some-name`.
+
+With nested variables, instead of using a hardcoded default value, the default can from another variable. eg:
+
+```{% raw %}
+"name": "{{ var "name" ?: "@different_var" }}"
+{% endraw %}```
+Here, if the variable `"name"` was not passed into the module call and is not a top-level variable in the `dinghyfile`, its value will come from a variable called `"different_var"` that is either a top-level variable or another variable passed in when the module is called. Note the `@` syntax for the nested variable. The `@` symbol is only used where the variable is used, not when it is passed in.
+le

--- a/content/en/docs/_user_guides/expression-language.md
+++ b/content/en/docs/_user_guides/expression-language.md
@@ -1,0 +1,62 @@
+---
+layout: post
+order: 80
+# migrated to spinnaker-user-guides/expression-langauge
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+The expression language is a powerful tool that you can use to add logic and decision-making to your pipelines. While a lot of the time you will probably use it to evaluate variables, it can do a lot more. You can write straight Java/Groovy into it. This means you can do transformations, filters, maps, etc. You can use it to branch your pipeline into different directions.
+
+Some of the most common uses include:
+- Getting build information from Jenkins
+- Passing image names from one stage to another
+- Retrieving a user's manual judgement response
+
+
+Before we go into examples and troubleshooting, check out the guide on spinnaker.io for an detailed overview: [https://www.spinnaker.io/docs/pipeline-expressions-guide](https://www.spinnaker.io/docs/pipeline-expressions-guide)
+
+## Common techniques
+
+### Dynamically defining User-Data
+
+If you are creating a deployment configuration for AWS, Spinnaker gives you the option to provide [user-data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data). As you can see here:
+
+![](/images/Image 2017-05-26 at 11.20.47 AM.png)
+
+The user-data field needs to be base64 encoded. It is possible to create this dynamically with the built in expression language. To do this you can use the `${ #toBase64() }` command. For example, You can pass the build number to the user-data via:
+
+![](/images/Image 2017-05-26 at 11.29.23 AM.png)
+
+
+## Examples
+
+You can find the expression language used in the examples within the [baking images]({% link _spinnaker_user_guides/baking-images.md %}), [deploying]({% link _spinnaker_user_guides/deploying.md %}), [working with Jenkins]({% link _spinnaker_user_guides/working-with-jenkins.md %}) and [finding images]({% link _spinnaker_user_guides/find-images.md %}) guides.
+
+## Troubleshooting
+
+Sometimes using the expression language doesn't go as anticipated. Here are some of the common issues:
+
+### Autocomplete popup menu
+
+Sometimes the UI doesn't display the autocomplete popup menu. This is because it doesn't have the context to do so. Try filling in as much of the details as you can for the stages in your pipeline, then run the pipeline. After it has ran (it's okay if it failed), go back to where you were trying to use the expression language and see if the autocomplete popup menu is displayed.
+
+### Expression doesn't get evaluated
+
+Sometimes your expression is just printed out plainly and not evaluated. Usually this happens when the expression is invalid and/or can not be resolved and does not mean that Spinnaker isn't trying to evaluate it. Try double checking that what you are referencing does exist. To check that it does exist, go to your pipeline's execution details and click the 'Source' link in the very bottom right hand corner. 
+
+For example:
+![](/images/Image 2017-04-03 at 3.37.57 PM.png)
+
+You should see a page full of JSON. It doesn't print in a very readable format, so you may want to copy and paste it into a text editor or another tool that will help you read it (I usually just curl this URL and pipe it to `jq`). You can navigate to the JSON field 'stages' for a list of stages in your pipeline. These stages are not necessarily in order. In the stage you'll see another field called 'context'. This is the information avaliable to the expression language. Make sure what you are referencing is in the context of the appropriate stage.
+
+### Testing your pipeline expressions
+
+The best way to test a pipeline expression is to create a sample pipeline and see if your SPEL expression does what you expect it to do before you add it to your production pipeline. Another feature that is helpful for writing SPEL is if the pipeline has ran in the past, the UI will show you autocomplete options based on the previous execution.

--- a/content/en/docs/_user_guides/find-images.md
+++ b/content/en/docs/_user_guides/find-images.md
@@ -1,0 +1,78 @@
+---
+layout: post
+order: 60
+# migrated to spinnaker-user-guides/find-images
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Prerequisites and Assumptions:
+
+- You have experience [baking]({% link _spinnaker_user_guides/baking-images.md %}) and [deploying images]({% link _spinnaker_user_guides/deploying.md %}) with Spinnaker
+
+
+
+Spinnaker provides a lot of auto-magic for determining which AMI should be deployed to which server group. However, sometimes it is necessary to override Spinnaker's selection.
+
+## Dynamic Base AMI
+
+Sometimes you may want to build your AMI in several different pipelines before deploying it. This is a popular method when you need to add a layer of standard tools and daemons to all of your instances (ex: Splunk or DataDog agents). Also, you may want to do regular security updates and have it roll out to all instances in your organization.
+
+Let's go through an example.
+
+
+I have created a multi-region bake pipeline that creates AMIs from a package built on Jenkins. For directions on how to create a pipeline like this, check out the [baking guide]({% link _spinnaker_user_guides/baking-images.md %}). You can see it running here:
+
+![](/images/Image 2017-04-04 at 11.01.25 AM.png)
+
+
+Next I want to create a pipeline that is triggered by a Jenkins job and installs the package that Jenkins created. However, I want that package to be installed on top of one of the AMIs from the multi-region bake above.
+
+
+I start by creating a new pipeline.
+
+
+I add an automated trigger to build from a Jenkins' job. For a more detailed example of this, check out the [baking guide]({% link _spinnaker_user_guides/baking-images.md %}).
+
+![](/images/Image 2017-04-04 at 2.47.40 PM.png)
+
+
+Now I add a 'Find Images From Tags' stage and input 'armoryami' in the 'Package' field. The 'package' you input needs to match the package installed by the baked AMI in the prior bake pipeline.
+
+![](/images/Image 2017-04-04 at 2.40.14 PM.png)
+
+By checking the 'us-west-2' checkbox, I am telling Spinnaker to find images in only that regions and make it available to the rest of the pipeline.
+
+
+Next I want to add my own package to this AMI. First, I add a bake stage. Since my Jenkins' job created an artifact named 'armory-hello-deploy', I input that into the 'Package' field. The next part is a little tricky. I need to specify the correct base AMI by checking the 'Show Advanced Options' and using the [expression language]({% link _spinnaker_user_guides/expression-language.md %}) in the 'Base AMI' field. 
+
+
+![](/images/Image 2017-04-04 at 3.03.22 PM.png)
+
+As you can see, the expression I use is:
+
+{% highlight shell %}
+${ #stage('Find Image from Tags')['context']['amiDetails'][0]['imageId'] }
+{% endhighlight %}
+
+### What is happening here? 
+
+- The `#stage('Find Image from Tags')` function references the previous pipeline stage named 'Find Image from Tags'. This function returns a map of data. 
+- The 'context' field of the map is populated after the 'Find Image from Tags' stage runs and contains the resulting data. 
+- The 'amiDetails' field is an array of all images found. This is especially relevant if you are looking for images in multiple regions. Although in our case, we are just working in 'us-west-2', so there is only one element in the array, '[0]'. 
+- Lastly, the 'Base AMI' field in the 'Bake Configuration' is expecting an AMI id as input so after we specify element '[0]', we further specify '[imageId]' to get the AMI id of the image.
+
+
+We can now execute the pipeline with the above inputs. 
+
+![](/images/Image 2017-04-04 at 3.22.17 PM.png)
+
+Notice the 'Results' box in the lower right hand corner. After inspecting it and comparing it to the bake pipeline in the very beginning of the example, I can see that Spinnaker did indeed choose the correct AMI.
+
+If you wanted to deploy this image, you can just add a deploy step and Spinnaker will deploy the correct AMI. For more instructions on deploying, check out the [deployment guide]({% link _spinnaker_user_guides/deploying.md %}).

--- a/content/en/docs/_user_guides/glossary.md
+++ b/content/en/docs/_user_guides/glossary.md
@@ -1,0 +1,144 @@
+---
+layout: post
+title: Glossary of Definitions
+published : false
+---
+
+{% include components/legacy_documentation.html %}
+
+<!-- For colin reference
+
+- [Baking]({% link _spinnaker_user_guides/baking-images.md %}#troubleshooting)
+- [Deploying]({% link _spinnaker_user_guides/deploying.md %}#common-errors-and-troubleshooting)
+- [Expression language]({% link _spinnaker_user_guides/expression-language.md %}#troubleshooting) -->
+
+Below is a list of words and phrases as they apply to Spinnaker and their definitions, including any additional information that may be helpful. 
+
+
+
+#### Amazon Web Services
+Amazon Web Services (AWS) is a cloud services provider from Amazon that offers computing power, database storage, content delivery and additional functionalities to businesses that operate in the cloud. For Spinnaker purposes, think of AWS as a data center but instead of being physical servers it is in the cloud.
+
+#### Amazon Machine Images
+Amazon Machine Images (AMIs) are predetermined 'templates' for instances that can be used to launch an instance of a virtual server. They generally include the configurations for the instance (Operating System, application server, applications), the permissions and Secrets that control which AWS accounts can access the instances, and a block device mapping that specifies the volumes to attach to the instance when it is launched.
+
+
+
+#### [Application]({% link _spinnaker_user_guides/application-screen.md %}) 
+An application inside Spinnaker represents what you would typically find in a single [code repository](#Code-Repository) - and in many cases, an application maps directly to a microservice.
+
+#### Auto-Scaling Group
+An auto-scaling group (ASG) contains a collection of [EC2](#elastic_compute_cloud) instances that share similar characteristics and are treated as a logical grouping for the purposes of instance scaling and management.
+
+
+#### Authorization
+Authorization (Auth) is the level of access to APIs that a user, application or role has within your [AWS](#Amazon_Web_Services) account. This is usually configured by your administrator. 
+
+
+#### [Baking]({% link _spinnaker_user_guides/baking-images.md %})
+The term 'baking' is used within Spinnaker to refer to the process of creating machine images, usually with [AMIs](#Amazon_Machine_Images).
+
+
+#### Cloud
+Short for cloud computing, the cloud as we refer to it is internet-based computing that provides processing resources (e.g.; database storage, networks, servers, applications) on demand to devices connected to the internet.
+
+#### CloudDriver
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Clouddriver).
+
+#### Cluster
+A server group is a regional view of servers, whereas a cluster is a world-wide view of server groups. 
+
+
+#### Code Repository
+A source code repository is a private or public storage location for file archive and web hosting, used for source codes of software or web pages.
+
+#### Continuous Delivery
+Continuous Delivery (CD) is an engineering approach for DevOps teams to produce software in short cycles: building, testing, and releasing software at a fast and frequent pace in order to iterate as quickly as possible. 
+
+#### Continuous Integration
+Continuous Integration (CI) is a development practice where software developers merge their separate changes and updates to a main source code repository - usually multiple times a day. 
+
+
+#### Deck
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Deck).
+
+#### Debian Package
+Debian packages (deb) are two tar archives contained in standard Unix ar archives - one holds the control information and the other contains the data used for installation. 
+
+
+#### Detail 
+For cluster and server group configurations, 'Detail' is usually any additional piece of user-defined information you want to label your cluster and server group(s) with.
+
+
+#### Echo
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Echo).
+
+#### Elastic Compute Cloud
+Elastic Compute Cloud (EC2) is part of the AWS cloud platform, a "pay as you go" virtual computer renting system that contains preconfigured software and applications requested by the user. 
+
+
+
+#### Execution
+When a pipeline runs, the end result is called an execution. 
+
+
+#### Gate
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Gate).
+
+
+#### Igor
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Igor).
+
+#### Infrastructure Version
+The infrastructure's version number; such as v011, v012, etc. This is automatically appended and is not user defined. 
+
+In AWS, Spinnaker will name your ASGs and Launch Configurations according to the naming convention mentioned above (ie. “armoryspinnaker-prod-polling-v015”). 
+
+Please note that if your user definition includes a hyphen, it will disrupt the naming convention. 
+
+
+#### [Jenkins]({% link _spinnaker_user_guides/working-with-jenkins.md %}) 
+Jenkins is an open source automation server that can package applications for distribution. Spinnaker pipelines can be [triggered](#trigger) from a build on Jenkins.  
+
+
+#### Lighthouse
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Armory_Lighthouse).
+
+
+#### [Load Balancer]({% link _overview/load-balancers.md %}) 
+For Spinnaker's purposes, a load balancer is a service that automatically distributes incoming traffic across all instances. The one most commonly used within AWS is the Elastic Load Balancer (ELB).
+
+
+#### Orca
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Orca).
+
+
+#### Pipeline
+A pipeline in Spinnaker is a series of stages linked together that can be executed serially or in parallel. All pipelines are defined in the context of an application. A typical pipeline will contain stages for “creating images”, “testing”, and “deploying”. The process of “creating images” is also commonly referred to as a “bake”.
+
+Learn to create [your first pipeline here]({% link _overview/your-first-pipeline.md %}).
+
+
+#### Project
+A project inside Spinnaker is a logical grouping of applications. For example, we might create a project called “Spinnaker” and its applications would be “Deck”, “Orca”, “Clouddriver”, etc. Spinnaker provides a helpful dashboard view using Deck for each project to visualize its applications and status of each application contained within it.
+
+#### Rosco
+A sub-service within Spinnaker. For more information, go to [sub-services]({% link _admin_guides/subservices.md %}#Rosco).
+
+#### Server Group
+From an Amazon Web Service (AWS) point of view, a server group is represented by an auto-scaling group (ASGs). All applications that are deployed by Spinnaker are deployed to server groups. 
+
+#### Stack
+You can think of a 'Stack' as a tag you give to anything that you want to be integrated together. Environments are usually a good example of something you would tag with a Stack. If you have an app that has an ELB, a Cache, and an [ASG](#auto-scaling-group), usually you would want to run integration tests on your staging environment separately from your production environment. In that case, you would give the staging ELB, Cache, and ASG all the “staging” stack, while prod ELB, Cache, and ASG would be the “prod” stack. 
+
+Note that Stack names are defined by the user in the Spinnaker configuration User Interface (UI).
+
+
+#### Stage
+Within a pipeline, the tasks that pipeline performs are called stages.
+
+
+#### Trigger
+A trigger is the entry point to a [pipeline](#pipeline) - when a pipeline is triggered, it attempts to [execute](#execution).
+
+

--- a/content/en/docs/_user_guides/kayenta.md
+++ b/content/en/docs/_user_guides/kayenta.md
@@ -1,0 +1,349 @@
+---
+layout: post
+title: Kayenta
+order: 74
+# migrated to spinnaker-user-guides/kayenta
+published: false
+---
+
+
+{% include components/legacy_documentation.html %}
+
+# What is Kayenta
+{:.no_toc}
+
+Kayenta is an automated canarying analysis (ACA) service that is provided through Armory Spinnaker. The goal of Kayenta is to provide the end user with confidence that a deployment is safe through automation and intelligence.
+
+Kayenta uses real-time data sources to validate that a canary is good or bad. Today, Kayenta supports the following real-time data sources:
+
+* DataDog
+* Stackdriver (Google)
+
+
+This guide includes:
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Configuring Kayenta on an Application
+
+If Kayenta is enabled for you instance, if you go to an application's config
+you should see a checkbox to enable Canarying:
+
+![image](/images/Image 2018-10-23 at 3.25.33 PM.png)
+
+Make sure it's checked and saved.
+
+If you don't see this option in your application config, make sure you've
+[configured Kayenta](https://www.spinnaker.io/guides/user/canary/).
+
+You can also find more information about Kayenta on [Automated Canary Deployments](/spinnaker/configure_kayenta)
+
+In this document, we will quickly run through the process to simply get you
+going.
+
+## Canary Configs
+
+(NOTE:  You may need to refresh your browser page to see these changes
+after enabling the Canary above)
+
+Your menubar should show "Delivery" and you should see the option for
+"Canary Configs" as a hover, or as a submenu element:
+
+![Canary Configs Menu Item](/images/[069c7e1865637f78eb92a091172c92da]_Image 2018-04-18 at 12.45.18 PM.png)
+
+Click on "Canary Configs" and "Add configuration".  You should see a
+mostly-blank form:
+
+![Canary Config Form](/images/Image 2018-04-18 at 12.56.54 PM.png)
+
+*Configuration Name*:  Spaces are not allowed, only alphanumerics, hyphens and
+underscores.  This name will be displayed as an option in the canary stage
+configuration later, so we recommend you make it a meaningful name.
+
+*Metric Store*:  If you only configured one metrics store, this will already
+be set for you.  Otherwise, you can choose from the options, the default will
+be the one you referenced in the environment file.
+
+*Description*:  Free form text to help your coworkers know what this canary
+is doing.
+
+## Groups
+
+A Canary Config can contain multiple groups of metrics, and each group can
+contain multiple metrics.  By default "Group 1" is set up for you to add to;
+you can rename the group by clicking on the group and then clicking on the
+pencil icon next to it.
+
+A group that has no metrics in it will be removed when the configuration is
+saved.  If you create an extra group or want to delete an existing one, just
+be sure you've removed all the metrics from that group before saving.
+
+Grouping is used to add different weights to the importance of different
+metrics or groups of metrics (see "Scoring" below).
+
+## Add Metric
+
+When you add a metric, the UI will be slightly different depending on what
+Metric Store you selected earlier.  The DataDog dialog looks like:
+
+![DataDog Metric Dialog](/images/Image 2018-04-18 at 1.11.59 PM.png)
+
+The Stackdriver dialog looks like:
+
+![Stackdriver Metric Dialog](/images/Image 2018-04-18 at 1.12.46 PM.png)
+
+In all cases, the Name is free-form and used to label the results and graphs.
+
+By default the "Fail on" selection of "either" means the comparison of canary
+and baseline metrics will be marked as a failure if the canary's data is
+either significantly greater or less than the baseline's data.  You can select
+"increase" if you only want to fail when the canary's metrics are significantly
+higher than the baseline (useful for things like error counts, memory and CPU
+usage, etc, where a significant improvement is not a failure), or, conversely,
+select "decrease" for the opposite (useful for metrics that measure things
+where bigger numbers are always better).
+
+### DataDog Metrics
+
+For DataDog, the metric is simply the aggregation function you wish to use
+(avg, min, max, sum), a colon, and the name of the metric.  You can use the
+[DataDog Metrics Explorer](https://app.datadoghq.com/metric/explorer) to find
+these names:
+
+![DataDog Metrics Explorer](/images/Image 2018-04-18 at 1.20.25 PM.png)
+
+For example, if you wanted to measure the average amount of CPU used, you could
+enter `avg:system.cpu.user`.
+
+### Stackdriver Metrics
+
+Please refer to the [Spinnaker Kayenta documentation](https://www.spinnaker.io/guides/user/canary/config/#create-metric-groups-and-add-metrics) for information
+on configuring Stackdriver metrics.
+
+### New Relic Metrics
+
+For New Relic, the [NRQL query language](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-reference) is ultimately used to query the
+data; we compose the query in pieces.  In the metric, you'll need to enter the
+desired metric (and any aggregation, average, max, etc) plus the table to use.
+For example, to retrieve the average duration of a web request, you'd enter
+`average(duration) FROM Transaction`.  Only one metric can be retrieved in 
+each metric definition.
+
+## Filter Templates
+
+Please refer to the [Spinnaker Kayenta documentation](https://www.spinnaker.io/guides/user/canary/config/filter_templates/) for information on configuring
+Filter Templates.  They are completely optional and may not be necessary for
+your application.
+
+## Scoring
+
+After adding some metrics to groups, you should see each non-empty groups in
+this section, with scores defaulted to "0".  You'll need to edit these scores
+to sum to 100 (if you've only created a single group, just set it to 100).
+
+When the canary runs for a given interval, all the metrics are evaluated and
+each metric is given a pass/fail based on the deviation from the baseline
+metric.  Within a group, each metric is evenly balanced (so if a group has
+two metrics, and one fails and one passes, the group is scored at 50%; if
+it had only one metric, it would score either 100% for a pass or 0% for a
+fail).
+
+Each group is then scored their Metric Group Weight proportional to the
+success of the metrics in the group.  A group with a weight of 40 and a
+50% failure rate would score a total of 20 (50% of 40).  The score of each
+group is added together for a final interval score.  It's this total score
+that is compared to the Thresholds evaluation.  If the total is above the
+"Marginal" level, the canary will continue to run; if it's less than the
+Marginal level, the canary will stop and record a failed stage immediately.
+
+If the canary runs to completion, and all the intervals scored above "Pass",
+the stage will be considered a success.  If *any* interval fell into the
+grey area between Marginal and Pass, the stage will end with a failure,
+although it will not have been pre-emptively cancelled.  This is intented to
+allow someone to look at the marginal responses and make their own evaluation
+of whether or not the pipeline should continue.
+
+## Configuring A Canary Analysis Stage
+
+If everything is configured properly, you should be able to create a stage
+of Type "Canary Analysis".  The stage form should look like this:
+
+![Blank Canary Config](/images/Image 2018-04-18 at 1.48.11 PM.png)
+
+*Analysis Type*:  "Real Time" (default) or "Retrospective".  If you select
+Retrospective, you'll see two additional fields appear, where you will set
+the start and end time of the evaluation.  This is the time period that will
+be examined on *every* execution of this stage, so it's most useful for
+examining historical data, or just testing your configs before applying them
+to live systems.
+
+*Config Name*:  Here you select which Canary Config (which we created in the
+previous section) to use.
+
+*Delay*:  It may be useful to wait a few minutes after the previous deploy
+stages have completed, to let the systems get into a stable running state,
+before checking metrics.  This field disappears if you've chosen to do a
+Retrospective analysis.
+
+*Interval*:  This defines the time between metrics inspections.  If this is
+set to 30, for example, the metrics will be compared only twice during a
+1-hour canary; if set to 5, it would be inspected 12 times during a 1-hour
+canary (see Lifetime, below).
+
+*Lookback Type*:  "Growing" (default) or "Sliding".  If set to "Growing",
+the metrics are queried from the start of the canary up to the time of the
+interval.  If set to "Sliding" (and you set the look back duration), it will
+only look at the metrics for that sliding window of time.
+
+*Metric Scopes*:  See below for details on this section.
+
+*Step*:  How many seconds between each metric datapoint to query.  NOTE: For
+DataDog, this field is ignored (DataDog does not let you define the interval)
+
+*Lifetime*:  How many hours to let this canary analysis run before making a
+final determination.  Note that if any single interval falls below a
+"Marginal" score, the analysis will stop immediately.
+
+*Scoring Thresholds*:  These are defaulted to whatever is configured in
+the Canary Config -- however, you can adjust these scores on a per-pipeline
+basis if desired.
+
+*Metrics Account*:  Select which account to use for metrics (if you've
+configured multiple).  NOTE:  If you've configured multiple metrics
+providers, like DataDog AND Stackdriver, be sure you've selected an account
+that matches the Canary Config's Metric Store.  The UI currently does not
+prevent you from selecting, for example, a Stackdriver account here, after
+selecting a Canary Config based on Datadog.
+
+*Storage Account*:  Select which account to use for storing the metrics data
+and graphs.
+
+*Scope Name*:  Select Default for now.
+
+### Metric Scopes
+
+This section gets filled in differently, depending on which metrics provider
+you're using, and how you've set up your pipeline prior to this stage.  For
+DataDog, as an example, the intention is to provide the tag:value pairs
+you've set up on your instances, identifying the different clusters, hosts,
+etc. that you're comparing.  For example, if you're using AWS Autoscaling
+Groups to cluster your baseline and canary instances, you would enter
+something like `autoscaling_group:myapp-v001` for the baseline and
+`autoscaling_group:myapp-v002` for the canary.  You can further refine
+the results by appending further tag:value pairs separated by commas,
+such as `autoscaling_group:myapp-v001,region:us-west-2`.
+
+For DataDog, the two Location fields are unused and can be safely left
+blank.  For Stackdriver (and other metrics sources) they are required fields.
+
+For more information on configuring these scopes, please refer to the
+[Spinnaker Kayenta Documentation](https://www.spinnaker.io/guides/user/canary/stage/#define-the-canary-stage).
+
+### Automating Canary Analysis In A Pipeline
+
+The Kayenta stage lets you run canary analysis against pretty much anything, so
+it's hard to prescribe a specific usage that would best fit your scenario.  To
+give you a head start, though, take a look at this pipeline:
+
+![Canary Deploy Pipeline](/images/Image 2018-04-20 at 2.08.37 PM.png)
+
+After configuration (where you would set up your automated triggers, for
+example), the steps are:
+
+1. Identify Baseline (Find Image from Cluster Configuration)
+
+   In this stage, we want to find our baseline, based on what's currently in
+   production.  We select our production cluster and then look for the
+   "Oldest" enabled Server Group.  This will later be referenced to act as our
+   baseline server group for the canary.
+
+   ![Identify Baseline](/images/[16ee274765420799d2f010fb44ac1208]_Image 2018-04-20 at 2.24.15 PM.png)
+
+2. Bake
+
+   This is where we actually bake the Canary image, otherwise just like any
+   other bake stage.
+
+3. Deploy Canary (Deploy)
+
+   Here we deploy the baked image to our cluster.  The important note here
+   is that we select the "None" strategy -- we don't want Spinnaker to do
+   anything to the existing server group yet, we want to run the new image
+   alongside the old image.
+
+   ![Canary Cluster Config](/images/[3683fd1f7f0f72a94e511d9b65f5dce5]_Image 2018-04-20 at 2.22.42 PM.png)
+
+4. Canary Analysis
+
+   We configure our canary analysis stage as described above.  In this
+   example, we can get the baseline server group name using SpEL:
+
+   `${ #stage('Identify Baseline')['context']['artifacts'][0]['metadata']['sourceServerGroup'] }`
+
+   (For Datadog, we want to prepend `autoscaling_group:` to
+   this so we get the correct Datadog tag.)
+
+   (For New Relic, you'll create a WHERE clause for the NRQL query to select
+   by.  If your code is adding a custom attribute to your data, which we do
+   recommend, you'll want to add the clause here, like `version='${...}'`)
+
+   The canary server group can be retrieved with the SpEL:
+
+   `${ deployedServerGroups[0].serverGroup }`
+
+   (again, we prepend `autoscaling_group:` to construct the tag for Datadog)
+
+   ![Canary Stage Example](/images/Image 2018-04-20 at 2.19.17 PM.png)
+
+   We also need to be sure that we don't stop the pipeline execution if the
+   canary fails -- we want to be able to "clean up" after a failure, so we
+   don't keep the bad canary alive longer than we need to:
+
+   ![Continue On Failure](/images/[41b5e2d8d228eae3e13bdbfaa4b307c6]_Image 2018-04-20 at 2.37.35 PM.png)
+
+5. Destroy Canary on Failure (Destroy Server Group)
+
+   The first of two options after the Canary Analysis, we run this conditional
+   on the Canary Analysis stage being in any state other than `SUCCEEDED` --
+   when the canary fails to pass its testing, we want to remove the failed
+   canary server group.  So here we destroy the "Newest Server Group" (the
+   canary) and clean up, leaving the existing good cluster intact.
+
+   ![Destroy Canary](/images/[d8482e840534fe6d2dfa2f4d377f499b]_Image 2018-04-20 at 2.27.00 PM.png)
+
+   ![Failure Condition](/images/Image 2018-04-20 at 3.38.20 PM.png)
+
+6. Promote Canary on Success (Destroy Server Group)
+
+   If our canary survives the coal mine, we want to deprecate the older code
+   in favor of the cluster.  In this simplistic version, we're presuming both
+   clusters are the same size, so all we need to do is remove the old cluster;
+   a real production pipeline would probably need to resize the canary before
+   removing the old cluster.  It's the same basic logic as the previous stage,
+   except we are destroying the "Oldest Server Group" (the same way we ID'd
+   the baseline in the first stage), conditional on the Canary Analysis stage
+   ending with `SUCCEEDED`:
+
+   ![Destroy Baseline](/images/Image 2018-04-20 at 2.32.44 PM.png)
+
+   ![Success Condition](/images/Image 2018-04-20 at 3.39.14 PM.png)
+
+7. Check Preconditions
+
+   The purpose of this stage here is to simply fail the pipeline if the canary
+   fails to pass.  Since we are ignoring the failure on the Canary Analysis
+   stage in order to proceed to our cleanup/promotion stages, we want this
+   stage to fail if the canary failed.  Here we just check that the Canary
+   Analysis stage succeeded (and if it did not, it will fail the pipeline).
+
+   ![Check Results](/images/Image 2018-04-20 at 2.35.22 PM.png)
+
+
+This should give you some idea of how you might want to integrate the Kayenta
+Canary Analysis stage into your production pipelines, and automate your
+deployments!
+
+
+
+

--- a/content/en/docs/_user_guides/kubernetes-v2.md
+++ b/content/en/docs/_user_guides/kubernetes-v2.md
@@ -1,0 +1,127 @@
+---
+layout: post
+title: Early Access Kubernetes V2 Provider Guide
+order: 100
+# No redirect - setup for ec2 vs. halyard installer is diffferent.
+---
+{% include components/legacy_documentation.html %}
+
+This guide includes:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+## Kubernetes V2 Provider Overview
+The new Kubernetes provider is centered on delivering and promoting Kubernetes manifests to different Kubernetes environments. These manifests are delivered to Spinnaker using [artifacts](https://www.spinnaker.io/reference/artifacts/in-kubernetes-v2/#kubernetes-objects-as-artifacts) and applied to the target cluster using `kubectl` in the background. Currently, there is support to supply artifacts through Git, GCS and Google Pub/Sub.  The V2 provider manages the version of the artifacts deployed to Kubernetes by appending a string such as `v421` to the resource that was deployed to Kubernetes.  This allows for easy rollbacks and management of resources.
+
+### What To Expect From The V2 Provider
+The new Kubernetes provider is very much a work in progress and is subject to changes in the UI and APIs. The user experience is still a work in progress and we're interested in understanding real-world usage patterns as we iterate on the provider to optimize the experience.  
+
+### Current Limitations
+-  The only supported services for artifact delivery are Github, GCS, or Google Pub/Sub. S3, SQS, and SNS are currently not supported.
+- Native Spinnaker deployment strategies such as red/black, highlander, rolling red/black deployment are not supported. If these strategies are desired consider using the deployment object in your manifests.
+- While you're able to deploy all Kubernetes resource types, the V2 provider only considers `containers` and `configMaps` for [binding to the deployed manifest](https://www.spinnaker.io/reference/artifacts/in-kubernetes-v2/#kubernetes-objects-as-artifacts). `secrets` and other resource types are coming soon.    
+- You cannot manually trigger the pipeline, you have to use Github triggers.
+
+### Available Manifest Based Stages
+
+There are 4 stages that are available:
+
+1. **Deploy Manifest** -  Uses `kubectl apply` to deploy a manifest.  Spinnaker will wait until the manifest stabilizes in the Kubernetes cluster or reach the expected capacity on healthy pods.
+
+2. **Delete Manifests** - Removes the manifests and their corresponding artifacts in kubernetes based on different types and labels.  
+
+3. **Scale Manifests** - Scales replica sets to a given static size.
+
+4. **Rollback Manifest** - Allows rollback of a given Kubernetes artifact by a given number of versions.  Helpful in cases of a failed deployment or failed manual QA.
+
+## Setting Up The V2 Provider
+
+Setting up the V2 provider is similar to the [V1 Kubernetes configuration](http://docs.armory.io/admin-guides/configure_kubernetes/#configure-clouddriver-to-use-the-kubectl-config-file) however we'll need to change the provider flag in `/opt/spinnaker/config/clouddriver-local.yml` to `v2`.  For example:
+
+```
+kubernetes:
+  enabled: true
+  accounts:
+    - name: k8s-v2
+      providerVersion: v2
+      kubeconfigFile: /opt/spinnaker/credentials/kubeconfig
+```
+
+We'll also need to enable artifact handling in Spinnaker by setting a flag in `/opt/spinnaker/config/spinnaker-local.yml`
+
+```
+features:
+  artifacts:
+    enabled: true
+```
+
+And we'll need to configure the Github artifact account in `/opt/spinnaker/config/clouddriver-local.yml`
+
+```yaml
+artifacts:
+  github:
+    enabled: true
+    accounts:
+    - name: github
+      username: BOT_USERNAME
+      token: YOURTOKEN
+```      
+
+Then restart Armory Spinnaker: `service armory-spinnaker restart`
+
+## Creating a Kubernetes V2 Pipeline
+
+### Configuring The Pipeline Trigger
+We'll begin by creating a pipeline that is triggered from Kubernetes artifacts and delivered through Github.  Below we'll define two artifacts that will be deployed as Kubernetes manifests: `deployment.yml` and `config-map.yml` which are valid Kubernetes manifests.  Make sure to select the source as `Github`.
+
+![artifacts](/images/page.png)
+
+After configuring the artifacts we'll need to associate them with a Github trigger so the pipeline is triggered whenever there are modifications pushed to Github.  For example, the pipeline below will only trigger when _either_ `deployment.yml` _or_ `config-map.yml` are modified and pushed to the repository.  If the manifest isn't modified it'll use the latest version that was deployed.
+
+> Note: If you haven't already, you'll need to configure [Github webhooks](https://www.spinnaker.io/setup/features/notifications/#github) for your Spinnaker instance.
+
+![github trigger](/images/trigger.png)
+
+
+### Configuring The Config Map Manifest Delivery
+
+We'll configure the `configMap` to be deployed first. Add a `Deploy (Manifest)` stage to your pipelines.
+
+![deploy manifest](/images/deploy_manifest.png)
+
+
+Once you've added the stage, select `Artifact` from the `Manifest Source` below and it will allow you to choose one of the expected artifacts that we configured in the previous section.  Choose `config-map.yml` and hit `save`. Spinnaker will deploy the chosen artifact but append a version to the name of the artifact. For [our example config map](https://github.com/Armory/spinnaker-k8s-v2-example/blob/master/config-map.yml). So for the name `k8-v2-config-map` it will appear in the Kubernetes cluster with `k8-v2-config-map-v001`.
+
+![config map](/images/config-map.png)
+
+### Configuring Deployment Manifest Delivery
+
+Next we'll configure a new `Deploy (Manifest)` stage to deploy the [deployment.yml](https://github.com/Armory/spinnaker-k8s-v2-example/blob/master/deployment.yml) manifest.  This manifest references our config-map as a volume and it's source will be replaced by the versioned artifact deployed in the previous step: `k8-v2-config-map-v001`.  So if our `deployment.yml` contains the following:
+
+```yaml
+volumes:
+  - name: k8-config
+    configMap:
+      name: k8-v2-config-map
+```
+
+the name will be replaced with the properly versioned artifact:
+```
+volumes:
+  - name: k8-config
+    configMap:
+      name: k8-v2-config-map-v000
+```
+
+![deployment](/images/Image 2018-01-26 at 5.36.53 PM.png)
+
+### Executing The Pipeline
+
+Your final pipeline should look similar to the one below.
+![final pipeline](/images/pipeline.png)
+
+In order to execute your pipeline the first time you'll need to edit both the `config-map.yml` and `deployment.yml`, commit the changes to git and push the changes to Github. The pipeline should trigger and execute flawlessly =)
+
+but if it doesn't, don't hesitate to reach out: http://go.armory.io/chat

--- a/content/en/docs/_user_guides/pipelines.md
+++ b/content/en/docs/_user_guides/pipelines.md
@@ -1,0 +1,85 @@
+---
+layout: post
+order: 50
+# Migrated to spinnaker-user-guides/pipelines
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+Pipelines are a combination of stages that enable some very sophisticated coordination and branching. They are the key to orchestrating deploys in Spinnaker and each one is specific to an application. To see an application's pipelines, select 'Applications' from Spinnaker's top navigation bar, click on an application's name, and then press the 'Pipelines' tab. The result from a pipeline running is called an execution.	
+
+Take this screenshot for example:
+
+![](/images/Image 2017-04-03 at 4.35.40 PM.png)
+
+There is a pipeline called 'Deploy' with two executions, both labeled 'Manual Start'. The top execution is marked as 'Succeeded' while the bottom is marked as 'Cancelled'. 
+
+For more information on creating bake and deploy pipelines, checkout the [baking]({% link _spinnaker_user_guides/baking-images.md %}) and [deploying]({% link _spinnaker_user_guides/deploying.md %}) guides.
+
+
+## Manual Execution
+
+You can re-run an execution by pressing the 'Start Manual Execution'. 
+
+![](/images/Image 2017-04-03 at 4.51.41 PM.png)
+
+If your pipeline has a Jenkins' trigger, you can select which Jenkins' build number to use for running the pipeline. 
+
+![](/images/Image 2017-04-03 at 4.53.50 PM.png)
+
+The artifacts produced by the build you select will be used in the pipeline. If your pipeline bakes an image, a cached image will be used if available. To force a rebuild, make sure you specify such before pressing the 'Run' button.
+
+
+## Enabling notifications
+
+Spinnaker supports several methods of notification. Notifications can be made when a pipeline runs, succeeds, or fails. You can be contacted via SMS, email, slack, hipchat, and/or pagerduty. Each of these outlets need to be configured within Spinnaker by your Spinnaker Administrator. Once it is configured, you can enable it in your pipeline.
+
+To enable it, navigate to the configuration screen for your pipeline. Make sure you have the 'Configuration' stage selected. Scroll down to the 'Notifications' section.
+
+![](/images/Image 2017-04-03 at 4.31.37 PM.png)
+
+ Press 'Add Notifications Preference'. For example's sake, I have selected to receive a notification via Slack in the `#engineering` channel whenever my pipeline fails.
+
+ Finally press 'Update' to finish. Don't forget to press 'Save Changes' on your pipeline configuration.
+
+
+## Pipeline JSON
+
+Pipelines are represented as JSON behind the scenes. The JSON is interpreted and displayed to you in the UI. However, sometimes it is helpful to view or edit the JSON directly. To access the JSON:
+
+1. Click 'Configure' on your pipeline:
+
+![](/images/Image 2017-05-04 at 4.23.33 PM.png)
+
+2. Press the 'Pipeline Actions' button in the upper right to display a dropdown menu.
+
+![](/images/Image 2017-05-04 at 4.30.11 PM.png)
+
+There are two JSON related options on this dropdown menu:
+
+a. If you select 'Edit as JSON' then you should see something like:
+
+![](/images/Image 2017-05-04 at 4.32.03 PM.png)
+
+From this screen you can edit the JSON directly. **Remember to always save your changes**, so they will be used in the next execution of your pipeline.
+
+b. If you select 'Show Revision History' then you should see something like:
+
+![](/images/Image 2017-05-04 at 4.35.39 PM.png)
+
+You can select different revisions using the dropdown menu labeled 'Revision' in the top left. You can compare it to different versions using the 'compare to' dropdown menu in the upper right. 
+
+
+## Troubleshooting
+
+### Hanging or Timed Out Pipelines
+
+A lot of the time pipelines hang because of a misconfigured stage. This is a common occurrence when a server group does not complete its deploy because the deployed instances never pass the healthcheck. This happens both when the healthcheck is misconfigured and/or when the image doesn't bake as expected. These two areas should be investigated first. For more information you can see the troubleshooting topic in the [deployment guide]({% link _spinnaker_user_guides/deploying.md %}).
+

--- a/content/en/docs/_user_guides/sla.md
+++ b/content/en/docs/_user_guides/sla.md
@@ -1,0 +1,106 @@
+---
+layout: post
+title: SLA
+order: 76
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+# What is the SLA?
+
+The Armory Platform exposes an SLA (Service Level Agreement) for the team
+to use to monitor their application's performance over time.  Each application
+can be configured to monitor different metrics, and flag when an application
+is not within the bounds of those metrics.
+
+## How it works:
+
+The Armory Platform will query your configured metrics datasource every 15
+minutes, and compare the performance of your application against the SLA.
+This generates a pass/fail evaluation of the application for that period 
+of time.  The SLA is then computed as the percent of time over the past two
+weeks your application has "passed" the SLA metrics.
+
+As soon as the system has exceeded your SLA definition, you will receive
+a notification in Slack, even if your SLA percentage is fairly healthy.
+
+## Default Behavior:
+
+When you create a new application (or existing applications, if you're
+upgrading) the SLA definition will be defaulted depending on the cloud
+provider.  Note that once you create your own metric to measure against,
+the default behavior will be disabled, in favor of your configured values.
+
+### AWS Defaults:
+
+If you haven't configured any metrics, by default an AWS-enabled application
+will check all loadbalancers configured to see if they are responding in less
+then 250ms, have at least 1 healthy host, and are not generating any 5XX
+errors at either the app or ELB level.  Once you configure a specific metric,
+these defaults will no longer be checked, instead only your configured metric
+will be used.  If you want to keep these metrics, see below for how they would
+be defined in the UI).
+
+### Other Providers:
+
+If your app is not hosted on AWS, the SLA will always read "77.7%" until
+something is configured.
+
+## Configuring SLA
+
+The SLA is configured from the Application Config screen, which you can
+get to by clicking on "CONFIG" in the upper-right corner of your screen,
+or by click on the SLA menu item.
+
+![Application Config](/images/[87aa1b00f4a1191efe3e2035d10daa4b]_Image 2018-02-13 at 11.34.05 AM.png)
+
+Then click "Edit Application Attributes":
+
+![Edit Application Attributes](/images/[88d39b8093055dbbcfbdae6b42669873]_Image 2018-02-13 at 11.36.29 AM.png)
+
+From here, you can choose to add CloudWatch (AWS) or DataDog metrics (or both!)
+
+![Add SLA Metric](/images/[a6a463f037bb70b519ffbd0042846866]_Image 2018-02-13 at 11.47.50 AM.png)
+
+### Cloudwatch Metrics
+
+When configuring a Cloudwatch Metric, all fields are required.  The Metric
+Name correlates to the AWS/ELB metric name, such as "Latency",
+"HTTPCode_ELB_5XX_Count".  For a complete reference, refer to the
+[AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/elb-metricscollected.html)
+
+![Example Cloudwatch Metric](/images/Image 2018-02-13 at 12.45.18 PM.png)
+
+#### A Note About Units
+
+In most cases, the units the Cloudwatch API returns isn't important because
+the numeric value is just compared against the Limit you've configured.  One
+special case is with Latency -- it's important to know that the Armory Platform
+expects to have milliseconds (ms) configured as the Limit, rather than
+fractional seconds.
+
+#### Default AWS Metrics Definitions
+
+As noted earlier, until you've defined a specific metric, AWS applications
+will default to a set of four metrics.  These metrics are actually repeated
+for each LB/region combination.  The other fields are defined as:
+
+| Metric Name          | Comparator | Limit |
+| -------------------- |:----------:|:-----:|
+| Latency              | <=         | 250   |
+| HealthyHostCount     | >=         | 1     |
+| HTTPCode_Backend_5XX | <=         | 0     |
+| HTTPCode_ELB_5XX     | <=         | 0     |
+
+### DataDog Metrics
+
+When configuring a Datadog Metric, the Tags field is optional, though
+recommended to help distinguish your data from other applications that you
+may have sending data into DataDog.  The fields correlate directly with
+what would go into a DataDog query; the example below is turned into the
+metrics query `avg:system.cpu.user{host:foo}`
+
+![Example DataDog Metric](/images/Image 2018-02-13 at 12.44.27 PM.png)
+
+

--- a/content/en/docs/_user_guides/troubleshooting.md
+++ b/content/en/docs/_user_guides/troubleshooting.md
@@ -1,0 +1,26 @@
+---
+layout: post
+order: 110
+---
+
+{% include components/legacy_documentation.html %}
+
+
+For help with the following topics, please checkout the troubleshooting sections embedded in the corresponding guide:
+
+- [Baking]({% link _spinnaker_user_guides/baking-images.md %}#troubleshooting)
+- [Deploying]({% link _spinnaker_user_guides/deploying.md %}#common-errors-and-troubleshooting)
+- [Expression language]({% link _spinnaker_user_guides/expression-language.md %}#troubleshooting)
+
+
+## FAQ 
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+#### Why are tasks hanging on the 'Force Cache Refresh' stage?
+
+This usually happens when the caching agent does not have appropriate permissions to the resources it is trying to cache. Different versions of Spinnaker need different levels of permission. If you are on AWS and have recently upgraded, try comparing your current IAM policy to the policies listed [here](https://github.com/Armory/spinnaker-aws-policy/tree/master/policies).
+
+Additionally, you may experience this problem when you are getting throttled by your cloud provider.

--- a/content/en/docs/_user_guides/video-tutorials.md
+++ b/content/en/docs/_user_guides/video-tutorials.md
@@ -1,0 +1,53 @@
+---
+layout: post
+title: Video Tutorials
+order: 9
+# migrated to spinnaker-user-gudies/video-tutorials
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+Spinnaker is the continuous delivery platform that codifies the software delivery best practices that put Netflix and Google a decade ahead of most other companies.
+
+## Overview tab
+<br/>
+What is Spinnaker
+
+{% include components/youtubePlayer.html id="H_rFShgmJHY" %}<br/>
+
+
+Concepts / Naming Conventions<br/>
+
+{% include components/youtubePlayer.html id="b8N23gcdRHc" %}
+
+
+## How To Create a Pipeline
+<br/>
+
+{% include components/youtubePlayer.html id="NBeUAjlcVJw" %}
+
+
+## How to Build a Pipeline
+<br/>
+
+{% include components/youtubePlayer.html id="L8bJUFhcqGs" %}
+
+
+## Various Pipline Stages
+
+ - Bake Stage
+ - Deploy Stage
+ - Manual Judgement Stage
+ - Check Preconditions
+ - Adding a Parallel Stage
+ 
+{% include components/youtubePlayer.html id="dM1trF4rsqU" %}
+
+

--- a/content/en/docs/_user_guides/webhooks.md
+++ b/content/en/docs/_user_guides/webhooks.md
@@ -1,0 +1,54 @@
+---
+layout: post
+order: 105
+# migrated to spinnaker-user-guides/webhooks
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+# How does Spinnaker use webhooks?
+{:.no_toc}
+Spinnaker has a stage type called "Webhook" which allows it to call out to APIs as part of running a pipeline:
+
+![Webhook Type Selection](/assets/images/webhook-type-selection.png)
+
+
+## Setting up the a webhook stage
+The basic configuration is what you might expect. Fill in the URL to make the request against, the HTTP method to use, and depending on the request type the payload and/or additional headers:
+
+![Webhook Basic Config](/assets/images/webhook-basic.png)
+
+Of particular note is that you can use [the Spinnaker pipeline expression language](/user-guides/expression-language/) both as part of the URL field and within the payload, making it easy to pass anything that's available as part of the pipeline context.
+
+In this simple configuration the stage will be marked as successful if it gets a 2XX status code back, and will fail on anything else. If the return value from the request itself isn't enough to determine the overall success you can check the "Wait for completion" checkbox and get a set of additional configuration:
+
+
+## Wait for completion using status field
+![Webhook Wait For Completion](/assets/images/webhook-completion.png)
+
+There are three different techniques Spinnaker can use to lookup the overall status:
+
+- "GET method against webhook URL" means that once a request is sent using the method specified in the stage, Spinnaker will swap to polling the same webhook URL but using the GET method instead
+- "From the Location header" means that Spinnaker will look for the URL to poll in the headers of the original request, and use that URL to poll for the final status
+- "From webhook's response" means Spinnaker will issue the original request, and will parse the response from that call to find a new URL it'll use to poll for the final status
+
+Spinnaker will use one of those mechanisms to find the status URL, and then repeatedly issue requests against that URL until it finds values that tell it what the final stage status should be. The "Status JsonPath" and mapping fields tell Spinnaker how to interpret the payloads that come back from the status URL. The "Status JsonPath" field is a [JsonPath](https://github.com/json-path/JsonPath) expression that Spinnaker uses to pull a single value from the payload for the status response. It compares the value from the payload to the values given in the SUCCESS, CANCELLED, and TERMINAL status mapping fields. Once there's a match the overall state of the stage is set.
+
+
+## Webhook execution
+Spinnaker records the URL used as part of the webhook, the payload, and the status URL as part of the stage details. If the webhook transaction can run for a long time and there's information available from the API, you can set the "Progress location" expression to also extract info to give some feedback about status in the Spinnaker UI. The "Progress location" value shows up in the Info field of the stage details:
+
+![Webhook Stage Details](/assets/images/webhook-stage-details.png)
+
+Once the webhook stage is complete the payload is attached to the stage context as "buildInfo". So if you need you can pull info out of the webhook response to pass into future stages using a pipeline expression. For instance, if the response from our stage above contains the value "threshold" that we want to use in another stage we can reference it like this:
+
+{% highlight shell %}
+${ #stage('Webhook')['context']['buildInfo']['threshold'] }
+{% endhighlight %}

--- a/content/en/docs/_user_guides/working-with-jenkins.md
+++ b/content/en/docs/_user_guides/working-with-jenkins.md
@@ -1,0 +1,104 @@
+---
+layout: post
+order: 20
+# migrated to spinnaker-user-gudies/working-with-jenkins
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+## Triggering a pipeline with Jenkins
+
+
+To add a Jenkins trigger to your pipeline, go to your configurations stage and select "add trigger", then select "Jenkins" from the Type dropdown menu. Select a Master from the Master category list and then select a Job to trigger from the pipeline.
+
+
+![](/images/Image 2017-03-27 at 4.47.35 PM.png)
+
+
+
+Note: Make sure you archive your package files and your properties file in Jenkins.
+
+
+
+### Property File
+
+
+The property file is a way to transfer information about your build from Jenkins to Spinnaker. The file needs to be archived by the Jenkins job and should contain key value pairs.
+
+
+As an example, if you had your Jenkins job create and archive a file named `build.properties` which looks like:
+
+{% highlight shell %}
+COMMITER_NAME=andrew
+BRANCH_NAME=mybranch
+CONFIG=config-3059cad.tar.gz
+{% endhighlight %}
+
+Then in the property files field in the Spinnaker Jenkins trigger, fill it in with `build.properties`.
+
+
+Now that those variables are in Spinnaker, we can access them elsewhere in our pipeline by using the built-in Spinnaker expression language.
+
+
+In any given stage we can use the expression `${ trigger.properties['BRANCH_NAME']}` to access the property value of the variable named `BRANCH_NAME`.
+
+
+Note: For more elaborate instructions on expression language, please refer to the [Spinnaker Expression Language Guide](http://docs.armory.io/user-guides/expression-language/).
+
+
+
+## How to Trigger a Jenkins Job through Spinnaker
+
+
+Step 1: In pipelines, click on 'Add stage'.
+
+
+Step 2: Select 'Jenkins' from Type. Name the Stage Name and Depends On if you need it.
+
+
+Step 3: Configure your Master and Job. If your Job is parameterized then Spinnaker will display a Parameters form for your input.
+
+
+Step 4: The Property File input works the same way as above - however you **cannot** use the same expression above to access it. Instead, you would access it with `${ #stage('Jenkins')['context']['BRANCH_NAME'] }`, supposing you wanted to access the `BRANCH_NAME` variable.
+
+
+### Example
+
+
+In this example, we will create a pipeline with a Jenkin's job stage and a manual judgement that repeats back the value of a property in a properties file from the Jenkins' job.
+
+First we navigate to my Jenkins Master and create a new Jenkins 2.0 Pipeline Job. As you can see in the image below, this job creates and archives a file named `build.properties` which contains the key value pair `KEY=VAL`.
+
+![](/images/Image 2017-03-27 at 5.20.02 PM.png)
+
+Then we go back to Spinnaker and create a new pipeline. We will skip over the Jenkins trigger for this example and create a Jenkins stage. Make sure to name the stage `Jenkins`. Make sure to type `build.properties` into the Properties field so that Spinnaker know where to source the property values.
+
+![](/images/Image 2017-03-27 at 5.21.05 PM.png)
+
+To demonstrate accessing our properties file, let's create a new `Manual Judgement` stage. In the Instructions text box input:
+{% highlight shell %}
+${ #stage('Jenkins')['context']['KEY'] }
+{% endhighlight %}
+Spinnaker has added the key value pairs from `build.properties` in the Jenkins' job to the context of the Jenkins stage. The above expression allows us to access that information.
+
+Don't forget to press the save button in the lower right corner. Your pipeline configuration should look like:
+
+![](/images/Image 2017-03-28 at 2.04.43 PM.png)
+
+Finally, navigate back to the pipeline execution screen an start a manual execution of the pipeline you just configured.
+
+When the execution gets to the manual judgement stage, you should see the word `VAL` in the intructions text area.
+
+![](/images/Image 2017-03-28 at 2.06.45 PM.png)
+
+## Runnings scripts on Spinnaker
+
+You can also run arbitrary scripts on Spinnaker (behind the scenes it is pushing this work off to a Jenkins master). Simply select the `Script` type stage while configuring a pipeline. You should see a screen like:
+
+![](/images/Image 2017-03-28 at 2.10.26 PM.png)

--- a/content/en/docs/_user_guides/writing-scripts.md
+++ b/content/en/docs/_user_guides/writing-scripts.md
@@ -1,0 +1,35 @@
+---
+layout: post
+order: 100
+# migrated to spinnaker-user-guides/writing-scripts
+published: false
+---
+
+{% include components/legacy_documentation.html %}
+
+This guide should include:
+{:.no_toc}
+* This is a placeholder for an unordered list that will be replaced with ToC. To exclude a header, add {:.no_toc} after it.
+{:toc}
+
+
+
+## API docs
+People often ask how they can write scripts and use Spinnaker programatically. You most certainly can. Spinnaker is a collection of subservices that all expose a RESTful API. You can see a list (with descriptions) of all of the endpoints by navigating to:
+
+{% highlight shell %}
+http(s)://<your-spinnaker-dns-name>:8084/swagger-ui.html
+{% endhighlight %}
+
+Notice that this uses port `8084`.
+
+You should see a screen that looks like:
+
+![](/images/Image 2017-04-03 at 4.06.51 PM.png)
+
+You can click on the controller you are interested in to see endpoints related to it. You can even test out hitting these different endpoints right in the UI.
+
+
+## Auth
+
+Being able to access the API when auth is enabled requires a certain configuration by your Armory Spinnaker Administrator. They will need to enable programatic access via mutual tls (x509 certs). Then you will need to use a cert when communicating with the API.


### PR DESCRIPTION
add three legacy folders: _admin_guides, _user_guides, _install_guide

I added _index.md to each. Add "legacy" to titles so we can easily see which are legacy. We can refactor when we create the legacy branch.