### PR TITLE
docs(migration): Set this branch as archived version for testing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -89,7 +89,7 @@ version = "v1.0"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://docs-hugo.netlify.app"
+url_latest_version = "https://docs-hugo.netlify.app/docs"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/armory/docs-hugo"
@@ -169,16 +169,11 @@ enable = false
 #Add new release versions here. These entries appear in the drop-down menu
 # at the top of the website.
 [[params.versions]]
-  version = "v2.11.65"
-  githubbranch = "master"
-  url = "https://docs-hugo.netlify.app"
-
-[[params.versions]]
-  version = "archive-test"
+  version = "v1.0"
   githubbranch = "archive-test"
   url = "https://v0-2.kubeflow.org"
 
 [[params.versions]]
-  version = "v0.3"
+  version = "v0.3 (kubeflow)"
   githubbranch = "v0.3-branch"
   url = "https://v0-3.kubeflow.org"

--- a/config.toml
+++ b/config.toml
@@ -75,47 +75,29 @@ privacy_policy = "https://www.armory.io/privacy-policy"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
-version_menu = "v2.11.65"
+version_menu = "v1.0"
 
 # Flag used in the "version-banner" partial to decide whether to display a
 # banner on every page indicating that this is an archived version of the docs.
 # Set this flag to "true" if you want to display the banner.
-archived_version = false
+archived_version = true
 
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the
 # current doc set.
-version = "2.11.65"
+version = "v1.0"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://docs.armory.io"
+url_latest_version = "https://docs-hugo.netlify.app"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/armory/docs"
+github_repo = "https://github.com/armory/docs-hugo"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 #github_project_repo = "https://github.com/armory"
 
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""
-
-#Add new release versions here. These entries appear in the drop-down menu
-# at the top of the website.
-# [[params.versions]]
-#  version = "v2.11.65"
-#  githubbranch = "master"
-#  url = "https://docs.armory.io"
-
-# [[params.versions]]
-#  version = "v0.2"
-#  githubbranch = "v0.2-branch"
-#  url = "https://v0-2.kubeflow.org"
-
-# [[params.versions]]
-#  version = "v0.3"
-#  githubbranch = "v0.3-branch"
-#  url = "https://v0-3.kubeflow.org"
-
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "011737558837375720776:fsdu1nryfng"
@@ -183,3 +165,20 @@ enable = false
 	url = "https://join.spinnaker.io/"
 	icon = "fab fa-slack"
    desc = "Chat with Armory users and developers in the Spinnaker Slack"
+
+#Add new release versions here. These entries appear in the drop-down menu
+# at the top of the website.
+[[params.versions]]
+  version = "v2.11.65"
+  githubbranch = "master"
+  url = "https://docs-hugo.netlify.app"
+
+[[params.versions]]
+  version = "archive-test"
+  githubbranch = "archive-test"
+  url = "https://v0-2.kubeflow.org"
+
+[[params.versions]]
+  version = "v0.3"
+  githubbranch = "v0.3-branch"
+  url = "https://v0-3.kubeflow.org"


### PR DESCRIPTION
Updated config.toml to make archive-test branch archived. We should see the archived banner across old pages. Also there should NOT be the v2.x version in the drop-down. Instead the banner should have a link to the site.

**LEAVE THIS HERE BECAUSE I'M USING THE PREVIEW URL IN THE MASTER AS V1.0**