### PR TITLE
docs(tf): add remote backend docs

### DIFF
--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -256,13 +256,58 @@ spec:
       armory:
         terraform:
           enabled: true
+          # Remote backends is an Early Access feature. Do not use it in production. Omit this field if you do not want to use remote backends.
+          remoteBackendSupport: true
+    profiles:
+      deck:
+        # Enables the UI for the Terraform Integration stage
+        settings-local.js: |
+          window.spinnakerSettings.feature.terraform = true;
 ```
+
+This example manifest also enables the Terraform Integration UI and support for remote backends.
 
 **Halyard**
 
 ```
 hal armory terraform enable
 ```
+
+### Remote backends
+
+{{< include "experimental-feature.html" >}}
+
+This Early Access feature is available in Armory 2.AB.XY and later.
+
+The Terraform Integration supports using remote backends provided by Terraform Cloud and Terraform Enterprise.
+
+When using remote backends, keep the following in mind:
+
+* The Terraform stage must use the same Terraform version that your Terraform Cloud/Enterprise workspace runs.
+* The minimum supported Terraform version is 0.12.0.
+* If you view a `plan` action in the Terraform Cloud/Enterprise UI, the type of `plan` action that the Terraform Integration performs is a "speculative plan." For more information, see [Speculative Plans](https://www.terraform.io/docs/cloud/run/index.html#speculative-plans).
+* You cannot save and apply a plan file.
+* You cannot use Named Profiles for authentication for remote backends.
+  
+#### Enable remote backend support
+
+See either the **Halyard** or **Operator** for how to enable remote backend support. Once enabled, end users can use remote backends by configuring the Terraform Integration stage with the following:
+
+* Select a version that is 0.12.0 or later and matches the version that your Terraform Cloud/Enterprise runs.
+* Specify a remote backend.
+
+**Halyard**
+To enable support, add the following config to your `terraformer-local.yml` file in the `.hal/default/profiles` directory:
+
+```
+terraform:
+  remoteBackendSupport: true
+```
+
+**Operator**
+
+See the example manifest in [Enabling the Terraform Integration](#enabling-the-terraform-integration).
+
 
 
 ## Enabling the Terraform Integration UI
@@ -273,20 +318,7 @@ Manually enable the stage UI for Deck:
 
 **Operator**
 
-Edit the `SpinnakerService` manifest to add the following:
-
-```yaml
-apiVersion: spinnaker.armory.io/{{< param operator-extended-crd-version >}}
-kind: SpinnakerService
-metadata:
-  name: spinnaker
-spec:
-  spinnakerConfig:
-    profiles:
-      deck:
-        settings-local.js: |
-          window.spinnakerSettings.feature.terraform = true;
-```
+See the example manifest in [Enabling the Terraform Integration](#enabling-the-terraform-integration).
 
 **Halyard**
 
@@ -446,7 +478,7 @@ Armory recommends that you enable authorization for your Named Profiles to provi
 
 You can see a demo here: [Named Profiles for Armory Spinnaker Terraform Integration](https://www.youtube.com/watch?v=RYO-b1kyEU0).
 
-{{% alert color=note title="Note" %}}Before you start, make sure you enable Fiat. For more information about Fiat, see [Fiat Overview]({{< ref "fiat-permissions-overview" >}}) and [Authorization (RBAC)](https://spinnaker.io/setup/security/authorization/){{% /alert %}}
+{{% alert color=note title="Note" %}}Before you start, make sure you enable Fiat. For more information about Fiat, see [Fiat Overview]({{< ref "fiat-permissions-overview" >}}) and [Authorization (RBAC)](https://spinnaker.io/setup/security/authorization/).{{% /alert %}}
 
 #### Halyard
 To start, edit `~/.hal/default/profiles/terraformer-local.yml` and add the following config:

--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -256,8 +256,6 @@ spec:
       armory:
         terraform:
           enabled: true
-          # Remote backends is an Early Access feature. Do not use it in production. Omit this field if you do not want to use remote backends.
-          remoteBackendSupport: true
     profiles:
       deck:
         # Enables the UI for the Terraform Integration stage
@@ -277,8 +275,6 @@ hal armory terraform enable
 
 {{< include "early-access-feature.html" >}}
 
-This Early Access feature is available in Armory 2.AB.XY and later.
-
 The Terraform Integration supports using remote backends provided by Terraform Cloud and Terraform Enterprise.
 
 When using remote backends, keep the following in mind:
@@ -290,23 +286,17 @@ When using remote backends, keep the following in mind:
   
 #### Enable remote backend support
 
-See either the **Halyard** or **Operator** for how to enable remote backend support. Once enabled, end users can use remote backends by configuring the Terraform Integration stage with the following:
+End users can use remote backends by configuring the Terraform Integration stage with the following parameters:
 
-* Select a version that is 0.12.0 or later and matches the version that your Terraform Cloud/Enterprise runs.
-* Specify a remote backend.
+* A Terraform version that is 0.12.0 or later and matches the version that your Terraform Cloud/Enterprise runs.
+* Reference a remote backend in your Terraform code.
 
-**Halyard**
-
-To enable support, manually add the following config to your `terraformer-local.yml` file in the `.hal/default/profiles` directory:
+To enable support, add the following config to your `terraformer-local.yml` file in the `.hal/default/profiles` directory:
 
 ```
 terraform:
   remoteBackendSupport: true
 ```
-
-**Operator**
-
-See the example manifest in [Enabling the Terraform Integration](#enabling-the-terraform-integration).
 
 ## Enabling the Terraform Integration UI
 
@@ -348,13 +338,13 @@ After you finish your Terraform integration configuration, perform the following
 
 2. Confirm that the Terraform Integration service (Terraformer) is deployed with your Spinnaker deployment:
 
-   ```
+   ```bash
    kubectl get pods -n <your-spinnaker-namespace>
    ```
 
    In the command output, look for a line similar to the following:
 
