### PR TITLE
docs(operator): clarify basic vs cluster in quick start install

### DIFF
--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -7,7 +7,7 @@ aliases:
   - /docs/spinnaker/operator/
 ---
 
-Using Armory Operator, you can: 
+Using Armory Operator, you can:
 
 - Manage Spinnaker with `kubectl` like other applications.
 - Expose Spinnaker via `LoadBalancer` or `Ingress` (optional)
@@ -47,16 +47,22 @@ kubectl apply -f deploy/crds/
 
 # We'll install in the spinnaker-operator namespace
 kubectl create ns spinnaker-operator
+```
 
-# Install operator cluster mode
+Next, install Operator in either `cluster` or `basic` mode:
+
+```bash
+# Install Operator cluster mode
 kubectl -n spinnaker-operator apply -f deploy/operator/cluster
+```
 
-# If instead you want to install the operator in basic mode
+```bash
+# OR install Operator in basic mode
 # kubectl -n spinnaker-operator apply -f deploy/operator/basic
-
 ```
 
 After installation, you can verify that the Operator is running with the following command:
+
 ```bash
 kubectl -n spinnaker-operator get pods
 ```
@@ -71,15 +77,25 @@ spinnaker-operator-7cd659654b-4vktl   2/2           Running      0             6
 > If you want to use a namespace other than `spinnaker-operator` in cluster mode, you'll also need to edit the namespace in `deploy/operator/cluster/role_binding.yaml`.
 
 
-## Spinnaker Install
+## Install Spinnaker
 
-To use the examples, change the parameters you need (especially the `persistentStorage` section). To install a basic version of Spinnaker in the "spinnaker" namespace, run the following command:
+Update the values such as `version` and `persistentStorage` in `deploy/spinnaker/<operator-installation-mode>/SpinnakerService.yml` before you install Spinnaker.
+
+If you installed Operator in `basic` mode, you must use the `spinnaker-operator` namespace. The permissions in `basic` mode are scoped to a single namespace so it doesn't see anything in other namespaces. Run the following command:
 
 ```bash
-kubectl create ns spinnaker
-kubectl -n spinnaker apply -f deploy/spinnaker/basic
+kubectl -n spinnaker-operator apply -f deploy/spinnaker/basic/SpinnakerService.yml
+```
 
-# Watch the install progress and check out the pods being created too!
+If you installed Operator in `cluster` mode, run this command:
+
+```bash
+kubectl -n spinnaker-operator apply -f deploy/spinnaker/cluster/SpinnakerService.yml
+```
+
+Watch the install progress and check out the pods being created:
+
+```bash
 kubectl -n spinnaker get spinsvc spinnaker -w
 ```
 


### PR DESCRIPTION
Discovered that in basic mode, you have to install Spinnaker in the same namespace as Spinnaker Operator. Update quick start section to reflect that.