### PR TITLE
docs(migration): change banner color to match armory.io

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -4,3 +4,5 @@ Add styles or override variables from the theme here.
 
 */
 
+$primary: #001321;
+$dark: #001321;

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -57,6 +57,3 @@ Learnd about the Open Source Spinnaker Community
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
-
-{{< blocks/section color="dark" >}}
-{{< /blocks/section >}}


### PR DESCRIPTION
add to assets/scss/_variables_project.scss
`$primary: #001321;
$dark: #001321;`

pulled that color from a screenshot of armory.io

remove blank block section from content/en/_index.thml