### PR TITLE
docs(migration): replace Jekyll params with Hugo params shortcode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,6 +88,9 @@ weight = 1
 # Everything below this are Site Params
 
 [params]
+halyard-armory-version = "1.9.3"
+operator-extended-crd-version = "v1alpha2"
+operator-oss-crd-version = "v1alpha2"
 copyright = "Armory Inc."
 privacy_policy = "https://www.armory.io/privacy-policy"
 terms_of_service = "https://www.armory.io/terms-of-service"

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/air-gapped.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/air-gapped.md
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
       - name: halyard
-        image: index.docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+        image: index.docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
         volumeMounts:
         - name: halconfig
           mountPath: /home/spinnaker/

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/configure-halyard.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/configure-halyard.md
@@ -55,7 +55,7 @@ docker run --name armory-halyard --rm \
     -e AWS_SECRET_ACCESS_KEY=<AWS secret key> \
     -v ~/.hal:/home/spinnaker/.hal \
     -v ~/.kube:/home/spinnaker/.kube \
-    -it docker.io/armory/halyard-armory:<Armory Halyard version>
+    -it docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
 
 Replace `<Armory Halyard version>` with the version of Halyard you want to run.

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/install-on-aws.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/install-on-aws.md
@@ -323,7 +323,7 @@ docker run --name armory-halyard -it --rm \
   -v ${WORKING_DIRECTORY}/.hal:/home/spinnaker/.hal \
   -v ${WORKING_DIRECTORY}/.secret:/home/spinnaker/.secret \
   -v ${WORKING_DIRECTORY}/resources:/home/spinnaker/resources \
-  armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+  armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
 
 ## Enter the Halyard container

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/install-on-gke.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/install-on-gke.md
@@ -236,7 +236,7 @@ docker run --name armory-halyard -it --rm \
   -v ${WORKING_DIRECTORY}/.hal:/home/spinnaker/.hal \
   -v ${WORKING_DIRECTORY}/.secret:/home/spinnaker/.secret \
   -v ${WORKING_DIRECTORY}/resources:/home/spinnaker/resources \
-  armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+  armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
 
 ## Enter the Halyard container

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/install-on-k8s.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/install-on-k8s.md
@@ -523,7 +523,7 @@ spec:
       containers:
       -
         name: halyard
-        image: armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+        image: armory/halyard-armory:{{< param halyard-armory-version >}}
         volumeMounts:
         -
           name: hal

--- a/content/en/docs/spinnaker-install-admin-guides/Secrets/secrets-vault.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Secrets/secrets-vault.md
@@ -24,7 +24,7 @@ After configuring authentication on the Vault side, use the following configurat
 Add the following snippet to the `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -63,7 +63,7 @@ Use the following configuration to enable Vault secrets using token auth:
 Add the following snippet to the `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/add-aws-account-iam.md
+++ b/content/en/docs/spinnaker-install-admin-guides/add-aws-account-iam.md
@@ -77,7 +77,7 @@ Here's an example situation:
     Here's a sample `SpinnakerService` manifest block that supports the above:
 
    ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
     kind: SpinnakerService
     metadata:
       name: spinnaker
@@ -378,7 +378,7 @@ The Clouddriver pod(s) should be now able to assume each of the Managed Roles (T
     For each of the Managed (Target) accounts you want to deploy to, add a new entry to the `accounts` array in `SpinnakerService` manifest as follows:
 
     ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
     kind: SpinnakerService
     metadata:
       name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/add-aws-account.md
+++ b/content/en/docs/spinnaker-install-admin-guides/add-aws-account.md
@@ -81,7 +81,7 @@ Here's an example situation:
 Here's a sample `SpinnakerService` manifest block that supports the above:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -382,7 +382,7 @@ The Clouddriver pod(s) should be now able to assume each of the Managed Roles (T
 For each of the Managed (Target) accounts you want to deploy to, add a new entry to the `accounts` array in `SpinnakerService` manifest as follows:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/add-kubernetes-account.md
+++ b/content/en/docs/spinnaker-install-admin-guides/add-kubernetes-account.md
@@ -160,7 +160,7 @@ export TARGET_NAMESPACES_COMMA_SEPARATED=dev-1,dev-2
 Add the following configuration to the `SpinnakerServce` manifest, replacing values as needed:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/api-endpoint.md
+++ b/content/en/docs/spinnaker-install-admin-guides/api-endpoint.md
@@ -390,7 +390,7 @@ Next, we will configure Spinnaker's Deck service to use the Deck certificate and
 Add the following snippet to the `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -533,7 +533,7 @@ If you are instead using a Layer 4 (TCP) load balancer (such as a `Service` conf
 In the `SpinnakerService` manifest you need to change the `overrideBaseUrl` settings of Deck and Gate in the following way:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -614,7 +614,7 @@ Once you've verified that your existing Gate and Deck endpoints continue to work
    **Operator**
 
    ```yaml
-   apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+   apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
    kind: SpinnakerService
    metadata:
      name: spinnaker
@@ -638,7 +638,7 @@ Once you've verified that your existing Gate and Deck endpoints continue to work
    **Operator**
 
    ```yaml
-   apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+   apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
    kind: SpinnakerService
    metadata:
      name: spinnaker
@@ -868,7 +868,7 @@ You can configure Gate to look for a list of endline-delimited groups in the `1.
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -1024,7 +1024,7 @@ When looking at audit logs, it can be helpful to differentiate different API cli
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/aws-dr.md
+++ b/content/en/docs/spinnaker-install-admin-guides/aws-dr.md
@@ -87,7 +87,7 @@ To keep the configurations in sync, set up automation to create a passive Spinna
 Make sure you set replicas for all Spinnaker services to 0. Example in `SpinnakerService` manifest for service `gate`:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/dns-and-ssl.md
+++ b/content/en/docs/spinnaker-install-admin-guides/dns-and-ssl.md
@@ -59,7 +59,7 @@ Update the endpoints for Spinnaker Deck (the Spinnaker UI microservice) and Spin
 * **Operator**
 
     ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
     kind: SpinnakerService
     metadata:
       name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/docker.md
+++ b/content/en/docs/spinnaker-install-admin-guides/docker.md
@@ -22,7 +22,7 @@ Spinnaker fresh), you'll need to enable Docker registry providers:
 Add the following snippet to `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -54,7 +54,7 @@ as an example.
 Add the following snippet to `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/fiat-create-permissions.md
