### PR TITLE
docs(shortcode): add shortcode to embed gsuite files

### DIFF
--- a/content/en/docs/smoke-test.md
+++ b/content/en/docs/smoke-test.md
@@ -341,3 +341,19 @@ Permissions
 </tr>
 </tbody>
 </table>
+
+
+## Google suite shortcode
+
+"Publish to web" and then copy the URL.
+
+### Sheet
+
+
+{{< gsuite src="https://docs.google.com/spreadsheets/d/e/2PACX-1vT9PZ2yPxUYIxis4SfAN6ZMFn7haf6KrHQqmW97Co744Mz0dskmD2fIJsR5-kNYG7NOlOKz1SzXww7i/pubhtml?gid=0&amp;single=true&amp;widget=true&amp;headers=false" width="100%" height="100%" >}}
+
+
+### Slide deck
+
+{{< gsuite src="https://docs.google.com/presentation/d/e/2PACX-1vQ7b90rHF2gS-4FUJWwuc8sK5JCb-fO-UupXqEZi-7eIdUBIcqTn2IEn0X9WSf0xucHlIVwPgovTQT5/embed?start=false&loop=false&delayms=3000" width="960" height="569" >}}
+

--- a/layouts/shortcodes/gsuite.html
+++ b/layouts/shortcodes/gsuite.html
@@ -1,0 +1,3 @@
+<div>
+  <iframe src="{{ .Get "src" }}" frameborder="0" width="{{ .Get "width" }}" height="{{ .Get "height" }}" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>


### PR DESCRIPTION
Add shortcode to embed gsuite files (sheets, docs, slides).

Add usage examples in smoke-test.md. compile with `--buildDrafts` to see the smoke-test page

https://s.armory.io/Blu11OwB