### PR TITLE
docs(dynamic-accounts): add known issue

### DIFF
--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-0.md
@@ -13,6 +13,17 @@ aliases:
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
+
 ### Breaking Changes
 
 Two known breaking changes with this release:

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-1.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-18-1.md
@@ -12,6 +12,7 @@ aliases:
 
 
 ## Known Issues
+
 ### Halyard version
 
 There is a known issue where Armory Halyard 1.9.0 fails to install Armory Spinnaker 2.18.1. The Pod for Echo enters a crash loop.
@@ -20,6 +21,15 @@ There is a known issue where Armory Halyard 1.9.0 fails to install Armory Spinna
 
 Use Armory Halyard 1.8.3 if you want to install Armory Spinnaker 2.18.1.
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
 
 ## Highlighted Updates
 ### Armory

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-4.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-4.md
@@ -23,6 +23,16 @@ This version includes an upgrade to the Spring Boot dependency. This requires yo
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Service Accounts using Fiat
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-5.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-5.md
@@ -34,6 +34,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Service Accounts using Fiat
 
 There is an issue creating or updating service accounts. This causes the pipeline permissions feature to not work.  

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-7.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-7.md
@@ -25,6 +25,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Plugins
 
 There is a known issue with the Plugins framework in Armory Spinnaker 2.17.7. If you want to build or use plugins, do not use this version. Use Armory Spinnaker 2.17.8 or later.

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-8.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-8.md
@@ -26,6 +26,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Pipelines as code
 
 Webhook secret validation is broken in this version. Please skip this version if you use this feature.

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-9.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-9.md
@@ -23,6 +23,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Pipelines as code
 
 Webhook secret validation is broken in this version. Please skip this version if you use this feature.

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-0.md
@@ -39,6 +39,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Vault secrets
 
 If you use Vault secrets, you should not use this version and instead update to v2.20.3. 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-1.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-1.md
@@ -39,6 +39,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Vault secrets
 
 If you use Vault secrets, you should not use this version and instead update to v2.20.3.

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-2.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-2.md
@@ -40,6 +40,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Vault Secrets and Spring Cloud
 
 If you use Vault Secrets in conjunction with Spring Cloud, skip this version and upgrade to 2.20.3.

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-3.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-3.md
@@ -43,6 +43,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-4.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-4.md
@@ -42,6 +42,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x or later, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-5.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-20-5.md
@@ -41,6 +41,16 @@ Breaking change: Kubernetes accounts with an unspecified providerVersion will no
 
 ## Known Issues
 
+### Dynamic Accounts for Kubernetes
+
+There is an issue with Dynamic Accounts for Kubernetes where the following issues occur:
+
+* Agents get be removed but still run on schedule. 
+* Force cache refresh times out.
+* If you have the clean up agent setup, your data randomly disappears and reappears.  
+
+These issues do not occur immediately, and you may even see modified accounts appear.
+
 ### Upgrading from 2.18.x with MySQL used for Front50 renames the plugin_artifacts table
 As a part of the upgrade from 2.18.x to 2.19.x or later, the table **plugin_artifacts** gets renamed to `plugin_info`. Downgrades from 2.19.x to 2.18.x do not revert the table name. The table remains named `plugin_info`, preventing access to the table.  
 

--- a/content/en/docs/spinnaker-install-admin-guides/dynamic-accounts.md
+++ b/content/en/docs/spinnaker-install-admin-guides/dynamic-accounts.md
@@ -6,6 +6,9 @@ aliases:
   - /spinnaker-install-admin-guides/dynamic_accounts/
 ---
 
+{{% alert type=warning color="warning" %}}There is currently a known issue with Dynamic Accounts for Kubernetes. Armory recommends that you do not use this feature until it is resolved. For more information, see the release notes for your version. For example, [2.20.5]({{< ref "armoryspinnaker_v2-20-5#dynamic-accounts-for-kubernetes" >}}).
+{{% /alert %}}
+
 ## Overview
 
 If you add, delete, or modify Kubernetes deployment targets on a regular basis, you may find that redeploying Clouddriver to pull in new


### PR DESCRIPTION
- Adds known issue entry for 2.18.0-2.20.5
- Adds a warning to the top of the dynamic k8s docs. Does not remove the docs since we've provided a custom image to a customer so that they can use this in the meantime.