+++ b/content/en/docs/spinnaker-install-admin-guides/fiat-create-permissions.md
@@ -48,7 +48,7 @@ Perform the following steps:
     Here is an example configuration with in-line comments:
 
     ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
     kind: SpinnakerService
     metadata:
       name: spinnaker
@@ -87,7 +87,7 @@ Perform the following steps:
     The following example builds upon the example from the previous steps. In-line comments describe additions:
 
     ```yaml
-    apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+    apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
     kind: SpinnakerService
     metadata:
       name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/github.md
+++ b/content/en/docs/spinnaker-install-admin-guides/github.md
@@ -37,7 +37,7 @@ Spinnaker fresh), you'll need to enable Github as an artifact source:
 Add the following snippet to `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -76,7 +76,7 @@ this:
 Add the following snippet to `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/jenkins.md
+++ b/content/en/docs/spinnaker-install-admin-guides/jenkins.md
@@ -18,7 +18,7 @@ configure access to your Jenkins masters.
 Add the following snippet to your `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -61,7 +61,7 @@ Add the Jenkins master to Spinnaker:
 Add the following snippet to your `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/okta.md
+++ b/content/en/docs/spinnaker-install-admin-guides/okta.md
@@ -82,7 +82,7 @@ keytool -genkey -v -keystore $KEYSTORE_PATH -alias saml -keyalg RSA -keysize 204
 Add the following snippet to `SpinnakerService` manifest. This references secrets stored in a Kubernetes secrets in the same namespace as Spinnaker, but secrets can be stored in any of the supported [secret engines](/spinnaker-install-admin-guides/secrets):
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/s3.md
+++ b/content/en/docs/spinnaker-install-admin-guides/s3.md
@@ -28,7 +28,7 @@ Spinnaker fresh), you'll need to enable S3 as an artifact source:
 Add the following snippet to `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -57,7 +57,7 @@ that account has access to can be referenced after that.
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/services-mtls.md
+++ b/content/en/docs/spinnaker-install-admin-guides/services-mtls.md
@@ -105,7 +105,7 @@ Change the readiness probe used by Kubernetes from an HTTP request to a TCP prob
 Add the following snippet to each service in `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/services-tls.md
+++ b/content/en/docs/spinnaker-install-admin-guides/services-tls.md
@@ -169,7 +169,7 @@ You can store secrets (and non secrets) in [supported secret stores]({{< ref "se
 For instance, assuming all the information is stored in a bucket named `mybucket` on s3 that all services have access to, `SpinnakerService` manifest (or the corresponding `echo-local.yml` in Halyard) might look like:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/slack-notifications.md
+++ b/content/en/docs/spinnaker-install-admin-guides/slack-notifications.md
@@ -39,7 +39,7 @@ You are now ready to configure Spinnaker with the bot you’ve just registered.
 Add the following snippet to the `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/sumologic-dashboard.md
+++ b/content/en/docs/spinnaker-install-admin-guides/sumologic-dashboard.md
@@ -48,7 +48,7 @@ Configure an HTTP Source. And get a copy of the endpoint URL from your SumoLogic
 Add to the `SpinnakerService` manifest the following snippet:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker-install-admin-guides/upgrade-oss-to-armory.md
