### PR TITLE
docs(docker): add primary account

### DIFF
--- a/content/en/docs/armory-admin/artifacts-docker-connect.md
+++ b/content/en/docs/armory-admin/artifacts-docker-connect.md
@@ -64,6 +64,7 @@ spec:
       providers:
         dockerRegistry:
           enabled: true
+          primaryAccount: my-docker-registry # Account with search priority. (Required when using a locally deployed registry.)
           accounts:
           - name: my-docker-registry
             requiredGroupMembership: [] # A user must be a member of at least one specified group in order to make changes to this account's cloud resources.


### PR DESCRIPTION
Add primaryAccount property since in some situations it is not optional(Locally deployed registry).

--
Same fix as https://github.com/armory/docs/pull/204. Made a new PR to avoid the merge conflicts from a ton of files being moved/renamed. 