### PR TITLE
fix(installDinghy): Add GitHub Config

### DIFF
--- a/content/en/docs/spinnaker/install-dinghy.md
+++ b/content/en/docs/spinnaker/install-dinghy.md
@@ -133,7 +133,7 @@ hal armory dinghy edit \
   --template-repo "dinghy-templates" \
   --github-token "your_token/password"
 # For Github enterprise, you may customize the endpoint:
-  --github-endpoint "https://your-endpoint-here.com/api/v3"
+  --github-endpoint "https://your-endpoint-here.com/api/v3" # (Default: https://api.github.com) Github API endpoint. Useful if you’re using Github Enterprise
 hal deploy apply
 ```
 


### PR DESCRIPTION
Match Halyard with Operator information for GitHub Enterprise as customer had to guess.