### PR TITLE
fix(docs): Adding pipeline naming restriction

### DIFF
--- a/content/en/docs/spinnaker-user-guides/pacrd/_index.md
+++ b/content/en/docs/spinnaker-user-guides/pacrd/_index.md
@@ -633,6 +633,7 @@ stages:
 # ...
 ```
 
+- Pipeline names do not support spaces and must follow the [Kubernetes naming convention](https://v1-16.docs.kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).  "Kubernetes resources can have names up to 253 characters long. The characters allowed in names are: digits (0-9), lower case letters (a-z), -, and .."
 
 ## v0.1.x - v0.4.0
 

--- a/content/en/docs/spinnaker-user-guides/pacrd/_index.md
+++ b/content/en/docs/spinnaker-user-guides/pacrd/_index.md
@@ -215,7 +215,7 @@ In Kubernetes, define your pipeline in a `pipeline.yaml` file. The configuration
 
 This example assumes that you've created the `myapplicationname`
 application from the [previous section](#applications). Create one before
-proceeding if you have not done so already.*
+proceeding if you have not done so already.
 
 ```yaml
 # file: deploy-nginx.yaml

--- a/content/en/docs/spinnaker-user-guides/pacrd/_index.md
+++ b/content/en/docs/spinnaker-user-guides/pacrd/_index.md
@@ -2,7 +2,7 @@
 title: PaCRD
 linkTitle: PaCRD
 description: >
-  This section contains guides for using PaCRD, a Kubernetes controller that manages the lifecycle of Spinnaker applications and pipelines within a cluster. 
+  This section contains guides for using PaCRD, a Kubernetes controller that manages the lifecycle of Spinnaker applications and pipelines within a cluster.
 aliases:
   - /docs/spinnaker/pacrd/
   - /docs/spinnaker-user-guides/pacrd
@@ -203,7 +203,7 @@ kubectl describe app myapplicationname
 
 Pipelines allow you to encode the process that your team follows to take a
 service from commit to a desired environment, such as production. You can
-read more about pipelines in the Spinnaker [docs][https://www.spinnaker.io/concepts/pipelines/].
+read more in the Spinnaker [Pipelines](https://www.spinnaker.io/concepts/pipelines/) guide.
 
 View Pipeline configuration options in the {{< linkWithTitle "pacrd-crd-docs.md" >}}.
 
@@ -211,7 +211,9 @@ View Pipeline configuration options in the {{< linkWithTitle "pacrd-crd-docs.md"
 
 In Kubernetes, define your pipeline in a `pipeline.yaml` file. The configuration fields are the same as what you see when you [create a pipeline](https://www.spinnaker.io/guides/user/pipeline/managing-pipelines/#create-a-pipeline) using the Spinnaker UI. The following example defines a simple pipeline named "myapplicationpipeline", which bakes a manifest and prompts for a manual judgment.
 
-*Note: This example assumes that you've created the `myapplicationname`
+>Pipeline names should follow the Kubernetes [Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) naming conventions.
+
+This example assumes that you've created the `myapplicationname`
 application from the [previous section](#applications). Create one before
 proceeding if you have not done so already.*
 
@@ -632,8 +634,6 @@ stages:
       # ...
 # ...
 ```
-
-- Pipeline names do not support spaces and must follow the [Kubernetes naming convention](https://v1-16.docs.kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).  "Kubernetes resources can have names up to 253 characters long. The characters allowed in names are: digits (0-9), lower case letters (a-z), -, and .."
 
 ## v0.1.x - v0.4.0
 


### PR DESCRIPTION
Spinnaker pipeline names allows for spaces, PACRD pipeline names does not.