### PR TITLE
docs(migration): config.toml - left menu collapsed by default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -111,7 +111,7 @@ offlineSearch = true
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)


### PR DESCRIPTION
this collapses the left menu by default. Only the section the user is inside of is expanded.

leaving as draft so readers can view both collapsed and expanded versions