### PR TITLE
docs(install): Include the gist for the air-gap install download script

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,6 +88,7 @@ weight = 1
 # Everything below this are Site Params
 
 [params]
+armory-version = "2.20.x"
 halyard-armory-version = "1.9.3"
 operator-extended-crd-version = "v1alpha2"
 operator-oss-crd-version = "v1alpha2"

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/air-gapped.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/air-gapped.md
@@ -115,9 +115,12 @@ It may be necessary to include your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY 
 
 You can download version `x.y.z` of Armory Spinnaker with this script:
 
+<details><summary>Show the script</summary>
+
 {{< gist armory-gists 1d14179659bd0f2c5026443efc136253 >}}
 
 Set the value for `NEW_DOCKER_REGISTRY` to point to your docker repository if needed.
+</details><br>
 
 For example, run the following command to download version {{< param armory-version >}}:
 

--- a/content/en/docs/spinnaker-install-admin-guides/Installation/air-gapped.md
+++ b/content/en/docs/spinnaker-install-admin-guides/Installation/air-gapped.md
@@ -113,12 +113,17 @@ It may be necessary to include your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY 
 
 ### Enabling a new version of Armory Spinnaker
 
-You can download version `x.y.z` of Armory Spinnaker with this [script](https://gist.github.com/ncknt/37b1743111eb727bcd81e21dffda90d6). Set the value for `NEW_DOCKER_REGISTRY` to point to your docker repository if needed.
+You can download version `x.y.z` of Armory Spinnaker with this script:
 
-For example:
+{{< gist armory-gists 1d14179659bd0f2c5026443efc136253 >}}
+
+Set the value for `NEW_DOCKER_REGISTRY` to point to your docker repository if needed.
+
+For example, run the following command to download version {{< param armory-version >}}:
 
 ```bash
-$ download-bom.sh 2.20.0 versions/
+# Replace `x` with the edge release you want to use.
+$ download-bom.sh {{< param armory-version >}} versions/
 ```
 
 You can then upload the files you just downloaded to your storage. Make sure they are readable from wherever Halyard (not necessarily Spinnaker services) will run. For example:


### PR DESCRIPTION
- Adds a parameter for the current Armory version
- Includes the gist in a collapsed section so that people don't have to click away if they don't want to
- (Not in the actual PR) moved the Gist to a common account (`armory-gists`) out of a personal account.