### PR TITLE
fix(docs): missing syntax in example

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,5 +1,5 @@
 {
-	"ignorePatterns": [
+	"ignorePatterns" [
 		{
 			"pattern": "/^images/(.*)"
 		},

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@master
       with:
         fetch-depth: 1
-    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.7
+    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.6
       with:
         use-quiet-mode: 'yes' # Specify yes to only show errors in output.#
         use-verbose-mode: 'yes' # Specify yes to show detailed HTTP status for checked links.#

--- a/content/en/docs/Overview/fiat-permissions-overview.md
+++ b/content/en/docs/Overview/fiat-permissions-overview.md
@@ -125,7 +125,7 @@ accounts:
       - dev
       - qa
       - ops
-    WRITE
+    WRITE:
       - admin
       - dev
       - ops


### PR DESCRIPTION
insert missing colon in fiat guide