### PR TITLE
fix(docs) Fixing Rolling Back Upgrade hal command

### DIFF
--- a/content/en/docs/installation/guide/upgrade-spinnaker.md
+++ b/content/en/docs/installation/guide/upgrade-spinnaker.md
@@ -52,7 +52,7 @@ Rolling an upgrade back is similar to upgrading Spinnaker:
 
 1. Select the version you want to rollback to:
    ```bash
-   hal config edit --version <target_version>
+   hal config version edit --version <target_version>
    ```
 2. Apply the rollback:
    ```bash


### PR DESCRIPTION
The Rolling Back an Upgrade section in the Spinnaker docs was missing the version subcommand in the example halyard command.  It is correct in the example above this one already.  This PR fixes that issue.