### PR TITLE
docs(migration): fix headings

### DIFF
--- a/content/en/docs/install-guide/jenkins.md
+++ b/content/en/docs/install-guide/jenkins.md
@@ -9,7 +9,7 @@ weight: 50
 Refer to the Spinnaker documentation for configuring Jenkins at
 [https://www.spinnaker.io/setup/ci/jenkins/](https://www.spinnaker.io/setup/ci/jenkins/)
 
-# Continuous Integration (CI)
+## Continuous Integration (CI)
 Spinnaker's goal is to leverage existing CI solutions to build and produce an artifact that can be deployed.
 
 ## Enabling Spinnaker to Communicate with Jenkins

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-15-2.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-15-2.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.15.2
 ---
 
-# 08/27/19 Release Notes
+## 08/27/19 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-15-3.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-15-3.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.15.3
 ---
 
-# 08/30/19 Release Notes
+## 08/30/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-0.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.16.0
 ---
 
-# 09/18/19 Release Notes
+## 09/18/19 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-1.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-1.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.16.1
 ---
 
-# 10/17/19 Release Notes
+## 10/17/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-2.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-2.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.16.2
 ---
 
-# 10/28/19 Release Notes
+## 10/28/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-3.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-16-3.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.16.3
 ---
 
-# 11/08/19 Release Notes
+## 11/08/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-0.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.17.0
 ---
 
-# 11/14/19 Release Notes
+## 11/14/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-1.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-1.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.17.1
 ---
 
-# 11/22/19 Release Notes
+## 11/22/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-2.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-2.md
@@ -6,7 +6,7 @@ aliases:
   - armoryspinnaker_v2.17.2
 ---
 
-# 12/16/19 Release Notes
+## 12/16/19 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-3.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-3.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.17.3
 ---
 
-# 01/14/20 Release Notes
+## 01/14/20 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-4.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-4.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.17.4
 ---
 
-# 01/18/20 Release Notes
+## 01/18/20 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-5.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-5.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.17.5
 ---
 
-# 02/01/20 Release Notes
+## 02/01/20 Release Notes
 
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-7.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-17-7.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.17.7
 ---
 
-# 03/30/20 Release Notes
+## 03/30/20 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-0.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.18.0
 ---
 
-# 02/14/20 Release Notes
+## 02/14/20 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-1.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-1.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.18.1
 ---
 
-# 04/03/20 Release Notes
+## 04/03/20 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-4.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-4.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.19.4
 ---
 
-# 04/15/20 Release Notes
+## 04/15/20 Release Notes
 
 > Note: Do not upgrade to Armory Spinnaker 2.19.4 (this version). Instead, upgrade to Armory Spinnaker [2.19.7]({{< ref "armoryspinnaker_v2-19-7" >}}) or later.
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-5.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-5.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.19.5
 ---
 
-# 04/17/20 Release Notes
+## 04/17/20 Release Notes
 
 > Note: Do not upgrade to Armory Spinnaker 2.19.4 (this version). Instead, upgrade to Armory Spinnaker [2.19.7]({{< ref "armoryspinnaker_v2-19-7" >}}) or later.
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-6.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-6.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.19.6
 ---
 
-# 04/20/20 Release Notes
+## 04/20/20 Release Notes
 
 > Note: Do not upgrade to Armory Spinnaker 2.19.4 (this version). Instead, upgrade to Armory Spinnaker [2.19.7]({{< ref "armoryspinnaker_v2-19-7" >}}) or later.
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-7.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-7.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.19.7
 ---
 
-# 04/20/20 Release Notes
+## 04/20/20 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-8.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-8.md
@@ -5,7 +5,7 @@ aliases:
   - armoryspinnaker_v2.19.8
 ---
 
-# 04/21/20 Release Notes
+## 04/21/20 Release Notes
 
 > Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a [previous working version]({{< ref "upgrade-spinnaker#rolling-back-an-upgrade" >}}) and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
 

--- a/content/en/docs/spinnaker-install-admin-guides/sumologic-dashboard.md
+++ b/content/en/docs/spinnaker-install-admin-guides/sumologic-dashboard.md
@@ -118,6 +118,6 @@ Use this dashboard to:
 
 ![SpinnakerPipelinesDashboard](/images/sumologic-dashboard-useractivity.png)
 
-# Limitations
+## Limitations
 
 * Log messages greater than 64kb get truncated by the Sumo Logic collector.  This means that there are potential events that will get dropped and not displayed in the dashboards.  Long pipelines composed of many stages or triggered by other pipelines can make messages longer.

--- a/content/en/docs/spinnaker-user-guides/kustomize-manifests.md
+++ b/content/en/docs/spinnaker-user-guides/kustomize-manifests.md
@@ -19,36 +19,36 @@ In the context of Spinnaker, Kustomize lets you generate a custom manifest, whic
 Spinnaker uses the latest non-kubectl version of Kustomize.
 ​
 
-# Kustomize in 2.16 (Beta)
+## Kustomize in 2.16 (Beta)
 ​
 ## Enabling Kustomize in 2.16 (Beta)
 ​
 Kustomize can be enabled by a feature flag in 2.16.
 
-* **Operator**
+**Operator**
 
-    Add the following settings to the `SpinnakerService` manifest:
+Add the following settings to the `SpinnakerService` manifest:
 
-    ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
-    kind: SpinnakerService
-    metadata:
-      name: spinnaker
-    spec:
-      spinnakerConfig:    
-        profiles:
-          deck:
-            settings-local.js: |
-              window.spinnakerSettings.feature.kustomizeEnabled = true;
-    ```
+```yaml
+apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:    
+    profiles:
+      deck:
+        settings-local.js: |
+          window.spinnakerSettings.feature.kustomizeEnabled = true;
+```
 ​
-* **Halyard**
+**Halyard**
 
-    Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
-​
-    ```javascript
-    window.spinnakerSettings.feature.kustomizeEnabled = true;
-    ```
+Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
+
+```javascript
+window.spinnakerSettings.feature.kustomizeEnabled = true;
+```
 ​
 ## Using Kustomize
 ​
@@ -70,7 +70,7 @@ Define the artifact:
 ​
 You can now run your pipeline and get a Kustomize rendered manifest!
 ​
-# Kustomize in 2.17 (Beta)
+## Kustomize in 2.17 (Beta)
 ​
 ### Requirements
 Kustomize in 2.17+ requires the [git/repo](https://www.spinnaker.io/reference/artifacts/types/git-repo/) artifact type.
@@ -79,32 +79,32 @@ Kustomize in 2.17+ requires the [git/repo](https://www.spinnaker.io/reference/ar
 ​
 Kustomize can be enabled by a feature flag in Armory Spinnaker 2.16 and later.
 
-* **Operator**
+**Operator**
 
-    Add the following settings to the `SpinnakerService` manifest and apply the changes:
+Add the following settings to the `SpinnakerService` manifest and apply the changes:
 
-    ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
-    kind: SpinnakerService
-    metadata:
-      name: spinnaker
-    spec:
-      spinnakerConfig:    
-        profiles:
-          deck:
-            settings-local.js: |
-              window.spinnakerSettings.feature.kustomizeEnabled = true;
-    ```
+```yaml
+apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:    
+    profiles:
+      deck:
+        settings-local.js: |
+          window.spinnakerSettings.feature.kustomizeEnabled = true;
+```
 
-* **Halyard**
+**Halyard**
 
-    Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
-​
-    ```javascript
-    window.spinnakerSettings.feature.kustomizeEnabled = true;
-    ```
+Add the following line to `~/.hal/{DEPLOYMENT_NAME}/profiles/settings-local.js`:
 
-    Apply your changes to your Spinnaker deployment:  `hal deploy apply`. Wait until the pods are in a RUNNING state before proceeding.
+```javascript
+window.spinnakerSettings.feature.kustomizeEnabled = true;
+```
+
+Apply your changes to your Spinnaker deployment:  `hal deploy apply`. Wait until the pods are in RUNNING state before proceeding.
 ​
 
 You can now use the *KUSTOMIZE* option on a _Bake (Manifest)_ stage.
@@ -117,7 +117,7 @@ You can now use the *KUSTOMIZE* option on a _Bake (Manifest)_ stage.
 ## Build the Pipeline
 ​
 For this example, we are going to use this [kustomize public repository](https://github.com/kubernetes-sigs/kustomize), specifically the *helloWorld* example.
-* * *
+
 ### Step 1 - Add an Expected Artifact
 ​
 Add a **git/repo** Expected Artifact in the _Configuration_ section:

--- a/content/en/docs/spinnaker/pacrd-crd-docs.md
+++ b/content/en/docs/spinnaker/pacrd-crd-docs.md
@@ -4,7 +4,7 @@ weight: 171
 ---
 {{< include "experimental-feature.html" >}}
 
-# pacrd.armory.spinnaker.io/v1alpha1
+## pacrd.armory.spinnaker.io/v1alpha1
 <p>
 <p>Package v1alpha1 contains API Schema definitions for the pacrd.armory.spinnaker.io Applications and Pipelines.</p>
 </p>

--- a/content/en/docs/spinnaker/pacrd.md
+++ b/content/en/docs/spinnaker/pacrd.md
@@ -108,11 +108,11 @@ now, I'm omitting this section of the docs. When we start to firm up the details
 of how this will be installed and run we can expand the Installation section
 and include details about customizing an install.
 
-# Installation
+## Installation
 
 !-->
 
-# Usage
+## Usage
 
 Once you have PaCRD installed and running in your cluster, you can define your applications and pipelines. Then apply them to the cluster.
 
@@ -457,7 +457,7 @@ Events:
   Warning  PipelineValidationFailed  0s (x4 over 3s)        pipelines  artifact with id "a-nonsense-value" and name "" could not be found for this pipeline
 ```
 
-# Known Limitations
+## Known Limitations
 
 ## v0.1.x - v0.7.x
 

--- a/content/en/docs/spinnaker/quickstart/Armory-Spinnaker-Quickstart-2.md
+++ b/content/en/docs/spinnaker/quickstart/Armory-Spinnaker-Quickstart-2.md
@@ -92,7 +92,7 @@ immutable_metadata  {"purpose":"example-purpose"}
 * Key: `immutable_metadata`
 * Value: `{"purpose":"us-west-2-dev-subnet"}`
 
-# Second: Connect Spinnaker to an Amazon EKS cluster
+## Second: Connect Spinnaker to an Amazon EKS cluster
 
 For the tasks in this section, complete them on your local workstation, *not from the Minnaker VM*.
 


### PR DESCRIPTION
Also deletes `content/en/docs/release-notes/armory-spinnaker/armoryspinnaker_v1.13.7.md`  which i missed in the initial cleanup.