### PR TITLE
docs(authn-github): Update 'Configuring GitHub OAuth for Spinnaker' page to include Operator section

### DIFF
--- a/content/en/docs/spinnaker-install-admin-guides/authn-github.md
+++ b/content/en/docs/spinnaker-install-admin-guides/authn-github.md
@@ -20,7 +20,25 @@ This post describes how to configure GitHub and Spinnaker to use GitHub as an OA
 3. Homepage URL: This would be the URL of your Spinnaker service e.g. https://spinnaker.acme.com
 4. Authorization callback URL: This is going to match your `--pre-established-redirect-uri` in halyard and the URL needs `login` appended to your gate endpoint e.g. https://gate.spinnaker.acme.com/login  or https://spinnaker.acme.com/gate/login
 
-## Configuring Spinnaker with Halyard
+## Configuring Spinnaker
+
+**Operator**
+
+Add the following snippet to your `SpinnakerService` manifest under the `spec.spinnakerConfig.config.security.authn` level:
+```
+oauth2:
+    enabled: true
+    client:
+      clientId: a08xxxxxxxxxxxxx93
+      clientSecret: 6xxxaxxxxxxxxxxxxxxxxxxx59   # Secret Enabled Field
+      scope: read:org,user:email
+      preEstablishedRedirectUri: https://gate.spinnaker.acme.com/login
+    provider: github
+```
+
+For additional configuration options review the [Spinnaker Operator Reference]({{< ref "operator-reference" >}})
+
+**Halyard**
 
 Run the following commands in Halyard with your Client ID and Client Secret.
 


### PR DESCRIPTION
Previously this page of the doc only included instructions on Halyard.