### PR TITLE
docs(DeployAWS): Clarify VPC Tagging

### DIFF
--- a/content/en/docs/spinnaker-user-guides/deploying.md
+++ b/content/en/docs/spinnaker-user-guides/deploying.md
@@ -37,9 +37,9 @@ Press the '+' on the right to create a new load balancer, you may need to select
 
 We'll enter 'prod' into the 'Stack' field because our environment contains dev, stage, and prod.
 
-Set the [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) grouping by tagging VPCs so that they will appear in the VPC dropdown selection in Spinnaker (this change may take some time to cache and reflect in Spinnaker).  Set your Firewall which maps to the pre-created security group, set the correct forwarding ports and most importantly set the healthcheck. 
+Set the [**VPC Subnet Type**]({{< ref "aws-subnets-configure" >}}) grouping by tagging VPCs so that they appear in the VPC dropdown selection in Spinnaker. This change may take some time to cache and reflect in Spinnaker.  In the **Firewalls** section, select your firewall, which maps to the preconfigured security group. Create the forwarding ports in the **Listeners** section. Finally, create the **Health Check**.
 
-Now we can hit create.
+Then press _Create_.
 
 ![](/images/Image-2019-02-21-at-16.33.44.png)
 
@@ -58,9 +58,9 @@ We'll be shown the option to copy a configuration from a currently running serve
 
 ![](/images/ezgif.com-gif-maker-(3).gif)
 
-Let's select the same **VPC Subnet** type as the ELB we just made. Remember to input 'prod' to the **Stack** field since that is what was used when creating the ELB.  
+Select the same **VPC Subnet** type as the ELB you just made. Remember to input 'prod' to the **Stack** field since that is what you used when creating the ELB.  
 
-Note: If the ELB steps above were skipped and do not see the VPCs grouping available or a new VPC group needs to be made, please be advised to follow the instructions at [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) and tag your VPCs so that they will be available for selection in the dropdown.
+>If you skipped the ELB steps above and do not see the VPCs grouping available, or you need to crate a new VPC group, follow the instructions in the [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) guide. Tag your VPCs so that they are available for selection in the dropdown.
 
 For this example, we'll use a Red/Black (also known as Blue/Green) **deployment strategy**. Leave 3 **maximum server groups** alive for normal services allows you to manually rollback in case of emergency easily.
 
@@ -88,7 +88,7 @@ Then click **Add** to complete this step.
 
 We return back to the deploy stage, with it now looking like:
 
-Finally, we can click **Save Changes** and select the back arror to return to the Pipeline Executions screen.
+Finally, we can click **Save Changes** and select the back arrow to return to the Pipeline Executions screen.
 
 ![](/images/Screen-Shot-2019-02-21-at-16.58.56.png)
 

--- a/content/en/docs/spinnaker-user-guides/deploying.md
+++ b/content/en/docs/spinnaker-user-guides/deploying.md
@@ -37,7 +37,7 @@ Press the '+' on the right to create a new load balancer, you may need to select
 
 We'll enter 'prod' into the 'Stack' field because our environment contains dev, stage, and prod.
 
-Set the [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}), which maps to our pre-created security group, set the correct forwarding ports and most importantly set the healthcheck.
+Set the [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) grouping by tagging VPCs so that they will appear in the VPC dropdown selection in Spinnaker (this change may take some time to cache and reflect in Spinnaker).  Set your Firewall which maps to the pre-created security group, set the correct forwarding ports and most importantly set the healthcheck. 
 
 Now we can hit create.
 
@@ -58,7 +58,9 @@ We'll be shown the option to copy a configuration from a currently running serve
 
 ![](/images/ezgif.com-gif-maker-(3).gif)
 
-Let's select the same **VPC Subnet** type as the ELB we just made. Remember to input 'prod' to the **Stack** field since that is what was used when creating the ELB.
+Let's select the same **VPC Subnet** type as the ELB we just made. Remember to input 'prod' to the **Stack** field since that is what was used when creating the ELB.  
+
+Note: If the ELB steps above were skipped and do not see the VPCs grouping available or a new VPC group needs to be made, please be advised to follow the instructions at [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) and tag your VPCs so that they will be available for selection in the dropdown.
 
 For this example, we'll use a Red/Black (also known as Blue/Green) **deployment strategy**. Leave 3 **maximum server groups** alive for normal services allows you to manually rollback in case of emergency easily.
 


### PR DESCRIPTION
Added clarification information in the article about VPCs as users may not start from the ELB stage.  Added clarification about the ELB information as it was unclear what maps to the security group that was preconfigured (it's the firewall category that maps to it, not the VPC subnet)