-   ```
+   ```bash
    spin-terraformer-d4334g795-sv4vz    2/2     Running            0          0d
    ```
 
@@ -443,7 +433,9 @@ Use the `tfc` credential kind to provide authentication to remote Terraform back
 - name: milton-tfc # Unique name for the profile. Shows up in Deck.
   variables:
   - kind: tfc
-    options: 
+    options:
+       domain: app.terraform.io # or Terraform Enterprise URL
+       token: <authentication-token> # Replace with your token
 
 
 

--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -275,7 +275,7 @@ hal armory terraform enable
 
 ### Remote backends
 
-{{< include "experimental-feature.html" >}}
+{{< include "early-access-feature.html" >}}
 
 This Early Access feature is available in Armory 2.AB.XY and later.
 
@@ -380,6 +380,7 @@ The Terraform integration supports multiple types of credentials for Named Profi
 * AWS
 * SSH
 * Static
+* Terraform remote backend
 
 If you don't see a credential that suits your use case, [let us know](https://feedback.armory.io/feature-requests)!
 
@@ -436,6 +437,19 @@ Use the `static` credential kind to provide any arbitrary key/value pair that is
       name: AWS_REGION
       value: us-west-2
 ```
+
+**Terraform remote backend**
+
+Use the `tfc` credential kind to provide authentication to remote Terraform backends.
+
+```yaml
+- name: milton-tfc # Unique name for the profile. Shows up in Deck.
+  variables:
+  - kind: tfc
+    options: 
+
+
+
 
 ### Configuring a Named Profile
 

--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -283,11 +283,10 @@ The Terraform Integration supports using remote backends provided by Terraform C
 
 When using remote backends, keep the following in mind:
 
-* The Terraform stage must use the same Terraform version that your Terraform Cloud/Enterprise workspace runs.
+* The Terraform stage must use the same Terraform version that your Terraform Cloud/Enterprise workspace is configured to run.
 * The minimum supported Terraform version is 0.12.0.
-* If you view a `plan` action in the Terraform Cloud/Enterprise UI, the type of `plan` action that the Terraform Integration performs is a "speculative plan." For more information, see [Speculative Plans](https://www.terraform.io/docs/cloud/run/index.html#speculative-plans).
+* In the Terraform Cloud/Enterprise UI, the type of `plan` action that the Terraform Integration performs is a "speculative plan." For more information, see [Speculative Plans](https://www.terraform.io/docs/cloud/run/index.html#speculative-plans).
 * You cannot save and apply a plan file.
-* You cannot use Named Profiles for authentication for remote backends.
   
 #### Enable remote backend support
 
@@ -308,8 +307,6 @@ terraform:
 **Operator**
 
 See the example manifest in [Enabling the Terraform Integration](#enabling-the-terraform-integration).
-
-
 
 ## Enabling the Terraform Integration UI
 

--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -297,7 +297,8 @@ See either the **Halyard** or **Operator** for how to enable remote backend supp
 * Specify a remote backend.
 
 **Halyard**
-To enable support, add the following config to your `terraformer-local.yml` file in the `.hal/default/profiles` directory:
+
+To enable support, manually add the following config to your `terraformer-local.yml` file in the `.hal/default/profiles` directory:
 
 ```
 terraform:

