### PR TITLE
docs(plugins): remove plugin config from spinnakerConfig.config

### DIFF
--- a/content/en/docs/installation/operator-reference/plugins.md
+++ b/content/en/docs/installation/operator-reference/plugins.md
@@ -13,34 +13,33 @@ Plugins are an experimental feature in Armory Spinnaker 2.20.3 (Spinnaker 1.20.6
 
 ## Parameters
 
-**spec.spinnakerConfig.config.spinnaker.extensibility.plugins**
+***spec.spinnakerConfig.profiles***
 
-Put plugin declaration and configuration at the same level as `version` in your `SpinnakerService.yml` file.
+Put configuration in the `service` that the plugin extends.  Only the impacted service will restart when you apply the manifest.
+
+Example:
 
 ```yaml
-kind: SpinnakerService
-metadata:
-  name: spinnaker
 spec:
+  # spec.spinnakerConfig - This section is how to specify configuration spinnaker
   spinnakerConfig:
-    config:
-      version:
-      spinnaker:
-        extensibility:
-          plugins:
-            <plugin-name>:
-              id:
-              enabled:
-              version:
-              extensions:
-                <extension-name>:
-                  id:
-                  enabled:
+    # spec.spinnakerConfig.config - This section contains the contents of a deployment found in a halconfig .deploymentConfigurations[0]
+    profiles:
+      orca:
+        spinnaker:
+          extensibility:
+            plugins:
+              <plugin-name>:
+                enabled: <true-or-false>
+                version: <version>
+                extensions:
+                  id: <extension-name>
+                  enabled: <true-or-false>
                   config: {}
-          repositories:
-            <repository-name>:
-              id:
-              url:
+            repositories:
+              <repository-name>:
+                id:
+                url:
 ```
 
 - `plugins`:
@@ -59,8 +58,6 @@ spec:
     - `url`: URL to `repositories.json` or `plugins.json`
 
 See the Plugin Users Guide _Add a plugin repository using Halyard_ [section](https://spinnaker.io/guides/user/plugins/#add-a-plugin-repository-using-halyard) for when you can use `plugins.json` instead of `repositories.json`.
-
-Alternately, you can put the plugin configuration in the `profiles: <service>` section. If you use this approach, only the service(s) relevant to the plugin will be restarted rather than all services.
 
 ### Deck proxy
 
@@ -103,33 +100,13 @@ The example below configures the [`pf4jStagePlugin`](https://github.com/spinnake
 
 ```yaml
 spec:
-  # spec.spinnakerConfig - This section is how to specify configuration spinnaker
   spinnakerConfig:
-    # spec.spinnakerConfig.config - This section contains the contents of a deployment found in a halconfig .deploymentConfigurations[0]
-    config:
-      spinnaker:
-        extensibility:
-          plugins:
-            Armory.RandomWaitPlugin:
-              enabled: true
-              version: 1.1.14
-              extensions:
-                id: armory.randomWaitStage
-                enabled: true
-                config:
-                  defaultMaxWaitTime: 15
-          repositories:
-            examplePluginsRepo:
-              id: examplePluginsRepo
-              url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
-
-
     # spec.spinnakerConfig.profiles - This section contains the YAML of each service's profile
     profiles:
-      gate:    # is the contents of ~/.hal/default/profiles/gate.yml
+      gate:
         spinnaker:
           extensibility:
-            deck-proxy:
+            deck-proxy: # you need this for plugins with a Deck component
               enabled: true
               plugins:
                 Armory.RandomWaitPlugin:
@@ -138,4 +115,20 @@ spec:
             repositories:
               examplePluginsRepo:
                 url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
+      orca:
+        spinnaker:
+          extensibility:
+           plugins:
+             Armory.RandomWaitPlugin:
+              enabled: true
+              version: 1.1.14
+              extensions:
+               id: armory.randomWaitStage
+               enabled: true
+               config:
+                 defaultMaxWaitTime: 15
+           repositories:
+             examplePluginsRepo:
+              id: examplePluginsRepo
+              url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
 ```

--- a/content/en/docs/plugin-guide/pf4j-deploy-example.md
+++ b/content/en/docs/plugin-guide/pf4j-deploy-example.md
@@ -31,41 +31,10 @@ Each plugin should provide configuration information. The `pf4jStagePlugin` has 
 
 **This guide assumes you are using Armory installed by the Armory Operator in `basic` mode.** Add plugin configuration in the `/spinnaker-operator/deploy/spinnaker/basic/SpinnakerService.yml` manifest file. Complete configuration information is in the _Operator Reference_ Plugins [section]({{< ref "plugins" >}}).
 
-You can configure the plugin in either the `spec.spinnakerConfig.config.spinnaker.extensibility.plugins` or the `spec.spinnakerConfig.profiles.<service>` sections of the manifest.
-
-### `spec.spinnakerConfig.config.spinnaker.extensibility.plugins`
-
-- You can put configuration in this section when the plugin extends multiple services.
-- All Spinnaker services restart when you apply the manifest.
-
-For example:
-
-```yaml
-spec:
-  # spec.spinnakerConfig - This section is how to specify configuration spinnaker
-  spinnakerConfig:
-    # spec.spinnakerConfig.config - This section contains the contents of a deployment found in a halconfig .deploymentConfigurations[0]
-    config:
-      spinnaker:
-        extensibility:
-          plugins:
-            Armory.RandomWaitPlugin:
-              enabled: true
-              version: 1.1.14
-              extensions:
-                id: armory.randomWaitStage
-                enabled: true
-                config:
-                  defaultMaxWaitTime: 15
-          repositories:
-            examplePluginsRepo:
-              id: examplePluginsRepo
-              url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
-```
 
 ### `spec.spinnakerConfig.profiles.<service>`
 
-Put configuration in the `service` that the plugin extends when you do not want all Spinnaker services to restart when you apply the manifest.
+Put configuration in the `service` that the plugin extends.  Only the impacted service will restart when you apply the manifest.
 
 Example:
 
@@ -95,47 +64,7 @@ spec:
 
 ### Deck proxy
 
-You need to configure a `deck-proxy` in Gate if your plugin has a Deck component. Locate the `profiles` section in your `SpinnakerService.yml` and add the proxy information to the `gate` section. The example below shows the plugin configured in `spec.spinnakerConfig.config.spinnaker.extensibility.plugins` and the Deck proxy in the `spec.spinnakerConfig.profiles.gate` section.
-
-```yaml
-spec:
-  # spec.spinnakerConfig - This section is how to specify configuration spinnaker
-  spinnakerConfig:
-    # spec.spinnakerConfig.config - This section contains the contents of a deployment found in a halconfig .deploymentConfigurations[0]
-    config:
-      spinnaker:
-        extensibility:
-          plugins:
-            Armory.RandomWaitPlugin:
-              enabled: true
-              version: 1.1.14
-              extensions:
-                id: armory.randomWaitStage
-                enabled: true
-                config:
-                  defaultMaxWaitTime: 15
-          repositories:
-            examplePluginsRepo:
-              id: examplePluginsRepo
-              url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
-
-    # spec.spinnakerConfig.profiles - This section contains the YAML of each service's profile
-    profiles:
-      gate: # is the contents of ~/.hal/default/profiles/gate.yml
-        spinnaker:
-          extensibility:
-            deck-proxy:
-              enabled: true
-              plugins:
-                Armory.RandomWaitPlugin:
-                  enabled: true
-                  version: 1.1.14
-            repositories:
-              examplePluginsRepo:
-                url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
-```
-
-This example shows plugin configuration in the `spec.spinnakerConfig.profiles` section and the Deck proxy in the `spec.spinnakerConfig.profiles.gate` section:
+You need to configure a `deck-proxy` in Gate if your plugin has a Deck component. Locate the `profiles` section in your `SpinnakerService.yml` and add the proxy information to the `gate` section. This example shows plugin configuration in the `spec.spinnakerConfig.profiles` section and the Deck proxy in the `spec.spinnakerConfig.profiles.gate` section:
 
 ```yaml
 spec:


### PR DESCRIPTION
Remove references to configuring a plugin in spec.spinnakerConfig.config because the Halyard bug still hasn't been fixed (https://armory.atlassian.net/browse/PLUG-391).  