### PR TITLE
docs(migration): HACK to eliminate white space on bottom of landing page

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -1,10 +1,10 @@
-+++
-title = "Armory Docs"
-linkTitle = "ArmoryDocs"
+---
+title: "Armory Docs"
+abstract: "Enterprise distribution of Spinnaker"
+cid: home
+---
 
-+++
-
-{{< blocks/cover title="Armory Documentation" image_anchor="top" height="min" color="orange" >}}
+{{< blocks/cover title="Armory Documentation" image_anchor="top" height="min" id="cover-section">}}
 <div class="mx-auto">
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 	Read the Docs<i class="fas fa-arrow-alt-circle-right ml-2"></i>
@@ -15,11 +15,11 @@ linkTitle = "ArmoryDocs"
 {{< /blocks/cover >}}
 
 
-{{% blocks/lead color="primary" %}}
+{{% blocks/lead color="primary" id="armory-desc" %}}
 Armory provides an enterprise distribution of Spinnaker, the cloud native, open source, continuous delivery platform that creates a paved road for your developers to deploy with speed and resilience.
 {{% /blocks/lead %}}
 
-{{< blocks/section color="300" >}}
+{{< blocks/section color="#101415" id="section-armory-links">}}
 
 {{% blocks/feature icon="fas fa-blog" title="Armory Blog"
 url="https://armory.io/blog" %}}
@@ -38,7 +38,7 @@ Watch vidoes about Armory features
 {{< /blocks/section >}}
 
 
-{{< blocks/section  color="primary" >}}
+{{< blocks/section  color="primary" id="section-spinnaker-links" >}}
 
 {{% blocks/feature icon="fas fa-shield-alt" title="Spinnaker in Production"
 url="https://resources.armory.io/" %}}
@@ -57,3 +57,7 @@ Learnd about the Open Source Spinnaker Community
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
+
+{{< blocks/bottom-image image_anchor="bottom" height="min" >}}
+
+{{< /blocks/bottom-image >}}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -57,7 +57,3 @@ Learnd about the Open Source Spinnaker Community
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
-
-{{< blocks/section  color="primary" >}}
-
-{{< /blocks/section >}}

--- a/layouts/shortcodes/blocks/bottom-image.html
+++ b/layouts/shortcodes/blocks/bottom-image.html
@@ -1,13 +1,13 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 {{ $blockID := printf "td-cover-block-%d" .Ordinal }}
 {{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**bottom*" }}
-
-{{ $col_id := .Get "color" | default "primary" }}
+{{ $logo_image := (.Page.Resources.ByType "image").GetMatch "**logo*" }}
+{{ $col_id := .Get "color" | default "dark" }}
 {{ $image_anchor := .Get "image_anchor" | default "smart" }}
-
+{{ $logo_anchor := .Get "logo_anchor" | default "smart" }}
 {{/* Height can be one of: auto, min, med, max, full. */}}
 {{ $height := .Get "height" | default "max" }}
-
+{{ $byline := .Get "byline" | default "" }}
 {{ with $promo_image }}
 {{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) }}
 {{ $promo_image_small := (.Fill (printf "960x540 %s" $image_anchor)) }}
@@ -25,6 +25,22 @@
 </style>
 {{ end }}
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }} js-td-cover td-overlay td-overlay--dark -bg-{{ $col_id }}">
-
-
+  <div class="container td-overlay__inner">
+    <div class="row">
+      <div class="col-12">
+        <div class="text-center">
+          {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
+          {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
+          <div class="pt-3 lead">
+            {{ .Inner | markdownify}}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {{ if $byline }}
+  <div class="byline">
+    <small>{{ $byline }}</small>
+  </div>
+  {{ end }}
 </section>

--- a/layouts/shortcodes/blocks/bottom-image.html
+++ b/layouts/shortcodes/blocks/bottom-image.html
@@ -1,0 +1,30 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $blockID := printf "td-cover-block-%d" .Ordinal }}
+{{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**bottom*" }}
+
+{{ $col_id := .Get "color" | default "primary" }}
+{{ $image_anchor := .Get "image_anchor" | default "smart" }}
+
+{{/* Height can be one of: auto, min, med, max, full. */}}
+{{ $height := .Get "height" | default "max" }}
+
+{{ with $promo_image }}
+{{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) }}
+{{ $promo_image_small := (.Fill (printf "960x540 %s" $image_anchor)) }}
+<link rel="preload" as="image" href="{{ $promo_image_small.RelPermalink }}" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
+<style>
+#{{ $blockID }} {
+    background-image: url({{ $promo_image_small.RelPermalink }});
+}
+@media only screen and (min-width: 1200px) {
+    #{{ $blockID }} {
+        background-image: url({{ $promo_image_big.RelPermalink }});
+    }
+}
+</style>
+{{ end }}
+<section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }} js-td-cover td-overlay td-overlay--dark -bg-{{ $col_id }}">
+
+
+</section>


### PR DESCRIPTION
HACK to eliminate white space on bottom of landing page that appears at full browser height on large monitors

I created a bottom-image block that is almost exactly the same as the cover block. If you DO NOT have an image with "-bottom" in the name, the block renders as the primary color background and fills the space at the bottom before the footer.

https://s.armory.io/WnubbBpK