### PR TITLE
docs(sched-checklinks): remove 'on push'

### DIFF
--- a/.github/workflows/sched-link-checker.yml
+++ b/.github/workflows/sched-link-checker.yml
@@ -1,12 +1,9 @@
-name: Check Site links
+name: Check Site links 9AM
 
 on:
-  push:
-    branches:
-    - master
   schedule:
   # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-  - cron: "0 9 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   markdown-link-check:


### PR DESCRIPTION
Leave sched time only

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule