### PR TITLE
fix(rollback): Remove old rollback instructions

### DIFF
--- a/content/en/docs/spinnaker-install-admin-guides/upgrade-spinnaker.md
+++ b/content/en/docs/spinnaker-install-admin-guides/upgrade-spinnaker.md
@@ -57,15 +57,3 @@ Rolling an upgrade back is similar to upgrading Spinnaker:
    ```
    hal deploy apply
    ```   
-
-### Rolling back an unresponsive Spinnaker deployment
-
-If you deploy a configuration or a change that takes down Spinnaker, rolling Spinnaker back requires modifying the Autoscaling Groups (ASGs) for the current unavailable deployment and the previous working state. The following steps walk you through how to rollback to a good state on AWS:
-
-1. In your AWS console, look for an existing deployment with the `armoryspinnaker` prefix.
-2. Find the ASGs of Armory Spinnaker that were deployed. Typically, they should be named `armoryspinnaker-ha-polling-v${VER}` where `${VER}` is something like `023`. You should see 2 ASGS, one that is active instead and the older version should be disabled:
-3. Edit the older ASG and remove any suspended processes that are listed:
-4. Increase the number of instances for the `armoryspinnaker-ha-polling` ASG to just 1 and set the other ASG `armoryspinnaker-ha`, the non-polling ASG back to at least 2.  
-5. Reduce the latest ASGs down to 0.
-6. Check the Armory Spinnaker ELB. Make sure all instances are attached to the user-facing and internal-services ELB and are healthy.
-7. Verify Spinnaker is in a working state.


### PR DESCRIPTION
Remove section Rolling back an unresponsive Spinnaker deployment since this no longer applies. This only applies to Spinnaker deployed on EC2 machines.