### PR TITLE
docs(v2.20): change URLs to other versions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -193,12 +193,12 @@ enable = false
 [[params.versions]]
   version = "Latest"
   githubbranch = "master"
-  url = "https://docs.armory.io"
+  url = "https://docs.armory.io/docs"
 
 [[params.versions]]
   version = "v2.20"
   githubbranch = "v2.20"
-  url = "https://v2-20.docs.armory.io"
+  url = "https://v2-20.docs.armory.io/docs"
 
 [[params.versions]]
   version = "v2.0-2.19"


### PR DESCRIPTION
Change URLs to other versions to go directly to /docs.  If the user is already in an archived version and wants to go to the latest docs, or another version, take user to /docs. This results in fewer mouse clicks for the user.