+++ b/content/en/docs/spinnaker-install-admin-guides/upgrade-oss-to-armory.md
@@ -57,7 +57,7 @@ If Halyard is running locally on your workstation, then perform the following st
      -v ${HOME}/armory/.config:/home/spinnaker/.config \
      -d \
      -u $(id -u) \
-     index.docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+     index.docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
    ```
 
    Omit any directories that do not apply to you. For example, if you do not use Azure, omit it.
@@ -90,7 +90,7 @@ If Halyard is already running in a Docker container in your Docker daemon, you c
 
 1. First, do a backup of your existing Halyard configuration. Exec into the Docker container, then run `hal backup create`.
 
-2. Stop the Halyard docker container, and re-start it with the Armory Halyard image (`index.docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}`) instead of the OSS Halyard image (`gcr.io/spinnaker-marketplace/halyard:stable`). Also, change the user id for Armory Halyard to be `1000`. For example, if you run the previous Docker image (OSS Halyard) like this:
+2. Stop the Halyard docker container, and re-start it with the Armory Halyard image (`index.docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}`) instead of the OSS Halyard image (`gcr.io/spinnaker-marketplace/halyard:stable`). Also, change the user id for Armory Halyard to be `1000`. For example, if you run the previous Docker image (OSS Halyard) like this:
 
    ```bash
    docker run --name halyard --rm \
@@ -107,7 +107,7 @@ If Halyard is already running in a Docker container in your Docker daemon, you c
      -v ${HOME}/armory/.hal:/home/spinnaker/.hal \
      -v ${HOME}/armory/.kube:/home/spinnaker/.kube \
      -d \
-     index.docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+     index.docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
    ```
 
     Note the different Docker image and different container name.
@@ -136,7 +136,7 @@ If Halyard is already running in a Docker container in your Docker daemon, you c
 
 If Halyard is running in your Kubernetes cluster, either as a Kubernetes Deployment or a Kubernetes StatefulSet, then you can do an in-place upgrade:
 
-1. First, update the image for your Halyard Deployment / StatefulSet from the OSS Halyard image (`gcr.io/spinnaker-marketplace/halyard:stable`) to the Armory Halyard image (`index.docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}`)
+1. First, update the image for your Halyard Deployment / StatefulSet from the OSS Halyard image (`gcr.io/spinnaker-marketplace/halyard:stable`) to the Armory Halyard image (`index.docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}`)
 
 1. Wait for the pod to start up.
 

--- a/content/en/docs/spinnaker-user-guides/kayenta.md
+++ b/content/en/docs/spinnaker-user-guides/kayenta.md
@@ -78,7 +78,7 @@ services:
 In your `SpinnakerService` manifest, add the following snippet:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
   kind: SpinnakerService
   metadata:
     name: spinnaker

--- a/content/en/docs/spinnaker-user-guides/kustomize-manifests.md
+++ b/content/en/docs/spinnaker-user-guides/kustomize-manifests.md
@@ -33,7 +33,7 @@ Kustomize can be enabled by a feature flag in 2.16.
 Add the following settings to the `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -87,7 +87,7 @@ Kustomize can be enabled by a feature flag in Armory Spinnaker 2.16 and later.
 Add the following settings to the `SpinnakerService` manifest and apply the changes:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/armory-halyard.md
+++ b/content/en/docs/spinnaker/armory-halyard.md
@@ -104,7 +104,7 @@ hal armory diagnostics edit [parameters]
 #### Equivalent SpinnakerService.yml config for Spinnaker Operator
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -199,7 +199,7 @@ hal armory dinghy edit [parameters]
 #### Equivalent SpinnakerService.yml config for Spinnaker Operator
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -443,7 +443,7 @@ hal armory secrets vault edit [parameters]
 #### Equivalent SpinnakerService.yml config for Spinnaker Operator
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/bake-and-share.md
+++ b/content/en/docs/spinnaker/bake-and-share.md
@@ -14,7 +14,7 @@ Many people have Spinnaker sitting in a different AWS account than where they ar
 You can add the following snippet to your `SpinnakerService` manifest and apply it after replacing the examplvalues with ones that correspond to your environment. The example adds an AWS account and configures the bakinservice (Rosco) with default values:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/configure-kayenta.md
