### PR TITLE
docs(installation): clarifications added on Halyard Versions

### DIFF
--- a/content/en/docs/installation/armory-halyard.md
+++ b/content/en/docs/installation/armory-halyard.md
@@ -38,6 +38,9 @@ Our installer currently expects to find your kubeconfig named `config` in
 the `.kube` directory you map below.  If you've named your config something
 else, you'll need to rename or symlink the file accordingly.
 
+For a list of halyard versions available and their release notes, including version differences, and matched versions with matched Armory releases, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/).
+
+
 ### Running Halyard Commands
 Once Armory-extended Halyard is running, you can interact with it by opening a separate
 Terminal and running:

--- a/content/en/docs/installation/armory-halyard.md
+++ b/content/en/docs/installation/armory-halyard.md
@@ -7,6 +7,8 @@ description: >
 
 Armory-extended Halyard is a versatile command line interface (CLI) to configure and deploy Spinnaker. It is made of a CLI that connects to a daemon.
 
+{{< include "halyard-note.md" >}}
+
 ## Running in Docker
 
 Running Armory-extended Halyard in Docker is convenient and portable. The daemon will need access to files and environment variables, such as:
@@ -38,10 +40,8 @@ Our installer currently expects to find your kubeconfig named `config` in
 the `.kube` directory you map below.  If you've named your config something
 else, you'll need to rename or symlink the file accordingly.
 
-For a list of halyard versions available and their release notes, including version differences, and matched versions with matched Armory releases, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/).
-
-
 ### Running Halyard Commands
+
 Once Armory-extended Halyard is running, you can interact with it by opening a separate
 Terminal and running:
 
@@ -49,7 +49,7 @@ Terminal and running:
 docker exec -it armory-halyard bash
 ```
 
-From there, you can issue all your [halyard commands](https://www.spinnaker.io/reference/halyard/).
+From there, you can issue all your [Halyard commands](https://www.spinnaker.io/reference/halyard/).
 
 ## Run in Kubernetes
 

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -236,9 +236,9 @@ cp kubeconfig-spinnaker-system-sa ${WORKING_DIRECTORY}/.secret
 
 ## Start the Halyard container
 
-On the `Halyard machine`, start the Halyard container (see the `armory/halyard-armory` [tag list](https://hub.docker.com/r/armory/halyard-armory/tags)) for the latest Armory-extended Halyard Docker image tag.
+On the `Halyard machine`, start the Halyard container (for a list of halyard versions available and their release notes, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/)).
 
-*If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker image.*
+*If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
 ```bash
 docker run --name armory-halyard -it --rm \

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -236,7 +236,9 @@ cp kubeconfig-spinnaker-system-sa ${WORKING_DIRECTORY}/.secret
 
 ## Start the Halyard container
 
-On the `Halyard machine`, start the Halyard container (for a list of halyard versions available and their release notes, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/)).
+{{< include "halyard-note.md" >}}
+
+On the `Halyard machine`, start the Halyard container.
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -314,9 +314,9 @@ cp kubeconfig-spinnaker-system-sa ${WORKING_DIRECTORY}/.secret
 
 ## Start the Halyard container
 
-On the `docker machine`, start the Halyard container (see the `armory/halyard-armory` [tag list](https://hub.docker.com/r/armory/halyard-armory/tags)) for the latest Armory-extended Halyard Docker image tag.
+On the `Halyard machine`, start the Halyard container (for a list of halyard versions available and their release notes, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/)).
 
-_If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker image_
+*If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
 ```bash
 docker run --name armory-halyard -it --rm \

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -314,7 +314,9 @@ cp kubeconfig-spinnaker-system-sa ${WORKING_DIRECTORY}/.secret
 
 ## Start the Halyard container
 
-On the `Halyard machine`, start the Halyard container (for a list of halyard versions available and their release notes, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/)).
+{{< include "halyard-note.md" >}}
+
+On the `Halyard machine`, start the Halyard container .
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -227,9 +227,9 @@ cp spinnaker-gcs-account.json ${WORKING_DIRECTORY}/.secret
 
 ## Start the Halyard container
 
-On the `docker machine`, start the Halyard container (see the `armory/halyard-armory` [tag list](https://hub.docker.com/r/armory/halyard-armory/tags)) for the latest Armory-extended Halyard Docker image tag.
+On the `Halyard machine`, start the Halyard container (for a list of halyard versions available and their release notes, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/)).
 
-*If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker image*
+*If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
 ```bash
 docker run --name armory-halyard -it --rm \

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -227,7 +227,9 @@ cp spinnaker-gcs-account.json ${WORKING_DIRECTORY}/.secret
 
 ## Start the Halyard container
 
-On the `Halyard machine`, start the Halyard container (for a list of halyard versions available and their release notes, please visit our [Armory-extended Halyard Release Notes page](https://docs.armory.io/docs/release-notes/rn-armory-halyard/)).
+{{< include "halyard-note.md" >}}
+
+On the `Halyard machine`, start the Halyard container.
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 

--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -47,6 +47,8 @@ The _Armory Operator_ is the newest installation and configuration method for Ar
 
 Halyard is the former installation method for Armory. It has been around the longest and is the first one supporting new Armory features. Operator uses a customized version of Halyard that is constantly updated to incorporate changes from base Halyard.
 
+{{< include "halyard-note.md" >}}
+
 *Prerequisites*
 
 * Your Kubernetes cluster has storage set up so that PersistentVolumeClaims properly allocates PersistentVolumes.
@@ -718,7 +720,7 @@ EOF
 
 ### Select the Armory version to install
 
-Before you use Halyard to install Armory, specify the version of Armory you want to use.
+Before you use Armory-extended Halyard to install Armory, specify the version of Armory you want to use. Make sure the version of Armory you want to install is compatible with the version of Armory-extended Halyard you are using.
 
 You can get a list of available versions of Armory with this command:
 
@@ -726,9 +728,9 @@ You can get a list of available versions of Armory with this command:
 hal version list
 ```
 
-* If you are installing Armory using Armory's Halyard, the command returns a version that starts with `2.x.x`
+* If you are installing Armory using Armory-extended Halyard, the command returns a version that starts with `2.x.x`
 
-* If you are installing OSS Armory and using OSS Halyard (installed from `gcr.io/spinnaker-marketplace/halyard:stable`), the command returns a version that starts with `1.x.x`
+* If you are installing open source Spinnaker and using open source Halyard (installed from `gcr.io/spinnaker-marketplace/halyard:stable`), the command returns a version that starts with `1.x.x`
 
 Select the version with the following:
 

--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -728,7 +728,7 @@ hal version list
 
 * If you are installing Armory using Armory's Halyard, the command returns a version that starts with `2.x.x`
 
-* If you are installing OSS Armory and using `gcr.io/spinnaker-marketplace/halyard:stable`, the command returns a version that starts with `1.x.x`
+* If you are installing OSS Armory and using OSS Halyard (installed from `gcr.io/spinnaker-marketplace/halyard:stable`), the command returns a version that starts with `1.x.x`
 
 Select the version with the following:
 

--- a/content/en/includes/halyard-note.md
+++ b/content/en/includes/halyard-note.md
@@ -1,0 +1,1 @@
+>Visit the [Armory-extended Halyard Release Notes page]({{< ref "rn-armory-halyard" >}}) for a list of available Armory-extended Halyard versions and their release notes. You can view version differences as well as which versions are compatible with which Armory releases.


### PR DESCRIPTION
Added references to Armory's release versions, along with release notes, instead of the repo.  Release notes will help people also determine what versions is needed

Added some more clarification if installing OSS Halyard, about what line to replace in the code