### PR TITLE
fix(docs): remove duplicate -n from example command

### DIFF
--- a/content/en/docs/spinnaker-user-guides/policy-engine-use.md
+++ b/content/en/docs/spinnaker-user-guides/policy-engine-use.md
@@ -80,7 +80,7 @@ kubectl -n <opaServerNamespace> create configmap manual-judgment --from-file=man
 After you create the policy ConfigMap, apply a label to it:
 
 ```
-kubectl -n <opaServerNamespace> label configmap manual-judgment openpolicyagent.org/policy=rego -n opa
+kubectl -n <opaServerNamespace> label configmap manual-judgment openpolicyagent.org/policy=rego
 ```
 
 This label corresponds to the label you add in the [example manifest]({{< ref "policy-engine-enable#using-configmaps-for-opa-policies" >}}. The example ConfigMap creates an OPA server and, by extension, the Policy Engine that only checks ConfigMaps with the correct label. This improves performance.


### PR DESCRIPTION
only one namespace flag is needed. two is just being silly. don't be silly.