### PR TITLE
docs(guide): update nginx-ingress deploy yaml

### DIFF
--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -414,18 +414,18 @@ If you already have an NGINX ingress controller installed on your cluster, skip 
 
 From the `workstation machine` (where `kubectl` is installed):
 
-Install the NGINX ingress controller components:
+If you are using Kubernetes version 1.14 or later, install the NGINX ingress controller components.
+
 
 ```bash
-kubectl --kubeconfig kubeconfig-gke apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
+kubectl --kubeconfig kubeconfig-gke apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud/deploy.yaml
 ```
 
-If you are using a Kubernetes version earlier than 1.14, you need to change kubernetes.io/os to beta.kubernetes.io/os at line 217 of `mandatory.yaml`. See the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) documentation for more details.
-
-Install the NGINX ingress controller GKE-specific service:
+If you are using a Kubernetes version earlier than 1.14, you need to apply the below `mandatory.yaml` file and change kubernetes.io/os to beta.kubernetes.io/os at line 217.
+<!--- See the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) documentation for more details. --->
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
+kubectl apply -f https://github.com/kubernetes/ingress-nginx/blob/nginx-0.30.0/deploy/static/mandatory.yaml
 ```
 
 ## Set up the Ingress for `spin-deck` and `spin-gate`

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -425,7 +425,7 @@ If you are using a Kubernetes version earlier than 1.14, you need to apply the b
 <!--- See the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) documentation for more details. --->
 
 ```bash
-kubectl apply -f https://github.com/kubernetes/ingress-nginx/blob/nginx-0.30.0/deploy/static/mandatory.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.30.0/deploy/static/mandatory.yaml
 ```
 
 ## Set up the Ingress for `spin-deck` and `spin-gate`

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -418,7 +418,7 @@ If you are using Kubernetes version 1.14 or later, install the NGINX ingress con
 
 
 ```bash
-kubectl --kubeconfig kubeconfig-gke apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud/deploy.yaml
+kubectl --kubeconfig kubeconfig-gke apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.35.0/deploy/static/provider/cloud/deploy.yaml
 ```
 
 If you are using a Kubernetes version earlier than 1.14, you need to apply the below `mandatory.yaml` file and change kubernetes.io/os to beta.kubernetes.io/os at line 217.


### PR DESCRIPTION
Replaced deprecated mandatory.yaml with current deploy process for Kubernetes >=1.14, [link to reference doc](https://kubernetes.github.io/ingress-nginx/deploy).

Updated instructions for for Kubernetes <1.14 and added working link to deprecated mandatory.yaml file, although may want to consider removing support as it's very outdated.

All files that reference `mandatory.yaml` must be updated:
- [ ] [guide/install-on-aks.md](https://github.com/armory/docs/blob/master/content/en/docs/installation/guide/install-on-aks.md)
- [x] [guide/install-on-gke.md](https://github.com/armory/docs/blob/master/content/en/docs/installation/guide/install-on-gke.md)
- [ ] [guide/install-on-k8s.md](https://github.com/sh4sh/docs/blob/master/content/en/docs/installation/guide/install-on-k8s.md)
