### PR TITLE
docs(shortcode): add tabs shortcodes 

### DIFF
--- a/content/en/docs/smoke-test/example1.md
+++ b/content/en/docs/smoke-test/example1.md
@@ -1,0 +1,8 @@
+---
+title: Example #1
+---
+
+This is an **example** content file inside the **includes** leaf bundle.
+
+{{< alert >}}Included content files can also contain shortcodes.{{< /alert >}}
+

--- a/content/en/docs/smoke-test/example2.md
+++ b/content/en/docs/smoke-test/example2.md
@@ -1,0 +1,7 @@
+---
+title: Example #1
+---
+
+This is another **example** content file inside the **includes** leaf bundle.
+
+

--- a/content/en/docs/smoke-test/index.md
+++ b/content/en/docs/smoke-test/index.md
@@ -397,8 +397,7 @@ Permissions
 {{< gsuite src="https://docs.google.com/presentation/d/e/2PACX-1vQ7b90rHF2gS-4FUJWwuc8sK5JCb-fO-UupXqEZi-7eIdUBIcqTn2IEn0X9WSf0xucHlIVwPgovTQT5/embed?start=false&loop=false&delayms=3000" width="960" height="569" >}}
 
 ## Tabs
-
-Copied from the Kubernetes website project.
+<!-- Copied from github.com/kubernetes/website project, which has a Creative Commons Attribution 4.0 International license -->
 
 In a markdown page (`.md` file) on this site, you can add a tab set to display multiple flavors of a given solution.
 

--- a/content/en/docs/smoke-test/index.md
+++ b/content/en/docs/smoke-test/index.md
@@ -396,3 +396,104 @@ Permissions
 
 {{< gsuite src="https://docs.google.com/presentation/d/e/2PACX-1vQ7b90rHF2gS-4FUJWwuc8sK5JCb-fO-UupXqEZi-7eIdUBIcqTn2IEn0X9WSf0xucHlIVwPgovTQT5/embed?start=false&loop=false&delayms=3000" width="960" height="569" >}}
 
