### PR TITLE
docs(fiat): add pub sub, webhooks, clouddriver api call

### DIFF
--- a/content/en/docs/Overview/fiat-permissions-overview.md
+++ b/content/en/docs/Overview/fiat-permissions-overview.md
@@ -2,7 +2,8 @@
 title: Permissions in Spinnaker
 linkTitle: Permissions in Spinnaker
 weight: 80
-description: Learn about how Fiat manages permissions in Spinnaker.
+description: >
+  Learn about how Fiat manages permissions in Spinnaker.
 ---
 
 ## Overview

--- a/content/en/docs/Overview/fiat-permissions-overview.md
+++ b/content/en/docs/Overview/fiat-permissions-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Permissions in Spinnaker
-summary: Learn about how Fiat manages permissions in Spinnaker.
 linkTitle: Permissions in Spinnaker
 weight: 80
+description: Learn about how Fiat manages permissions in Spinnaker.
 ---
 
 ## Overview
@@ -247,3 +247,53 @@ The command returns JSON that lists the following information:
 - Spinnaker applications the user/service account has access to
 - Clouddriver accounts the user/service account has access to
 - Build services the user/service account has access to
+
+## Pub Sub and Webhooks
+
+Fiat does not support Pub Sub triggers or authenticating webhooks with group permissions.
+
+## Permissions for Clouddriver accounts
+
+Check Clouddriver's current runtime context with a REST API call to Gate.
+
+**Headers**
+
+Header         | Information
+-------------- | --------------------------------
+Request URL    | `$GATE_URL/credentials`
+Request Method | `GET`
+content-type   | `application/json;charset=UTF-8`
+
+
+The API call returns JSON that lists the Clouddriver accounts.
+
+```json
+[
+  {
+    "name": <account-name>,
+    "type": <account-type>,
+    "providerVersion": <version>,
+    "requiredGroupMembership": [
+
+    ],
+    "skin": <version>,
+    "permissions": {
+
+    },
+    "authorized": <true-or-false>
+  },
+  {
+	 "name": "my-docker-registry",
+	 "type": "dockerRegistry",
+	 "providerVersion": "v1",
+	 "requiredGroupMembership": [
+
+	 ],
+	 "skin": "v1",
+	 "permissions": {
+
+	 },
+	 "authorized": "true"
+  }
+]
+```

--- a/content/en/docs/Overview/fiat-permissions-overview.md
+++ b/content/en/docs/Overview/fiat-permissions-overview.md
@@ -284,17 +284,17 @@ The API call returns JSON that lists the Clouddriver accounts.
     "authorized": <true-or-false>
   },
   {
-	 "name": "my-docker-registry",
-	 "type": "dockerRegistry",
-	 "providerVersion": "v1",
-	 "requiredGroupMembership": [
+    "name": "my-docker-registry",
+    "type": "dockerRegistry",
+    "providerVersion": "v1",
+    "requiredGroupMembership": [
 
-	 ],
-	 "skin": "v1",
-	 "permissions": {
+    ],
+    "skin": "v1",
+    "permissions": {
 
-	 },
-	 "authorized": "true"
+    },
+    "authorized": "true"
   }
 ]
 ```


### PR DESCRIPTION
Jira: [BOB-124](https://armory.atlassian.net/browse/BOB-124)

Please help fill in the following gaps in the attached document about Fiat:

- Pub Sub Triggering (There's material about service accounts, but not much for triggering or specifically Pub Sub Triggers)
- Webhooks (There's no information about authenticating webhooks with group permissions, both inbound and outbound. I believe this is due to there not being much capacity to do this in Spinnaker, but it should be called out)
-  API requests for Account Permission information (There are curl examples for Fiat and Front50, but not for Clouddriver. There is reference to the configuration for Clouddriver, but we should be able to  make an API request to audit the current runtime context)

https://cloud-armory.slack.com/archives/CGWMDVBCN/p1598899955004100

Deploy preview:  https://deploy-preview-189--armory-docs.netlify.app/docs/overview/fiat-permissions-overview/#pub-sub-and-webhooks