### PR TITLE
docs(fix): config.toml change link to v2.20

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -198,7 +198,7 @@ enable = false
 [[params.versions]]
   version = "v2.20"
   githubbranch = "v2.20"
-  url = "https://v2-20.docs.armory.io"
+  url = "https://v2-20.docs.armory.io/docs"
 
 [[params.versions]]
   version = "v2.0-2.19"


### PR DESCRIPTION
changed link to v2.20 to go directly to /docs
Only "latest" should to go docs.armory.io rather than <url>/docs because the landing page doesn't display the "archive" banner