--- a/content/en/docs/spinnaker/terraform-enable-integration.md
+++ b/content/en/docs/spinnaker/terraform-enable-integration.md
@@ -263,7 +263,7 @@ spec:
           window.spinnakerSettings.feature.terraform = true;
 ```
 
-This example manifest also enables the Terraform Integration UI and support for remote backends.
+This example manifest also enables the Terraform Integration UI.
 
 **Halyard**
 
@@ -436,9 +436,7 @@ Use the `tfc` credential kind to provide authentication to remote Terraform back
     options:
        domain: app.terraform.io # or Terraform Enterprise URL
        token: <authentication-token> # Replace with your token
-
-
-
+```
 
 ### Configuring a Named Profile
 

--- a/content/en/docs/spinnaker/terraform-use-integration.md
+++ b/content/en/docs/spinnaker/terraform-use-integration.md
@@ -30,14 +30,15 @@ To use the stage, perform the following steps:
 5. Configure the Terraform Integration stage.
     The available fields may vary slightly depending on what you configure for the stage:
     * **Basic Settings**
-      * **Terraform Version**:  Terraform version to use. All Terraform stages within a pipeline that modify state (apply, output, destroy) must use the same version.
+      * **Terraform Version**:  Terraform version to use. All Terraform stages within a pipeline that modify state (apply, output, destroy) must use the same version. If you use a remote backend, the minimum supported version is 0.12.0 and you must select the same Terraform version that your Terraform Cloud/Enterprise runs.
       * **Action**: Terraform action to perform. You can select any of the following actions:
-        * **Plan**: The output of the plan command is saved to a base64-encoded Spinnaker artifact and is injected into context.  You can use this artifact with a webhook to send the plan data to an external system or to use it in an `apply` stage. Optionally, you can select **Plan for Destroy** to view what Terraform destroys if you run the Destroy action.
+        * **Plan**: The output of the plan command is saved to a base64-encoded Spinnaker artifact and is injected into context.  You can use this artifact with a webhook to send the plan data to an external system or to use it in an `apply` stage. Optionally, you can select **Plan for Destroy** to view what Terraform destroys if you run the Destroy action. 
+          * For remote backends, if you view a `plan` action in the Terraform Cloud/Enterprise UI, the type of `plan` action that the Terraform Integration performs is a "speculative plan." For more information, see [Speculative Plans](https://www.terraform.io/docs/cloud/run/index.html#speculative-plans).
         * **Apply**: Run `terraform apply`. Optionally, you can ignore state locking. Armory recommends you do not ignore state locking because it can lead to state corruption. Only ignore state locking if you understand the consequences.
         * **Destroy**: Run `terraform destroy`. Optionally, you can ignore state locking. Armory recommends you do not ignore state locking because it can lead to state corruption.  Only ignore state locking if you understand the consequences.
         * **Output**: Run `terraform output`.
       * **Targets**: Scope execution to a certain subset of resources.
-      * **Workspace**: [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html) to use. The workspace gets created if it does not already exist.
+      * **Workspace**: [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html) to use. The workspace gets created if it does not already exist. Fore remote backends, the workspace must be explicit or prefixed. For more information about what that means, see the Terraform documentation about [remote backends](https://www.terraform.io/docs/backends/types/remote.html)
     * **Main Terraform Artifact**
       * **Expected Artifact**: Required. Select or define only one `git/repo` type artifact.
         ![Terraform git repo artifact](/images/terraform-git-repo.png)
@@ -65,6 +66,8 @@ To use the stage, perform the following steps:
     * **Backend Artifact**: Optional. Configuration stored outside of the primary repo that gets used for authenticating to a state backend. For example, if you want to use an S3 artifact for your backend state, specify it in this section.
 
       For the `backendArtifact` and other artifacts, you can replace `github/file` with some other artifact type. For example, if you're using the BitBucket artifact provider, specify `bitbucket/file` and the corresponding artifact account.
+
+      The Terraform Integration supports remote backends [Early Access]({{< ref "release-definitions" >}}). Select a Terraform version that is 0.12.0 or higher when configuring the stage and specify a remote backend in this configuration.
 
 ## Custom Plugins
 

--- a/content/en/docs/spinnaker/terraform-use-integration.md
+++ b/content/en/docs/spinnaker/terraform-use-integration.md
@@ -67,7 +67,7 @@ To use the stage, perform the following steps:
 
       For the `backendArtifact` and other artifacts, you can replace `github/file` with some other artifact type. For example, if you're using the BitBucket artifact provider, specify `bitbucket/file` and the corresponding artifact account.
 
-      The Terraform Integration supports remote backends [Early Access]({{< ref "release-definitions" >}}). Select a Terraform version that is 0.12.0 or higher when configuring the stage and specify a remote backend in this configuration.
+      The Terraform Integration supports remote backends as an [Early Access]({{< ref "release-definitions" >}}) feature. Select a Terraform version that is 0.12.0 or higher when configuring the stage. Then, you can use Terraform code that references a remote backend.
 
 ## Custom Plugins
 

--- a/content/en/docs/spinnaker/terraform-use-integration.md
+++ b/content/en/docs/spinnaker/terraform-use-integration.md
@@ -30,7 +30,7 @@ To use the stage, perform the following steps:
 5. Configure the Terraform Integration stage.
     The available fields may vary slightly depending on what you configure for the stage:
     * **Basic Settings**
-      * **Terraform Version**:  Terraform version to use. All Terraform stages within a pipeline that modify state (apply, output, destroy) must use the same version. If you use the remote backend, the minimum supported version is 0.12.0 and you must select the same Terraform version that your Terraform Cloud/Enterprise is configured to use.
+      * **Terraform Version**:  Terraform version to use. All Terraform stages within a pipeline that modify state (apply, output, destroy) must use the same version. If you want to use the remote backend, the minimum supported version is 0.12.0 and you must select the same Terraform version that your Terraform Cloud/Enterprise is configured to use.
       * **Action**: Terraform action to perform. You can select any of the following actions:
         * **Plan**: The output of the plan command is saved to a base64-encoded Spinnaker artifact and is injected into context.  You can use this artifact with a webhook to send the plan data to an external system or to use it in an `apply` stage. Optionally, you can select **Plan for Destroy** to view what Terraform destroys if you run the Destroy action. 
           * For remote backends, if you view a `plan` action in the Terraform Cloud/Enterprise UI, the type of `plan` action that the Terraform Integration performs is a "speculative plan." For more information, see [Speculative Plans](https://www.terraform.io/docs/cloud/run/index.html#speculative-plans).

--- a/content/en/docs/spinnaker/terraform-use-integration.md
+++ b/content/en/docs/spinnaker/terraform-use-integration.md
@@ -30,7 +30,7 @@ To use the stage, perform the following steps:
 5. Configure the Terraform Integration stage.
     The available fields may vary slightly depending on what you configure for the stage:
     * **Basic Settings**
-      * **Terraform Version**:  Terraform version to use. All Terraform stages within a pipeline that modify state (apply, output, destroy) must use the same version. If you use a remote backend, the minimum supported version is 0.12.0 and you must select the same Terraform version that your Terraform Cloud/Enterprise runs.
+      * **Terraform Version**:  Terraform version to use. All Terraform stages within a pipeline that modify state (apply, output, destroy) must use the same version. If you use the remote backend, the minimum supported version is 0.12.0 and you must select the same Terraform version that your Terraform Cloud/Enterprise is configured to use.
       * **Action**: Terraform action to perform. You can select any of the following actions:
         * **Plan**: The output of the plan command is saved to a base64-encoded Spinnaker artifact and is injected into context.  You can use this artifact with a webhook to send the plan data to an external system or to use it in an `apply` stage. Optionally, you can select **Plan for Destroy** to view what Terraform destroys if you run the Destroy action. 
           * For remote backends, if you view a `plan` action in the Terraform Cloud/Enterprise UI, the type of `plan` action that the Terraform Integration performs is a "speculative plan." For more information, see [Speculative Plans](https://www.terraform.io/docs/cloud/run/index.html#speculative-plans).
@@ -38,7 +38,7 @@ To use the stage, perform the following steps:
         * **Destroy**: Run `terraform destroy`. Optionally, you can ignore state locking. Armory recommends you do not ignore state locking because it can lead to state corruption.  Only ignore state locking if you understand the consequences.
         * **Output**: Run `terraform output`.
       * **Targets**: Scope execution to a certain subset of resources.
-      * **Workspace**: [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html) to use. The workspace gets created if it does not already exist. Fore remote backends, the workspace must be explicit or prefixed. For more information about what that means, see the Terraform documentation about [remote backends](https://www.terraform.io/docs/backends/types/remote.html)
+      * **Workspace**: [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html) to use. The workspace gets created if it does not already exist. For remote backends, the workspace must be explicit or prefixed. For more information about what that means, see the Terraform documentation about [remote backends](https://www.terraform.io/docs/backends/types/remote.html)
     * **Main Terraform Artifact**
       * **Expected Artifact**: Required. Select or define only one `git/repo` type artifact.
         ![Terraform git repo artifact](/images/terraform-git-repo.png)

--- a/content/en/includes/early-access-feature.html
+++ b/content/en/includes/early-access-feature.html
@@ -1,6 +1,6 @@
 <div class="alert alert-warning" role="alert">
 <h4 class="alert-heading">Early Access</h4>
-The information below is written for an Early Access feature. Reach out to Armory if you are interested in using this! Your feedback will help shape the development of this feature.
+The information below is written for an Early Access feature. <a href="mailto:hello@armory.io">Contact us</a> if you are interested in using this! Your feedback will help shape the development of this feature.
 <br><br>
 <b>Do not use Early Access features in a production instance of Spinnaker.
 </b>

--- a/content/en/includes/early-access-feature.html
+++ b/content/en/includes/early-access-feature.html
@@ -1,0 +1,7 @@
+<div class="alert alert-warning" role="alert">
+<h4 class="alert-heading">Early Access</h4>
+The information below is written for an Early Access feature. Reach out to Armory if you are interested in using this! Your feedback will help shape the development of this feature.
+<br><br>
+<b>Do not use Early Access features in a production instance of Spinnaker.
+</b>
+</div>

--- a/content/en/includes/experimental-feature.html
+++ b/content/en/includes/experimental-feature.html
@@ -1,7 +1,7 @@
 <div class="alert alert-warning" role="alert">
-<h4 class="alert-heading">Early Access</h4>
-The information below is written for an Early Access feature. Reach out to Armory if you are interested in using this! Your feedback will help shape the development of this feature.
+<h4 class="alert-heading">Experimental</h4>
+The information below is written for an experimental feature. Reach out to Armory if you are interested in using this! Your feedback will help shape the development of this feature.
 <br><br>
-<b>Do not use this Early Access features in production.
+<b>Do not use this experimental feature in a production instance of Spinnaker.
 </b>
 </div>

--- a/content/en/includes/experimental-feature.html
+++ b/content/en/includes/experimental-feature.html
@@ -1,7 +1,7 @@
 <div class="alert alert-warning" role="alert">
-<h4 class="alert-heading">Experimental</h4>
-The information below is written for an experimental feature. Reach out to Armory if you are interested in using this! Your feedback will help shape the development of this feature.
+<h4 class="alert-heading">Early Access</h4>
+The information below is written for an Early Access feature. Reach out to Armory if you are interested in using this! Your feedback will help shape the development of this feature.
 <br><br>
-<b>Do not use this experimental feature in a production instance of Spinnaker.
+<b>Do not use this Early Access features in production.
 </b>
 </div>


### PR DESCRIPTION
* Adds remote backend docs
* Combines the terraformer operator manifests into 1 file instead of having bits and pieces in different places