+## Tabs
+
+Copied from the Kubernetes website project.
+
+In a markdown page (`.md` file) on this site, you can add a tab set to display multiple flavors of a given solution.
+
+The `tabs` shortcode takes these parameters:
+
+* `name`: The name as shown on the tab.
+* `codelang`: If you provide inner content to the `tab` shortcode, you can tell Hugo what code language to use for highlighting.
+* `include`: The file to include in the tab. If the tab lives in a Hugo [leaf bundle](https://gohugo.io/content-management/page-bundles/#leaf-bundles), the file -- which can be any MIME type supported by Hugo -- is looked up in the bundle itself. If not, the content page that needs to be included is looked up relative to the current page. Note that with the `include`, you do not have any shortcode inner content and must use the self-closing syntax. For example, <code>{{</* tab name="Content File #1" include="example1" /*/>}}</code>. The language needs to be specified under `codelang` or the language is taken based on the file name. Non-content files are code-highlighted by default.
+* If your inner content is markdown, you must use the `%`-delimiter to surround the tab. For example, `{{%/* tab name="Tab 1" %}}This is **markdown**{{% /tab */%}}`
+* You can combine the variations mentioned above inside a tab set.
+
+Below is a demo of the tabs shortcode.
+
+{{% alert title="Warning" color="warning" %}}
+The tab **name** in a `tabs` definition must be unique within a content page.
+{{% /alert %}}
+
+### Tabs demo: Code highlighting
+
+```go-text-template
+{{</* tabs name="tab_with_code" >}}
+{{{< tab name="Tab 1" codelang="bash" >}}
+echo "This is tab 1."
+{{< /tab >}}
+{{< tab name="Tab 2" codelang="go" >}}
+println "This is tab 2."
+{{< /tab >}}}
+{{< /tabs */>}}
+```
+
+Renders to:
+
+{{< tabs name="tab_with_code" >}}
+{{< tab name="Tab 1" codelang="bash" >}}
+echo "This is tab 1."
+{{< /tab >}}
+{{< tab name="Tab 2" codelang="go" >}}
+println "This is tab 2."
+{{< /tab >}}
+{{< /tabs >}}
+
+### Tabs demo: Inline Markdown and HTML
+
+```go-html-template
+{{</* tabs name="tab_with_md" >}}
+{{% tab name="Markdown" %}}
+This is **some markdown.**
+{{% alert title="Warning" color="warning" %}}
+It can even contain shortcodes.
+{{% /alert %}}
+{{% /tab %}}
+{{< tab name="HTML" >}}
+<div>
+	<h3>Plain HTML</h3>
+	<p>This is some <i>plain</i> HTML.</p>
+</div>
+{{< /tab >}}
+{{< /tabs */>}}
+```
+
+Renders to:
+
+{{< tabs name="tab_with_md" >}}
+{{% tab name="Markdown" %}}
+This is **some markdown.**
+
+{{% alert title="Warning" color="warning" %}}
+It can even contain shortcodes.
+{{% /alert %}}
+
+{{% /tab %}}
+{{< tab name="HTML" >}}
+<div>
+	<h3>Plain HTML</h3>
+	<p>This is some <i>plain</i> HTML.</p>
+</div>
+{{< /tab >}}
+{{< /tabs >}}
+
+### Tabs demo: File include
+
+```go-html-template
+{{</* tabs name="tab_with_file_include" */>}}
+{{</* tab name="Content File #1" include="example1" */>}}
+{{</* tab name="Content File #2" include="example2" */>}}
+{{</* tab name="JSON File" include="podtemplate" */>}}
+{{</* /tabs */>}}
+```
+
+Renders to:
+
+{{< tabs name="tab_with_file_include" >}}
+{{< tab name="Content File #1" include="example1" />}}
+{{< tab name="Content File #2" include="example2" />}}
+{{< tab name="JSON File" include="podtemplate.json" />}}
+{{< /tabs >}}
+
+

--- a/content/en/docs/smoke-test/podtemplate.json
+++ b/content/en/docs/smoke-test/podtemplate.json
@@ -1,0 +1,22 @@
+  {
+    "apiVersion": "v1",
+    "kind": "PodTemplate",
+    "metadata": {
+      "name": "nginx"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "nginx"
+        },
+        "generateName": "nginx-"
+      },
+      "spec": {
+         "containers": [{
+           "name": "nginx",
+           "image": "dockerfile/nginx",
+           "ports": [{"containerPort": 80}]
+         }]
+      }
+    }
+  }

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,0 +1,19 @@
+{{ if .Parent }}
+	{{ $name := trim (.Get "name") " " }}
+	{{ $include := trim (.Get "include") " "}}
+	{{ $codelang := .Get "codelang" }}
+	{{ if not (.Parent.Scratch.Get "tabs") }}
+	{{ .Parent.Scratch.Set "tabs" slice }}
+	{{ end }}
+	{{ with .Inner }}
+	{{ if $codelang }}
+	{{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" (highlight . $codelang "") ) }}
+	{{ else }}
+	{{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
+	{{ end }}
+	{{ else }}
+	{{ $.Parent.Scratch.Add "tabs" (dict "name" $name "include" $include "codelang" $codelang) }}
+	{{ end }}
+{{ else }}
+	{{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}
+{{ end}}

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,3 +1,4 @@
+<!-- Copied from github.com/kubernetes/website project, which has a Creative Commons Attribution 4.0 International license -->
 {{ if .Parent }}
 	{{ $name := trim (.Get "name") " " }}
 	{{ $include := trim (.Get "include") " "}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,0 +1,50 @@
+{{- .Page.Scratch.Add "tabset-counter" 1 -}}
+{{- $tab_set_id := .Get "name" | default (printf "tabset-%s-%d" (.Page.RelPermalink) (.Page.Scratch.Get "tabset-counter") ) | anchorize -}}
+{{- $tabs := .Scratch.Get "tabs" -}}
+{{- if .Inner -}}{{- /* We don't use the inner content, but Hugo will complain if we don't reference it. */ -}}{{- end -}}
+<ul class="nav nav-tabs" id="{{ $tab_set_id }}" role="tablist">
+	{{- range $i, $e := $tabs -}}
+	  {{- $id := printf "%s-%d" $tab_set_id $i -}}
+	  {{- if (eq $i 0) -}}
+		<li class="nav-item"><a data-toggle="tab" class="nav-link active" href="#{{ $id }}" role="tab" aria-controls="{{ $id }}" aria-selected="true">{{- trim .name " " -}}</a></li>
+	  {{ else }}
+		<li class="nav-item"><a data-toggle="tab" class="nav-link" href="#{{ $id }}" role="tab" aria-controls="{{ $id }}">{{- trim .name " " -}}</a></li>
+	  {{- end -}}
+{{- end -}}
+</ul>
+<div class="tab-content" id="{{ $tab_set_id }}">
+{{- range $i, $e := $tabs -}}
+{{- $id := printf "%s-%d" $tab_set_id $i -}}
+{{- if (eq $i 0) -}}
+  <div id="{{ $id }}" class="tab-pane show active" role="tabpanel" aria-labelledby="{{ $id }}">
+{{ else }}
+  <div id="{{ $id }}" class="tab-pane" role="tabpanel" aria-labelledby="{{ $id }}">
+{{ end }}
+<p>
+	{{- with .content -}}
+		{{- . -}}
+	{{- else -}}
+		{{- if eq $.Page.BundleType "leaf" -}}
+			{{- /* find the file somewhere inside the bundle. Note the use of double asterisk */ -}}
+			{{- with $.Page.Resources.GetMatch (printf "**%s*" .include) -}}
+				{{- if ne .ResourceType "page" -}}
+				{{- /* Assume it is a file that needs code highlighting. */ -}}
+				{{- $codelang := $e.codelang | default ( path.Ext .Name | strings.TrimPrefix ".") -}}
+				{{- highlight .Content $codelang "" -}}
+				{{- else -}}
+					{{- .Content -}}
+				{{- end -}}
+			{{- end -}}
+		{{- else -}}
+		{{- $path := path.Join $.Page.File.Dir .include -}}
+		{{- $page := site.GetPage "page" $path -}}
+		{{- with $page -}}
+			{{- .Content -}}
+		{{- else -}}
+		{{- errorf "[%s] tabs include not found for path %q" site.Language.Lang $path -}}
+		{{- end -}}
+		{{- end -}}
+	{{- end -}}
+</div>
+{{- end -}}
+</div>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,3 +1,4 @@
+<!-- Copied from github.com/kubernetes/website project, which has a Creative Commons Attribution 4.0 International license -->
 {{- .Page.Scratch.Add "tabset-counter" 1 -}}
 {{- $tab_set_id := .Get "name" | default (printf "tabset-%s-%d" (.Page.RelPermalink) (.Page.Scratch.Get "tabset-counter") ) | anchorize -}}
 {{- $tabs := .Scratch.Get "tabs" -}}


### PR DESCRIPTION
- add tab.html and tabs.html
- add usage examples to smoke-test, which required creating a leaf bundle for smoke test

Compile with --buildDrafts to see the smoke test content.
Video of tabs usage content I added to smoke test:  https://s.armory.io/bLuwKv8X

Note: shortcodes and usage copied from kubernetes/website