### PR TITLE
docs(migration): fix code blocks

### DIFF
--- a/content/en/docs/Overview/fiat-permissions-overview.md
+++ b/content/en/docs/Overview/fiat-permissions-overview.md
@@ -104,7 +104,7 @@ The following sections describe some of the roles from the role matrix example i
 
 The configuration for `fiat-admin` in the `fiat-local.yml` file looks like the following snippet:
 
-```
+```yaml
 admin:
   roles:
     - fiat-admin
@@ -116,7 +116,7 @@ admin:
 
 The Halconfig snippet for configuring access to `dev-infra` based on our mapping exercise looks similar to the following:
 
-```
+```yaml
 accounts:
 - name: dev-infra
   permissions:
@@ -141,7 +141,7 @@ For information about how to configure permissions for Clouddriver accounts, see
 
 `build1` is a Jenkins deployment used for CI in this example. The Halconfig for controlling access to `build1` looks similar to the following snippet:
 
-```
+```yaml
 ci:
   jenkins:
     enabled: true
@@ -200,7 +200,7 @@ content-type   | `application/json;charset=UTF-8`
 
 The API call returns information about the apps. Refer to the `name` and `permissions` sections to find your applications and the corresponding permissions:
 
-```
+```json
 {
     ...
     "name": "app2",
@@ -230,14 +230,14 @@ Verifying the permissions for service accounts requires access to the Front50 an
 
 List all the service accounts with the following command (from the Front50 pod):
 
-```
+```bash
 export FRONT50=http://spin-front50:8080
 curl -s $FRONT50/serviceAccounts
 ```
 
 Check user or service account permissions for all of Spinnaker (from the Fiat pod):
 
-```
+```bash
 export FIAT=http://spin-fiat:7003
 curl -s $FIAT/authorize/$user-or-service-account
 ```

--- a/content/en/docs/armory-admin/Secrets/_index.md
+++ b/content/en/docs/armory-admin/Secrets/_index.md
@@ -27,13 +27,13 @@ We can now store secrets (tokens, passwords, sensitive files) separately from th
 
 When referencing string secrets (passwords, tokens) in configs, use the following general format:
 
-```
+```yaml
 encrypted:<secret engine>!<key1>:<value1>!<key2>:<value2>!...
 ```
 
 When referencing files, the same parameters are used but with the `encryptedFile` prefix:
 
-```
+```yaml
 encryptedFile:<secret engine>!<key1>:<value1>!<key2>:<value2>!...
 ```
 

--- a/content/en/docs/armory-admin/Secrets/secrets-aws-sm.md
+++ b/content/en/docs/armory-admin/Secrets/secrets-aws-sm.md
@@ -13,13 +13,13 @@ You can reference a KeyStore or KeyStore password stored in AWS Secrets Manager.
 
 **Keystore**
 
-```
+```yaml
   keyStore: encryptedFile:secrets-manager!r:<some region>!s:<secret name>
 ```
 
 **Keystore password**
 
-```
+```yaml
   keyStorePassword: encrypted:secrets-manager!r:<some region>!s:<secret name>!k:some-key
 ```
 
@@ -32,6 +32,6 @@ You can reference a KeyStore or KeyStore password stored in AWS Secrets Manager.
 
 For example, the following example references a KeyStore stored in `us-west-2`:
 
-```
+```yaml
 encryptedFile:secrets-manager!r:us-west-2!s:dev--cert
 ```

--- a/content/en/docs/armory-admin/Secrets/secrets-gcs.md
+++ b/content/en/docs/armory-admin/Secrets/secrets-gcs.md
@@ -28,17 +28,19 @@ github:
 ## Referencing secrets
 Now that secrets are securely stored in the bucket, you reference them in your config files with the following format:
 
-```
+```yaml
 encrypted:gcs!b:<bucket>!f:<path to file>!k:<optional yaml key>
 ```
 
 
 For example, to reference `github.password` from the file above, use:
-```
+
+```yaml
 encrypted:gcs!b:mybucket!f:spinnaker-secrets.yml!k:github.password
 ```
 
 To reference the content of our kubeconfig file:
-```
+
+```yaml
 encrypted:gcs!f:mykubeconfig!b:mybucket
 ```

--- a/content/en/docs/armory-admin/Secrets/secrets-kubernetes.md
+++ b/content/en/docs/armory-admin/Secrets/secrets-kubernetes.md
@@ -46,22 +46,22 @@ For more information on how to create secrets in Kubernetes refer to the [offici
 
 You reference secret values in your config with the following format:
 
-```
+```yaml
 encrypted:k8s!n:<secret name>!k:<secret key>
 ```
 
 Similarly you can reference secret files:
 
-```
+```yaml
 encryptedFile:k8s!n:<secret name>!k:<secret key>
 ```
 
 For example, to reference the GitHub token:
-```
+```yaml
 encrypted:k8s!n:spin-secrets!k:github-token
 ```
 
 And to reference the content of our kubeconfig file:
-```
+```yaml
 encryptedFile:k8s!n:spin-secrets!k:kubeconfig-prod
 ```

--- a/content/en/docs/armory-admin/Secrets/secrets-s3.md
+++ b/content/en/docs/armory-admin/Secrets/secrets-s3.md
@@ -30,24 +30,24 @@ Note: *You could choose to store the password under different keys than `github.
 ### Storing sensitive files
 Some Spinnaker configuration uses information stored as files. For example, upload the `kubeconfig` file of your Kubernetes account directly to `mybucket/mykubeconfig`:
 
-```
+```yaml
 aws s3 cp /path/to/mykubeconfig s3://mybucket/mykubeconfig
 ```
 
 ## Referencing secrets
 Now that secrets are safely stored in the bucket, you reference them from your config files with the following format. The S3 specific parameters (`r:<region>`, `b:<bucket>`, etc) can be in any order:
 
-```
+```yaml
 encrypted:s3!r:<region>!b:<bucket>!f:<path to file>!k:<optional yaml key>
 ```
 
 
 For example, to reference `github.password` from the file above, we'll use:
-```
+```yaml
 encrypted:s3!r:us-west-2!b:mybucket!f:spinnaker-secrets.yml!k:github.password
 ```
 
 And to reference the content of our kubeconfig file:
-```
+```yaml
 encryptedFile:s3!f:mykubeconfig!r:us-west-2!b:mybucket
 ```

--- a/content/en/docs/armory-admin/Secrets/secrets-vault.md
+++ b/content/en/docs/armory-admin/Secrets/secrets-vault.md
@@ -81,7 +81,7 @@ spec:
 
 **Halyard**
 
-```
+```bash
 hal armory secrets vault enable
 hal armory secrets vault edit \
     --auth-method TOKEN \
@@ -111,7 +111,7 @@ Halyard will need access to the Vault server in order to decrypt secrets for val
 ### Halyard locally or in Docker
 If you're running Halyard locally, you can use Token auth method. Set your `VAULT_TOKEN` environment variable and add the secrets block to `halyard.yml` like so:
 
-```
+```yaml
 halyard:
   halconfig:
     ...
@@ -129,14 +129,14 @@ secrets:
 
 Then, restart the daemon if this is the first time you are configuring the Token auth method:
 
-```
+```bash
 hal shutdown
 ```
 Your next hal command automatically starts the daemon if you're running Halyard locally. If it's running within a Docker container, mount the volume containing the updated `halyard.yml` and restart the container.
 
 ### Halyard in Kubernetes
 Or if you're running Halyard in Kubernetes, you can have Halyard use Kubernetes auth:
-```
+```yaml
 halyard:
   halconfig:
     ...
@@ -158,17 +158,17 @@ Restart the pod so that Halyard restarts with your new config.
 ## Storing secrets
 To store a file, simply prepend the file path with `@`. It accepts relative paths but cannot resolve `~`:
 
-```
+```bash
 vault kv put secret/spinnaker/kubernetes config=@path/to/kube/config
 ```
 The command above stores a single key-value pair at the `secret/spinnaker/kubernetes` path. **Any updates to that path will replace the existing values even if using a different key!** In order to store multiple secrets at the same path, it must be done in a single command, like so:
-```
+```bash
 vault kv put secret/spinnaker/github password=<password> token=<token>
 ```
 Otherwise, just store different secrets at different paths, like we're doing in these examples.
 
 Make sure to base64 encode any binary files:
-```
+```bash
 base64 -i saml.jks -o saml.b64
 vault kv put secret/spinnaker/saml base64keystore=@saml.b64
 ```
@@ -178,7 +178,7 @@ vault kv put secret/spinnaker/saml base64keystore=@saml.b64
 
 Now that secrets are safely stored in Vault, reference them in config files with the following syntax:
 
-```
+```yaml
 encrypted:vault!e:<secret engine>!p:<path to secret>!k:<key>!b:<is base64 encoded?>
 ```
 

--- a/content/en/docs/armory-admin/Secrets/vault-k8s-configuration.md
+++ b/content/en/docs/armory-admin/Secrets/vault-k8s-configuration.md
@@ -57,7 +57,7 @@ $ kubectl -n default apply --filename vault-auth-service-account.yml
 
 **spinnaker-kv-ro.hcl**
 
-```
+```hcl
 # For K/V v1 secrets engine
 path "secret/spinnaker/*" {
     capabilities = ["read", "list"]

--- a/content/en/docs/armory-admin/api-endpoint.md
+++ b/content/en/docs/armory-admin/api-endpoint.md
@@ -514,13 +514,13 @@ The mechanism to achieve this will depend on what type of Ingress you are using.
 
 * If you are using an NGINX Ingress Controller, you will need to add these annotations to the `Ingress` resource that is set up for Deck and gate:
 
-  ```
+  ```yaml
   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   ```
 
 * If you are using the Amazon AWS ALB Ingress Controller, you will need to add these annotations to the `Ingress` resource that is set up for Deck and gate:
 
-  ```
+  ```yaml
   alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
   alb.ingress.kubernetes.io/healthcheck-protocol: "HTTPS"
   ```

--- a/content/en/docs/armory-admin/armory-halyard-reference.md
+++ b/content/en/docs/armory-admin/armory-halyard-reference.md
@@ -16,7 +16,7 @@ If this is your first time using Halyard to install Spinnaker we recommend that 
 
 
 #### Usage
-```
+```bash
 hal [parameters] [subcommands]
 ```
 ### Global Parameters
@@ -45,7 +45,7 @@ hal [parameters] [subcommands]
 Armory-specific commands are described here.
 
 #### Usage
-```
+```bash
 hal armory [subcommands]
 ```
 
@@ -61,7 +61,7 @@ hal armory [subcommands]
 Configure diagnostics reporting
 
 #### Usage
-```
+```bash
 hal armory diagnostics [parameters] [subcommands]
 ```
 
@@ -80,7 +80,7 @@ hal armory diagnostics [parameters] [subcommands]
 Disable diagnostics
 
 #### Usage
-```
+```bash
 hal armory diagnostics disable [parameters]
 ```
 
@@ -95,7 +95,7 @@ hal armory diagnostics disable [parameters]
 Edit diagnostics settings
 
 #### Usage
-```
+```bash
 hal armory diagnostics edit [parameters]
 ```
 
@@ -129,7 +129,7 @@ spec:
 Enable diagnostics
 
 #### Usage
-```
+```bash
 hal armory diagnostics enable [parameters]
 ```
 
@@ -144,7 +144,7 @@ hal armory diagnostics enable [parameters]
 Configure Dinghy pipelines as code
 
 #### Usage
-```
+```bash
 hal armory dinghy [parameters] [subcommands]
 ```
 
@@ -164,7 +164,7 @@ hal armory dinghy [parameters] [subcommands]
 Disable Dinghy
 
 #### Usage
-```
+```bash
 hal armory dinghy disable [parameters]
 ```
 
@@ -179,7 +179,7 @@ hal armory dinghy disable [parameters]
 Edit Dinghy settings
 
 #### Usage
-```
+```bash
 hal armory dinghy edit [parameters]
 ```
 
@@ -243,7 +243,7 @@ spec:
 Enable Dinghy
 
 #### Usage
-```
+```bash
 hal armory dinghy enable [parameters]
 ```
 
@@ -257,7 +257,7 @@ hal armory dinghy enable [parameters]
 Configure Dinghy to send processing results to a Slack channel  (Halyard >= 1.6.3)
 
 #### Usage
-```
+```bash
 hal armory dinghy slack [enable|disable]
 ```
 
@@ -275,7 +275,7 @@ hal armory dinghy slack [enable|disable]
 Enable Slack notifications from Dinghy (Halyard >= 1.6.3)
 
 #### Usage
-```
+```bash
 hal armory dinghy slack enable [parameters]
 ```
 
@@ -304,7 +304,7 @@ hal armory dinghy slack disable [parameters]
 Enable or disable webhook secrets validation in GitHub. This does not support other providers. If this option is enabled, all GitHub webhooks will be validated.  (Halyard >= 1.8.4)
 
 #### Usage
-```
+```bash
 hal armory dinghy webhooksecrets <provider> [ enable | disable]
 ```
 
@@ -314,7 +314,7 @@ hal armory dinghy webhooksecrets <provider> [ enable | disable]
 Add or edit webhook secrets validation in GitHub. This does not support other providers.  (Halyard >= 1.8.4)
 
 #### Usage
-```
+```bash
 hal armory dinghy webhooksecrets <provider> edit [parameters]
 ```
 
@@ -330,7 +330,7 @@ hal armory dinghy webhooksecrets <provider> edit [parameters]
 List webhook secrets validations for GitHub. This does not support other providers. (Halyard >= 1.8.4)
 
 #### Usage
-```
+```bash
 hal armory dinghy webhooksecrets <provider> list [parameters]
 ```
 
@@ -346,7 +346,7 @@ hal armory dinghy webhooksecrets <provider> list [parameters]
 Delete webhook secrets validations for GitHub. This does not support other providers. Provide at least one parameter for the command to delete the webhook secrets.  (Halyard >= 1.8.4)
 
 #### Usage
-```
+```bash
 hal armory dinghy webhooksecrets <provider> delete [parameters]
 ```
 
@@ -363,7 +363,7 @@ hal armory dinghy webhooksecrets <provider> delete [parameters]
 Runs Armory installer
 
 #### Usage
-```
+```bash
 hal armory init [parameters]
 ```
 
@@ -381,7 +381,7 @@ hal armory init [parameters]
 Configure secrets management
 
 #### Usage
-```
+```bash
 hal armory secrets [subcommands] [parameters]
 ```
 
@@ -398,7 +398,7 @@ hal armory secrets [subcommands] [parameters]
 Configure settings for secrets management with Vault in the Spinnaker services. [See our documentation for configuring Halyard itself to use Vault]({{< ref "secrets-vault#configuring-halyard-to-use-vault-secrets" >}}).
 
 #### Usage
-```
+```bash
 hal armory secrets vault [subcommands] [parameters]
 ```
 
@@ -417,7 +417,7 @@ hal armory secrets vault [subcommands] [parameters]
 Disable Vault secret engine
 
 #### Usage
-```
+```bash
 hal armory secrets vault disable [parameters]
 ```
 
@@ -431,7 +431,7 @@ hal armory secrets vault disable [parameters]
 Edit Vault secret engine settings
 
 #### Usage
-```
+```bash
 hal armory secrets vault edit [parameters]
 ```
 
@@ -469,7 +469,7 @@ spec:
 Enable Vault secret engine
 
 #### Usage
-```
+```bash
 hal armory secrets vault enable [parameters]
 ```
 

--- a/content/en/docs/armory-admin/authn-github.md
+++ b/content/en/docs/armory-admin/authn-github.md
@@ -27,7 +27,7 @@ This post describes how to configure GitHub and Spinnaker to use GitHub as an OA
 
 Add the following snippet to your `SpinnakerService` manifest under the `spec.spinnakerConfig.config.security.authn` level:
 
-```
+```yaml
 oauth2:
     enabled: true
     client:
@@ -44,7 +44,7 @@ For additional configuration options review the [Spinnaker Operator Reference]({
 
 Run the following commands in Halyard with your Client ID and Client Secret.
 
-```shell
+```bash
 CLIENT_ID=a08xxxxxxxxxxxxx93
 CLIENT_SECRET=6xxxaxxxxxxxxxxxxxxxxxxx59
 PROVIDER=github

--- a/content/en/docs/armory-admin/diagnostics-configure.md
+++ b/content/en/docs/armory-admin/diagnostics-configure.md
@@ -13,14 +13,14 @@ When you engage Armory Support, the support team might ask you about enabling Ar
 
 Here's the Halyard command to enable this feature:
 
-```
+```bash
 hal armory diagnostics enable
 hal armory diagnostics edit --logging-enabled=true
 ```
 
 And similarly, to disable it:
 
-```
+```bash
 hal armory diagnostics disable
 hal armory diagnostics edit --logging-enabled=false
 ```

--- a/content/en/docs/armory-admin/dinghy-enable.md
+++ b/content/en/docs/armory-admin/dinghy-enable.md
@@ -437,7 +437,7 @@ spec:
 
 Create `.hal/default/profiles/dinghy-local.yml` with the following config:
 
-```
+```bash
 Logging:
   Level: INFO
 ```

--- a/content/en/docs/armory-admin/exposing-spinnaker.md
+++ b/content/en/docs/armory-admin/exposing-spinnaker.md
@@ -86,7 +86,7 @@ hal deploy apply
 ```
 
 If you have a DNS in mind, set it up like the following example:
-```
+```bash
 spinnaker-gate.armory.io CNAME --> (spin-gate-public dns) aaaaa-1111.us-west-2.elb.amazonaws.com
 spinnaker.armory.io      CNAME --> (spin-deck-public dns) aaaaa-2222.us-west-2.elb.amazonaws.com
 ```
@@ -162,7 +162,7 @@ hal deploy apply
 
 If your Armory installation will be using authentication and you expect to scale the API server (Gate) beyond more than one instance you'll want to enable sticky sessions. This will ensure that clients will connect and authenticate with the same server each time. Otherwise, you may be forced to reauthenticate if you get directed to a new server. To enable sticky sessions, you'll want to enable session affinity on the Gate service created above.
 
-```
+```bash
 GATE_SVC=<spin-gate/spin-gate-public>  # spin-gate if using Spinnaker Operator, spin-gate-public if using Halyard
 kubectl -n ${NAMESPACE} patch service/$GATE_SVC --patch '{"spec": {"sessionAffinity": "ClientIP"}}'
 ```
@@ -201,7 +201,7 @@ kubectl -n spinnaker apply -f spinnakerservice.yml
 
 After a few seconds you can view which ports were opened in EKS worker nodes, you'll need them in the next step:
 
-```
+```bash
 DECK_PORT=$(kubectl get service spin-deck -o jsonpath='{.spec.ports[0].nodePort}')
 GATE_PORT=$(kubectl get service spin-gate -o jsonpath='{.spec.ports[0].nodePort}')
 ```
@@ -225,7 +225,7 @@ kubectl -n ${NAMESPACE} expose service spin-deck --type NodePort \
 
 After a few seconds you can view which ports were opened in EKS worker nodes, you'll need them in the next step:
 
-```
+```bash
 DECK_PORT=$(kubectl get service spin-deck-nodeport -o jsonpath='{.spec.ports[0].nodePort}')
 GATE_PORT=$(kubectl get service spin-gate-nodeport -o jsonpath='{.spec.ports[0].nodePort}')
 ```

--- a/content/en/docs/armory-admin/generating-certificates.md
+++ b/content/en/docs/armory-admin/generating-certificates.md
@@ -15,7 +15,7 @@ You need a recent version of OpenSSL.
 
 Generate a key for our certificate authority:
 
-```
+```bash
 openssl genrsa -aes256 -passout pass:TRUSTSTORE_PASS -out ca.key 2048
 ```
 
@@ -25,7 +25,7 @@ Replace `TRUSTSTORE_PASS` with your own CA password.
 
 Next, generate the certificate of the CA:
 
-```
+```bash
 openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.pem -passin pass:TRUSTSTORE_PASS -subj /C=US/ST=California/O=Acme Corp/OU=Devops/CN=mydomain.com"
 ```
 
@@ -35,7 +35,7 @@ Replace the values of the `subj` parameter with your own. Only the `CN` part is 
 
 Import the `ca.pem` file you generated into a Java truststore:
 
-```
+```bash
 keytool -importcert -storetype PKCS12 -keystore services/ca.p12 -storepass TRUSTSTORE_PASS -alias ca -file ca.pem -noprompt
 ```
 
@@ -45,7 +45,7 @@ The `CN` attribute must match the hostname of the service. It will generally be 
 
 Generate the keystore with the following commands:
 
-```
+```bash
 openssl genrsa -aes256 -passout pass:KEY_PASSWORD -out svc.key 2048
 openssl req -new -key svc.key -out svc.csr -subj /C=US/CN=spin-svc.spinnaker -passin pass:KEY_PASSWORD
 openssl x509 -req -in svc.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out svc.crt -days 3649 -sha256 -passin pass:TRUSTSTORE_PASS
@@ -61,6 +61,7 @@ openssl x509 -req -sha256 -in svc.csr -CA ca.pem -CAkey ca.key -CAcreateserial -
 ```
 
 The `svc-cert.ext` referenced in the command should contain the following (example for Clouddriver):
+
 ```
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
@@ -77,7 +78,7 @@ DNS.2 = spin-clouddriver
 
 ## Generating keys and certificates (Golang)
 
-```
+```bash
 openssl genrsa -aes256 -passout pass:KEY_PASSWORD -out svc.key 2048
 openssl req -new -key svc.key -out svc.csr -subj /C=US/CN=spin-svc.spinnaker -passin pass:KEY_PASSWORD
 openssl x509 -req -in svc.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out svc.crt -days 3650 -sha256 -passin pass:TRUSTSTORE_PASS

--- a/content/en/docs/armory-admin/hostname-deck-gate-configure.md
+++ b/content/en/docs/armory-admin/hostname-deck-gate-configure.md
@@ -111,18 +111,18 @@ directory.
 
 1. Update Deck's URL using Halyard command
 
-   ```
+   ```bash
    hal config security ui edit --override-base-url https://spinnaker.example.com
    ```
 
-1. Update Gate's URL using Halyard command
+2. Update Gate's URL using Halyard command
 
-   ```
+   ```bash
    hal config security api edit --override-base-url https://spinnaker.example.com/api/v1
    ```
 
-1. Apply the Spinnaker Configuration changes using Halyard command
+3. Apply the Spinnaker Configuration changes using Halyard command
 
-   ```
+   ```bash
    hal deploy apply
    ```

--- a/content/en/docs/armory-admin/integrations-sumologic.md
+++ b/content/en/docs/armory-admin/integrations-sumologic.md
@@ -24,7 +24,8 @@ The Spinnaker Sumo Logic App uses echo logs that output event information from S
 ### Query sample
 
 The following sample query generates a dashboard to monitor pipelines starting:  
-```
+
+```json
 _sourceCategory="dev/sales-demo-cluster/echo" and _collector="Spinnaker Instance"  orca pipeline starting
 | json field=_raw "content.execution.status","content.execution.application","details.type","content.execution.name","content.execution.trigger.type","content.execution.authentication.user" as status,application,logType,pipeline, triggerType, user nodrop
 | where logType = "orca:pipeline:starting"

--- a/content/en/docs/armory-admin/jenkins-connect.md
+++ b/content/en/docs/armory-admin/jenkins-connect.md
@@ -92,7 +92,7 @@ hal config ci jenkins master add <jenkins-master-name> \
     --password # You will be prompted for your Jenkins API token interactively
 ```
 
-Apply your changes using ```hal deploy apply```.
+Apply your changes using `hal deploy apply`.
 
 ## Troubleshooting Authentication / Connectivity
 

--- a/content/en/docs/armory-admin/mtls-configure.md
+++ b/content/en/docs/armory-admin/mtls-configure.md
@@ -119,7 +119,7 @@ spec:
 
 This can be done by adding the following to each service under `<deploy>/service-settings/<service>.yml`:
 
-```
+```yaml
 kubernetes:
   useTcpProbe: true
 ```

--- a/content/en/docs/armory-admin/packer.md
+++ b/content/en/docs/armory-admin/packer.md
@@ -180,7 +180,8 @@ If you'd like to add additional Packer template or script files, you can add the
 Add any Packer template and supporting scripts as string-formatted entries under the `spec.spinnakerConfig.files` section of the `SpinnakerService` config.
 
 If you have a template named example-packer-config.json containing the following:
-```
+
+```json
 {
   "packerSetting" : "someValue"
 }
@@ -188,14 +189,14 @@ If you have a template named example-packer-config.json containing the following
 
 and a script file named my-custom-script.sh containing the following:
 
-```
+```bash
 #!/bash/bash -e
 echo "Hello world!"
 ```
 
 make the following entries into the `SpinnakerService` config:
 
-```
+```yaml
 files:
   profiles__rosco__packer__example-packer-config.json: |
     {

--- a/content/en/docs/armory-admin/policy-engine-enable.md
+++ b/content/en/docs/armory-admin/policy-engine-enable.md
@@ -268,7 +268,7 @@ Once Spinnaker finishes redeploying, Policy Engine can evaluate pipelines based 
 
 You can make debugging issues with runtime validation for your pipelines easier by adjusting the logging level to `DEBUG`. Add the following snippet to `hal/default/profiles/spinnaker-local.yml`:
 
-```
+```yaml
 logging:
   level:
     com.netflix.spinnaker.clouddriver.kubernetes.OpaDeployDescriptionValidator: DEBUG
@@ -285,7 +285,7 @@ From this information, you can extract the exact JSON being enforced. You can us
 
 Note: The following ConfigMap is missing some annotations that Spinnaker adds later.
 
-```
+```yaml
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/content/en/docs/armory-admin/rate-limit.md
+++ b/content/en/docs/armory-admin/rate-limit.md
@@ -25,7 +25,7 @@ Spinnaker queries your Cloud Provider (AWS, GCP, Azure, Kubernetes, etc) frequen
 
 Below is an example configuration for global rate limits for all services that you would place in your `SpinnakerService` manifest under section `spec.spinnakerConfig.profiles.clouddriver` if using the Operator, or in `~/.hal/<deployment-name>/profiles/clouddriver-local.yml` if using Halyard:
 
-```yml
+```yaml
 serviceLimits:
   defaults:
     rateLimit: 10.0   # default max req/second
@@ -33,7 +33,7 @@ serviceLimits:
 
 If you have multiple Cloud Providers, you can limit each one differently:
 
-```yml
+```yaml
 serviceLimits:
   cloudProviderOverrides:
     aws:
@@ -42,7 +42,7 @@ serviceLimits:
 
 You can provide account specific overrides as well in case you have significantly more resources in one account while others have less:
 
-```yml
+```yaml
 serviceLimits:
   accountOverrides:
     my-test:
@@ -54,6 +54,7 @@ serviceLimits:
 And finally, you can have more fine-grained control for particular AWS endpoints that might have a different rate limits.
 
 We've found that this formula works pretty well:
+
 ```
 max_req_second = num_of_x_resources / clouddriver_30s_poll_interval
 ```
@@ -62,7 +63,7 @@ For example, if we have 90 load balancers and clouddriver polls every 30 seconds
 
 Here's the list of rate limits you can adjust created from [AmazonClientProvider.java@v5.36.0](https://github.com/spinnaker/clouddriver/blob/v5.36.0/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java) on 05/14/2019 by using the regex `\w+\.class`:
 
-```yml
+```yaml
 serviceLimits:
   implementationLimits:
     AWSApplicationAutoScaling:

--- a/content/en/docs/armory-admin/terraform-enable-integration.md
+++ b/content/en/docs/armory-admin/terraform-enable-integration.md
@@ -132,13 +132,17 @@ spec:
 **Halyard**
 
 1. Enable Git Repo as an artifact provider:
-   ```
+   
+   ```bash
    hal config artifact gitrepo enable
    ```
+
 2. Add the Git Repo account:
-   ```
+   
+   ```bash
    hal config artifact gitrepo account add gitrepo-for-terraform --token
    ```
+
    The command prompts you for your Git Repo PAT.
 
 For more configuration options, see [Git Repo](https://spinnaker.io/setup/artifacts/gitrepo/).
@@ -183,11 +187,11 @@ spec:
 
 1. Enable GitHub as an artifact provider:
 
-   ```
+   ```bash
    hal config artifact github enable
    ```
 2. Add the GitHub account:
-   ```
+   ```bash
    hal config artifact github account add github-for-terraform --token
    ```
    The command prompts you for your GitHub PAT.
@@ -267,7 +271,7 @@ This example manifest also enables the Terraform Integration UI.
 
 **Halyard**
 
-```
+```bash
 hal armory terraform enable
 ```
 
@@ -293,7 +297,7 @@ End users can use remote backends by configuring the Terraform Integration stage
 
 To enable support, add the following config to your `terraformer-local.yml` file in the `.hal/default/profiles` directory:
 
-```
+```bash
 terraform:
   remoteBackendSupport: true
 ```
@@ -312,7 +316,7 @@ See the example manifest in [Enabling the Terraform Integration](#enabling-the-t
 
 Edit `~/.hal/default/profiles/settings-local.js` and add the following:
 
-```
+```js
 window.spinnakerSettings.feature.terraform = true;
 ```
 
@@ -470,7 +474,7 @@ Configure profiles that users can select when creating a Terraform Integration s
 3. Save the file.
 4. Apply your changes:
 
-   ```
+   ```bash
    hal deploy apply
    ```
 

--- a/content/en/docs/armory-admin/travis-connect.md
+++ b/content/en/docs/armory-admin/travis-connect.md
@@ -17,7 +17,7 @@ there are a few "gotchas" to watch out for.
 
 First, configure your Travis master:
 
-```
+```bash
 hal config ci travis master add Travis --address https://api.travis-ci.org --base-url https://travis-ci.org --github-token
 ```
 
@@ -30,7 +30,7 @@ For reference, you can look at the [Spinnaker docs](https://www.spinnaker.io/ref
 
 Next, enable Travis with Halyard:
 
-```
+```bash
 hal config ci travis enable
 ```
 
@@ -42,7 +42,7 @@ go into a CrashLoopBackoff state.  The fix for this is to go into your
 `<profile>/profiles/` directory and add (or update, if you already have one)
 `igor-local.yml`.  Add this section:
 
-```
+```bash
 artifact:
   decorator:
     enabled: true
@@ -54,7 +54,7 @@ artifact:
 If you want to be able to run Travis jobs as a stage in your pipeline, you'll
 need to enable the stage as well:
 
-```
+```bash
 hal config features edit --travis true
 ```
 

--- a/content/en/docs/armory-agent/agent-troubleshooting.md
+++ b/content/en/docs/armory-agent/agent-troubleshooting.md
@@ -76,5 +76,3 @@ Common errors:
 - For better availability, you can run Agent deployments in [different availability zones](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
 
 - Restarting the Agent won't cause direct outages provided it is limited in time (less than 30s). No operation can happen while no Agent is connected to Spinnaker. Caching is asynchronous and other operations are retried `kubesvc.operations.retry.maxRetries` times. Furthermore, restarts are generally fast and the Agent resumes where it left off.
-
-

--- a/content/en/docs/armory-agent/armory-agent-quick.md
+++ b/content/en/docs/armory-agent/armory-agent-quick.md
@@ -22,7 +22,7 @@ You modify the current Clouddriver deployment as well as add a new Kubernetes `S
 
 The easiest installation path is to modify an existing [`spinnakerservice.yaml`]({{< ref "operator-config" >}}) with [kustomize](https://kustomize.io/). To start, download additional manifests into the directory with your `SpinnakerService`:
 
-```
+```bash
 # AGENT_PLUGIN_VERSION is found in the compatibility matrix above
 curl https://armory.jfrog.io/artifactory/manifests/kubesvc-plugin/agent-plugin-$AGENT_PLUGIN_VERSION.tar.gz | tar -xJvf -
 ```

--- a/content/en/docs/installation/armory-halyard.md
+++ b/content/en/docs/installation/armory-halyard.md
@@ -23,7 +23,7 @@ Running Armory-extended Halyard in Docker is convenient and portable. The daemon
 
 You can start Armory-extended Halyard in a Docker container with the following command:
 
-```
+```bash
 docker run --name armory-halyard --rm \
     -v ~/.hal:/home/spinnaker/.hal \
     -v ~/.kube:/home/spinnaker/.kube \
@@ -45,7 +45,7 @@ else, you'll need to rename or symlink the file accordingly.
 Once Armory-extended Halyard is running, you can interact with it by opening a separate
 Terminal and running:
 
-```
+```bash
 docker exec -it armory-halyard bash
 ```
 
@@ -58,7 +58,8 @@ Armory-extended Halyard can also be installed as a Kubernetes `StatefulSet`. The
 ### Installing Daemon
 
 You can install Armory-extended Halyard with the following manifest:
-```
+
+```yaml
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -106,7 +107,7 @@ spec:
 ```
 
 Copy and paste the manifest into a file named halyard.yml, then deploy the above manifest (halyard.yml) into Kubernetes with the following command:
-```
+```bash
 kubectl apply -f halyard.yml
 ```
 > Note: This installs Halyard into the namespace 'halyard'
@@ -115,6 +116,6 @@ kubectl apply -f halyard.yml
 ### Running Halyard Commands
 
 Once the `StatefulSet` is ready - you can interact with it by running:
-```
+```bash
 kubectl -n halyard exec -ti statefulset/halyard bash
 ```

--- a/content/en/docs/installation/guide/air-gapped.md
+++ b/content/en/docs/installation/guide/air-gapped.md
@@ -19,13 +19,13 @@ If you are unable to access this bucket from the machine running Halyard, host t
 
 Your GCS or S3 compatible bucket needs to contain a `versions.yml` at the root of the bucket with the following information:
 
-```
-latestHalyard: 1.7.1
-latestSpinnaker: 2.16.0
+```yaml
+latestHalyard: {{< param halyard-armory-version >}}
+latestSpinnaker: {{< param armory-version >}}
 versions:
-- version: 2.16.0
-  alias: OSS Release 1.16.1
-  changelog: https://docs.armory.io/release-notes/armoryspinnaker_v2.16.0/
+- version: {{< param armory-version >}}
+  alias: OSS Release <ossVersion> # The corresponding OSS version can be found in the Release Notes
+  changelog: <Link to Armory Release Notes for this version>
   minimumHalyardVersion: 1.2.0
   lastUpdate: "1568853000000"
 ```
@@ -131,12 +131,12 @@ You can then upload the files you just downloaded to your storage. Make sure the
 
 **AWS**
 
-```
+```bash
 $ aws cp --recursive versions/ s3://myownbucket
 ```           
 **GCS**
 
-```
+```bash
 $ gsutil cp -m -r ...
 ```
 
@@ -188,11 +188,11 @@ kubectl apply -f manifest.yml
 Finally, to access the deployed Halyard environment, perform the following steps:
 
 1. Get the name for the Halyard pod:
-   ```
+   ```bash
    kubectl get pods
    ```
 2. Exec into the pod:
-   ```
+   ```bash
    kubectl exec -it {pod-name} /bin/bash
    ```
 

--- a/content/en/docs/installation/guide/configure-halyard.md
+++ b/content/en/docs/installation/guide/configure-halyard.md
@@ -9,7 +9,7 @@ aliases:
 
 Armory-extended Halyard can be configured via `/opt/spinnaker/config/halyard.yml`. If you run the Docker image, you can provide your own configuration by mounting the file or directory to the container. If you're running the Armory Operator, you can also configure the behavior of the internal Halyard by creating a Kubernetes ConfigMap and mounting it to the Halyard container.
 
-```
+```yaml
 halyard:
   halconfig:
     directory: <user's home directory>/.hal
@@ -34,7 +34,7 @@ Armory-extended Halyard stores all the versions in a public s3 bucket (`halconfi
 
 ### Using a different s3 bucket
 To use a different s3 bucket, you just need to change these two properties to point to your own bucket:
-```
+```yaml
 spinnaker:
   config:
     input:
@@ -45,12 +45,12 @@ spinnaker:
 ### Using a private s3 bucket
 By default Armory-extended Halyard will access version definitions and bills of materials without using the host's s3 credentials. You can force it to sign the s3 requests by adding:
 
-```
+```yaml
 spinnaker.config.input.anonymousAccess: false
 ```
 
 With that change, you'll need to pass AWS credentials to Halyard's daemon - for instance by specifying environment variables:
-```
+```bash
 docker run --name armory-halyard --rm \
     -e AWS_ACCESS_KEY_ID=<AWS account key> \
     -e AWS_SECRET_ACCESS_KEY=<AWS secret key> \
@@ -59,24 +59,22 @@ docker run --name armory-halyard --rm \
     -it docker.io/armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
 
-Replace `<Armory-extended Halyard version>` with the version of Halyard you want to run.
-
 ### Using a private s3 bucket with assume role
 
 Armory-extended Halyard can be configured to assume a specified role when accessing the bucket:
-```
+```yaml
 spinnaker.config.input.assumeRoleArn: <role arn to assume>
 ```
 
 ### Using an s3 compatible storage
 If you're using an s3 compatible storage such as minio, you can override the endpoint:
 
-```
+```yaml
 spinnaker.config.input.endpoint: http://192.168.1.1:9000
 ```
 
 You can also enable [path-style](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro) access with:
 
-```
+```yaml
 spinnaker.config.input.enablePathStyleAccess: true
 ```

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -235,7 +235,7 @@ gke-kubeconfig: |
 
 For the third option, the `gke-kubeconfig` file is copied to a bucket. Then the `config-patch.yml` references the location of that file for the `kubeconfig` file key like this:
 
-```
+```yaml
 kubeconfigFile: encryptedFile:gcs!b:bucketname!f:secrets/kubeconfig-gke
 ```
 

--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -822,7 +822,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 
 Get the external IP for the NGINX ingress controller:
 
-```
+```bash
 kubectl get svc -n ingress-nginx
 ```
 

--- a/content/en/docs/installation/guide/upgrade-oss-to-armory.md
+++ b/content/en/docs/installation/guide/upgrade-oss-to-armory.md
@@ -67,7 +67,7 @@ If Halyard is running locally on your workstation, then perform the following st
 
 3. Exec into the Halyard container
 
-   ```
+   ```bash
    docker exec -it armory-halyard bash
    ```
 
@@ -115,7 +115,7 @@ If Halyard is already running in a Docker container in your Docker daemon, you c
 
 3. Exec into the Halyard container:
 
-   ```
+   ```bash
    docker exec -it armory-halyard bash
    ```
 

--- a/content/en/docs/installation/guide/upgrade-spinnaker.md
+++ b/content/en/docs/installation/guide/upgrade-spinnaker.md
@@ -51,10 +51,10 @@ Then, apply your upgrade with `hal deploy apply`.
 Rolling an upgrade back is similar to upgrading Spinnaker:
 
 1. Select the version you want to rollback to:
-   ```
+   ```bash
    hal config edit --version <target_version>
    ```
 2. Apply the rollback:
-   ```
+   ```bash
    hal deploy apply
    ```   

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -491,7 +491,7 @@ There are two ways in which you can remove this ownership relationship so that A
 First, export Armory configuration settings to a format that Halyard understands:
 1. From the `SpinnakerService` manifest, copy the contents of `spec.spinnakerConfig.config` to its own file named `config`, and save it with the following structure:
 
-   ```
+   ```yaml
    currentDeployment: default
    deploymentConfigurations:
    - name: default
@@ -524,7 +524,7 @@ kubectl delete -f deploy/crds/
 
 Run the following script to remove ownership of Armory resources, where `NAMESPACE` is the namespace where Armory is installed:
 
-```
+```bash
 NAMESPACE=
 for rtype in deployment service
 do
@@ -536,7 +536,7 @@ done
 ```
 After the script completes, delete the Armory Operator and its CRDs from the Kubernetes cluster:
 
-```
+```bash
 kubectl delete -n <namespace> -f deploy/operator/<installation type>
 kubectl delete -f deploy/crds/
 ```

--- a/content/en/docs/release-notes/rn-armory-halyard/_index.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/_index.md
@@ -15,7 +15,7 @@ simple_list_reverse: true
 ## Halyard
 Armory-extended Halyard  is an extended version of Halyard that deploys Armory features. You can find the base OSS version:
 
-```
+```bash
 > hal --version
 1.4.1-rc8 (OSS 1.17.0-8a5b28e-stable3 build 8)
 ```

--- a/content/en/docs/spinnaker-user-guides/StaticBaselineJudge.md
+++ b/content/en/docs/spinnaker-user-guides/StaticBaselineJudge.md
@@ -22,7 +22,7 @@ To input the metric value needed, edit the config as JSON.
 
 Set the following property:
 
-```
+```yaml
 
 "extendedProperties": {
    "staticBaseline": 300
@@ -39,7 +39,7 @@ That means you can have multiple metrics in your Canary Config: ones that make u
 
 As an example of this, the following Canary Config has two metrics defined, one is setting the staticBaseline parameter and the other is not:
 
-```
+```yaml
 {
   "applications": [
     "training"

--- a/content/en/docs/spinnaker-user-guides/artifacts-docker-using.md
+++ b/content/en/docs/spinnaker-user-guides/artifacts-docker-using.md
@@ -60,6 +60,6 @@ You can reference the Docker tag that triggered the pipeline with the
 expression `${trigger['tag']}`, which may be all you need, as in this
 image spec line from a Kubernetes manifest:
 
-```
+```bash
 - image: "docker.io/armory/demoapp:${trigger['tag']}"
 ```

--- a/content/en/docs/spinnaker-user-guides/best-practices.md
+++ b/content/en/docs/spinnaker-user-guides/best-practices.md
@@ -49,8 +49,8 @@ One piece of "dynamic metadata" available to the EC2 instance, is the instance i
 
 You can issue an authentication by issuing the following:
 
-```
-$ vault auth-enable aws-ec2
+```bash
+vault auth-enable aws-ec2
 ```
 
 And then proceeding with any additional vault commands and execution that needs to happen.  These steps need to happen at startup you'll want add this script as a [base 64 encoded users-data in your deployment steps]({{< ref "deploying" >}}).

--- a/content/en/docs/spinnaker-user-guides/deploying.md
+++ b/content/en/docs/spinnaker-user-guides/deploying.md
@@ -245,7 +245,7 @@ UI to add block devices.
 
 ### Block devices definition
 
-```
+```json
 "blockDevices": [
   {
     "deleteOnTermination": [true|false],
@@ -257,7 +257,7 @@ UI to add block devices.
 ]
 ```
 ### Example of additional block devices
-```
+```json
 "clusters": [
         {
           "account": "my-aws-account",

--- a/content/en/docs/spinnaker-user-guides/kayenta-canary-use.md
+++ b/content/en/docs/spinnaker-user-guides/kayenta-canary-use.md
@@ -67,7 +67,7 @@ Note: If you see the following error `The was an error saving your config: 400` 
 
 In `.hal/default/profiles/gate-local.yml`, add the following snippet:
 
-```
+```yaml
 services:
   kayenta:
     canaryConfigStore: true

--- a/content/en/docs/spinnaker-user-guides/kubernetes-v2.md
+++ b/content/en/docs/spinnaker-user-guides/kubernetes-v2.md
@@ -67,7 +67,7 @@ volumes:
 ```
 
 the name will be replaced with the properly versioned artifact:
-```
+```yaml
 volumes:
   - name: k8-config
     configMap:

--- a/content/en/docs/spinnaker-user-guides/pacrd.md
+++ b/content/en/docs/spinnaker-user-guides/pacrd.md
@@ -50,7 +50,7 @@ accounts
 
 Download the current `pacrd` manifest to your local machine:
 
-```
+```bash
 curl -fsSL https://engineering.armory.io/manifests/pacrd-0.9.0.yaml > pacrd-0.9.0.yaml
 ```
 
@@ -94,7 +94,7 @@ data:
 
 When you are ready, apply the `pacrd` manifest to your cluster:
 
-```sh
+```bash
 # If using `kubectl` >= 1.14
 kubectl apply -k .
 
@@ -149,7 +149,7 @@ spec:
 
 Create the application in your cluster by running:
 
-```
+```bash
 kubectl apply -f application.yaml
 ```
 
@@ -157,7 +157,7 @@ Check on the status of your application by using either the `get` or `describe`
 commands. `kubectl` recognizes either `app` or `application` for the resource
 kind:
 
-```sh
+```bash
 kubectl get app myapplicationname
 
 # or kubectl get application myapplicationname
@@ -184,7 +184,7 @@ Spinnaker. If an error occurs during the update, your application may show an
 `ErrorFailedUpdate` state. You can see the details of that failure by describing
 the resource and looking in the "Events" section:
 
-```
+```bash
 kubectl describe app myapplicationname
 ```
 
@@ -202,7 +202,7 @@ Spinnaker. If an error occurs during deletion, your application may show an
 `ErrorFailedDelete` state. You can see the details of that failure by describing
 the resource and looking in the "Events section":
 
-```
+```bash
 kubectl describe app myapplicationname
 ```
 
@@ -254,7 +254,7 @@ spec:
 
 Create your pipeline in your cluster:
 
-```
+```bash
 kubectl apply -f pipeline.yaml
 ```
 
@@ -262,7 +262,7 @@ Check on the status of your pipeline by using either the `get` or `describe`
 commands. `kubectl` will recognize either `pipe` or `pipeline` for the resource
 kind:
 
-```sh
+```bash
 kubectl get pipe myapplicationpipeline
 
 # or ... kubectl get pipeline myapplicationpipeline
@@ -278,7 +278,7 @@ myapplicationpipeline   Updated   5s               http://spinnaker.company.com/
 A `describe` call can give you additional contextual information about the
 status of your pipeline:
 
-```
+```bash
 kubectl describe pipeline myapplicationpipeline
 ```
 
@@ -319,7 +319,7 @@ Spinnaker. If an error occurs during the update, your pipeline may show an
 `ErrorFailedUpdate` state. You can see the details of that failure by describing
 the resource and looking in the "Events" section:
 
-```
+```bash
 kubectl describe pipeline myapplicationpipeline
 ```
 
@@ -337,7 +337,7 @@ Spinnaker. If an error occurred during deletion, then your pipeline may show an
 `ErrorFailedDelete` state. You can see the details of that failure by describing
 the resource and looking in the "Events section":
 
-```
+```bash
 kubectl describe pipeline myapplicationpipeline
 ```
 
@@ -444,7 +444,7 @@ creation. If you use the above example but replace the `id` reference with
 
 Execute `kubectl describe`:
 
-```
+```bash
 kubectl describe pipeline my-pipeline
 ```
 

--- a/content/en/docs/spinnaker-user-guides/policy-engine-use.md
+++ b/content/en/docs/spinnaker-user-guides/policy-engine-use.md
@@ -25,7 +25,7 @@ The Policy Engine uses [OPA's Data API](https://www.openpolicyagent.org/docs/lat
 
 In general, the only requirement for the Policy Engine in Rego syntax is the following:
 
-```
+```json
 package opa.pipelines
 
 deny["some text"] {
@@ -49,7 +49,7 @@ The following OPA policy enforces one requirement on all pipelines:
 * Any pipeline with more than one stage must have a manual judgement stage.
 
 
-```rego
+```json
 # manual-judgment.rego. Notice the package. The opa.pipelines package is used for policies that get checked when a pipeline is saved.
 package opa.pipelines
 
@@ -73,13 +73,13 @@ Armory recommends using ConfigMaps to add OPA policies instead of the API for OP
 
 If you have configured OPA to look for a ConfigMap, you can create the ConfigMap for `manual-judgement.rego` with this command:
 
-```
+```bash
 kubectl -n <opaServerNamespace> create configmap manual-judgment --from-file=manual-judgment.rego
 ```
 
 After you create the policy ConfigMap, apply a label to it:
 
-```
+```bash
 kubectl -n <opaServerNamespace> label configmap manual-judgment openpolicyagent.org/policy=rego
 ```
 
@@ -89,7 +89,7 @@ This label corresponds to the label you add in the [example manifest]({{< ref "p
 
 Replace the endpoint with your OPA endpoint:
 
-```
+```bash
 curl -X PUT \
 -H 'content-type:text/plain' \
 -v \
@@ -109,7 +109,7 @@ As an example, let's use Policy Engine to prevent Kubernetes LoadBalancer Servic
 
 Deployment validation works by mapping an OPA policy package to a Spinnaker deployment task. For example, deploying a Kubernetes Service is done using the Deploy (Manifest) stage, so we'll write a policy that applies to that task.
 
-```
+```json
 # Notice the package. The package maps to the task you want to create a policy for.
 package spinnaker.deployment.tasks.deployManifest
 
@@ -155,7 +155,7 @@ Now that the policy has been uploaded to the OPA server, the policy gets enforce
 
 You can disable a `deny` policy by adding a false statement to the policy body.  For example, you can add `0 == 1` as a false statement to the manual judgement policy we used previously:
 
-```
+```json
 package opa.pipelines
 
 deny["Every pipeline must have a Manual Judgment stage"] {

--- a/content/en/docs/spinnaker-user-guides/terraform-use-integration.md
+++ b/content/en/docs/spinnaker-user-guides/terraform-use-integration.md
@@ -47,13 +47,13 @@ To use the stage, perform the following steps:
 
           Regular GitHub:
 
-          ```
+          ```bash
           https://api.github.com/repos/{org}/{repo}/contents/{file path}
           ```
 
           Github Enterprise:
 
-          ```
+          ```bash
           https://{host}/api/v3/repos/{org}/{repo}/contents/{file path}
           ```
         * **Checkout subpath**: Enable this option to specify a **Subpath** within a Git repo. Useful if you have a large repo and the Terraform files are located in a specific directory.
@@ -84,7 +84,7 @@ Any plugin you want to use must meet the following requirements:
 
 **Configuring Terraform plugins**:
 
-```
+```yaml
 {
   "action": "plan",
   "artifacts": [
@@ -109,7 +109,7 @@ Any plugin you want to use must meet the following requirements:
 
 The Terraform Integration caches all the defined plugins by default and does not redownload them.  To configure the Terraform Integration to redownload a plugin, add the following JSON under the metadata key in the artifact object:
 
-```
+```yaml
 "metadata": {
     "sha256sum": "longString",
     "forceDownload": true,
@@ -136,7 +136,7 @@ If you have a Terraform template configured with [Output Values](https://www.ter
 
 For example, if you have a Terraform template that has this:
 
-```
+```hcl
 output "bucket_arn" {
     value = "${aws_s3_bucket.my_bucket.arn}"
 }
@@ -144,7 +144,7 @@ output "bucket_arn" {
 
 Then you can set up an `Output` stage that exposes this in the pipeline execution context.  If you have an `Output` stage with the stage name `My Output Stage`, then after running the `Output` stage, access the bucket ARN with this:
 
-```
+```hcl
 ${#stage('My Output Stage')["context"]["status"]["outputs"]["bucket_arn"]["value"]}
 ```
 

--- a/content/en/docs/spinnaker-user-guides/using-dinghy.md
+++ b/content/en/docs/spinnaker-user-guides/using-dinghy.md
@@ -478,7 +478,7 @@ Inside the `dinghyfile`, `stage.minimal.wait.localmodule` and `stage.minimal.wai
 
 `dinghyfile`:
 
-``` json
+```json
 {
   "application": "localmodules",
   "globals": {
@@ -500,7 +500,7 @@ Inside the `dinghyfile`, `stage.minimal.wait.localmodule` and `stage.minimal.wai
 ```
 
 `stage.minimal.wait.localmodule` and `stage.minimal.wait.module` have the same content:
-``` json
+```json
 {
   "name": "{{ var "waitname" ?: "Local Module Wait" }}",
   "waitTime":  "{{ var "waitTime" ?: 10 }}",
@@ -510,7 +510,7 @@ Inside the `dinghyfile`, `stage.minimal.wait.localmodule` and `stage.minimal.wai
 
 The rendered file looks like this:
 
-``` json
+```json
 {
   "application": "localmodules",
   "globals": {
@@ -576,7 +576,7 @@ And inside the `dinghyfile`, `stage.minimal.wait.localmodule` and `stage.minimal
 
 `dinghyfile`
 
-``` json
+```json
 {
   "application": "localmodules",
   "globals": {
@@ -596,7 +596,7 @@ And inside the `dinghyfile`, `stage.minimal.wait.localmodule` and `stage.minimal
 ```
 
 `stage.minimal.wait.module`:
-``` json
+```json
 {
   "name": "{{ var "waitname" ?: "Local Module Wait" }}",
   "waitTime":  "{{ var "waitTime" ?: 10 }}",
@@ -894,7 +894,7 @@ pipelines:
 
 ### HCL template format
 
-```
+```hcl
 "application" = "Some App"
 "globals" = {
     "waitTime" = 42
@@ -1477,7 +1477,7 @@ spec:
 
 Create `.hal/default/profiles/dinghy-local.yml` and add the following snippet:
 
-```
+```yaml
 Logging:
   Level: INFO
 ```


### PR DESCRIPTION
Copy codeblock functionality requires the codeblock to have the type of code specified. 