### PR TITLE
docs(migraiton): footer cleanup

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -141,7 +141,7 @@ enable = false
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
 	name = "Email Armory"
-	url = "info@armory.io"
+	url = "mailto:info@armory.io"
 	icon = "fa fa-envelope"
         desc = "Discussion and help from your fellow users"
 [[params.links.user]]

--- a/config.toml
+++ b/config.toml
@@ -149,11 +149,6 @@ enable = false
 	url = "https://twitter.com/cloudarmory"
 	icon = "fab fa-twitter"
         desc = "Follow us on Twitter to get the latest news!"
-[[params.links.user]]
-	name = "Stack Overflow"
-	url = "https://stackoverflow.com/search?q=spinnaker"
-	icon = "fab fa-stack-overflow"
-        desc = "Practical questions and curated answers"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"


### PR DESCRIPTION
- Removes stack overflow link since no one at Armory or OSS checks Stack Overflow
- Fixes the armory email link (assuming info@armory.io is real)