+++ b/content/en/docs/spinnaker/configure-kayenta.md
@@ -15,7 +15,7 @@ configure Kayenta using Halyard at
 For Operator, the following example is an equivalent `SpinnakerService` manifest. The example config uses Datadog as a metrics provider and stores canary configs and analysis in a GCS bucket:
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/exposing-spinnaker.md
+++ b/content/en/docs/spinnaker/exposing-spinnaker.md
@@ -26,7 +26,7 @@ While there are many ways to expose Spinnaker, we find the method described in t
 Update your `SpinnakerService` manifest with the following example `expose` configuration, which will automatically create one Kubernetes service LoadBalancer for the API (Gate) and one for the UI (Deck):
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -100,7 +100,7 @@ This tutorial presumes you've already created a certificate in the AWS Certifica
 Update and apply the `SpinnakerService` manifest to specify the DNS names for Gate and Deck, and to provide annotations specific for EKS LoadBalancers:
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -180,7 +180,7 @@ A `NodePort` Kubernetes service opens the same port (automatically chosen) on al
 **Operator**
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -279,7 +279,7 @@ Spinnaker needs to know which url's are used to access it. After you have update
 Update and apply the `SpinnakerService` manifest:
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -365,7 +365,7 @@ Now tell Spinnaker about its external endpoints:
 Update and apply the `SpinnakerService` manifest:
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -413,7 +413,7 @@ To enable redirects, complete the following steps:
 Update the `SpinnakerService` manifest with the following:
 
 ```yaml
-apiversion: spinnaker.io/{{ site.data.versions.operator-extended-crd-version }}
+apiversion: spinnaker.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/install-dinghy.md
+++ b/content/en/docs/spinnaker/install-dinghy.md
@@ -20,8 +20,10 @@ To configure Pipelines as code, start by enabling it:
 
 In `SpinnakerService` manifest:
 
+
+
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -60,7 +62,7 @@ To set/override the Spinnaker Redis settings do the following:
 In `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -102,7 +104,7 @@ Then run `hal deploy apply` to deploy the changes.
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -151,7 +153,7 @@ If your gate endpoint is protected by a firewall, you’ll need to configure you
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -193,7 +195,7 @@ You'll need to setup webhooks for each project that has the dinghyfile or module
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -257,7 +259,7 @@ All providers available in Dinghy are supported. Please refer to the list below 
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -310,7 +312,7 @@ If you have configured Spinnaker to send Slack notifications for pipeline events
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -353,7 +355,7 @@ To use one of these alternate formats, you'll need to configure a local override
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -390,7 +392,7 @@ You have probably configured global logging levels with `spinnaker-local.yml`. T
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/install.md
+++ b/content/en/docs/spinnaker/install.md
@@ -59,7 +59,7 @@ docker run --name armory-halyard --rm \
     -v ~/.hal:/home/spinnaker/.hal \
     -v ~/.kube:/home/spinnaker/.kube \
     -v ~/.aws:/home/spinnaker/.aws \
-    -it docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+    -it docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
 
 > Note: If you're installing to Google Cloud, you'll want to change the
@@ -113,7 +113,7 @@ spec:
     spec:
       containers:
       - name: halyard
-        image: index.docker.io/armory/halyard-armory:{{ site.data.versions.halyard-armory-version }}
+        image: index.docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
         volumeMounts:
         - name: halconfig
           mountPath: /home/spinnaker/

--- a/content/en/docs/spinnaker/policy-engine.md
+++ b/content/en/docs/spinnaker/policy-engine.md
@@ -31,7 +31,7 @@ The steps to enable the Policy Engine vary based on whether you use the [Operato
 Add the following section to `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -55,7 +55,7 @@ spec:
 If you are using an in-cluster OPA instance (such as one set up with the instructions below), Spinnaker can access OPA via the Kubernetes service DNS name. The following example configures Spinnaker to connect with an OPA server at http://opa.opaserver:8181:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -36,7 +36,7 @@ To set/override the Spinnaker Redis settings do the following:
 In `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -96,7 +96,7 @@ If you do not already have a `git/repo` artifact account configured, you must do
 Edit the `SpinnakerService` manifest to add the following:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -148,7 +148,7 @@ skip this section.
 Edit the `SpinnakerService` manifest to add the following:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -186,7 +186,7 @@ Enable the Terraform Integration
 In `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -221,7 +221,7 @@ identify the artifact account.
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -258,7 +258,7 @@ Github directories hosting your Terraform templates.
 In `SpinnakerService` manifest:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker
@@ -297,7 +297,7 @@ For Armory Spinnaker 2.17.3 and later, the UI is on by default. If you are using
 Edit the `SpinnakerService` manifest to add the following:
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker

--- a/content/en/docs/spinnaker/using-dinghy.md
+++ b/content/en/docs/spinnaker/using-dinghy.md
@@ -909,7 +909,7 @@ You have probably configured global logging levels with `spinnaker-local.yml`. T
 **Operator**
 
 ```yaml
-apiVersion: spinnaker.armory.io/{{ site.data.versions.operator-extended-crd-version }}
+apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
 kind: SpinnakerService
 metadata:
   name: spinnaker


### PR DESCRIPTION
Jira: https://armory.atlassian.net/browse/DOC-185

Move the three parameters from https://github.com/armory/documentation/blob/master/_data/versions.yml to config.toml

Replace `site.data.versions.` with < param .