### PR TITLE
docs(migration): landing page - remove docs from feature section

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -20,39 +20,40 @@ Armory provides an enterprise distribution of Spinnaker, the cloud native, open 
 {{% /blocks/lead %}}
 
 {{< blocks/section color="300" >}}
-{{% blocks/feature icon="fa-lightbulb" title="Armory Docs"
-url="https://docs.armory.io" %}}
-Read the Armory documentation
-{{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-github" title="Armory Blog"
+{{% blocks/feature icon="fas fa-blog" title="Armory Blog"
 url="https://armory.io/blog" %}}
 Read the latest about Armory features and events
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-twitter" title="Armory Knowledge Base" url="https://kb.armory.io" %}}
+{{% blocks/feature icon="fas fa-book" title="Armory Knowledge Base" url="https://kb.armory.io" %}}
 Search the KB
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fas fa-video" title="Armory Videos"
+url="https://www.youtube.com/channel/UC9ESNuSCMXLsdRdBDhjSzcA" %}}
+Watch vidoes about Armory features
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
 
 
 {{< blocks/section  color="primary" >}}
-{{% blocks/feature icon="fa-lightbulb" title="Armory Videos"
-url="https://www.youtube.com/channel/UC9ESNuSCMXLsdRdBDhjSzcA" %}}
-Watch vidoes about Armory features
-{{% /blocks/feature %}}
 
-
-{{% blocks/feature icon="fab fa-github" title="Spinnaker in Production"
+{{% blocks/feature icon="fas fa-shield-alt" title="Spinnaker in Production"
 url="https://resources.armory.io/" %}}
 Learn how the world uses Spinnaker to accelerate software delivery
 {{% /blocks/feature %}}
 
 
-{{% blocks/feature icon="fab fa-twitter" title="Spinnaker Webinars"
+{{% blocks/feature icon="fab fa-youtube" title="Spinnaker Webinars"
 url="https://resources.armory.io/webinars" %}}
-Watch webinars about Armory and Spinnaker!
+Watch webinars about Armory and Spinnaker
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fas fa-laptop" title="Spinnaker Community"
+url="https://www.spinnaker.io/community/" %}}
+Learnd about the Open Source Spinnaker Community
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}


### PR DESCRIPTION
Changes to _index.html landing page

Removed docs from features section since the page already has 2 links to the docs content.
Added  Spinnaker Community to second feature line to maintain balance. Looks silly with 3 features on first line and 2 features on second.
Updated icons.  https://fontawesome.com/icons?d=gallery