### PR TITLE
docs(fix): AWS cost spreadsheet width fix

### DIFF
--- a/content/en/docs/cloud-resources/resources-aws.md
+++ b/content/en/docs/cloud-resources/resources-aws.md
@@ -102,13 +102,5 @@ The example below is based on a basic Armory instance without disaster recovery.
 
 AWS pricing can change without notice, so be sure to determine your costs using the [AWS Pricing Calculator](https://calculator.aws).
 
-{{< gsuite src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSlG-eNaziGxpi-d4NbiQfd6RREHZ-EdShx89nTl1gZGeZ5NECAm85BfOXp5-jWVOaPC9d6pzo6vfww/pubhtml?gid=0&amp;single=true&amp;widget=true&amp;headers=false"  width="960" height="400" >}}
-
-
-
-
-
-
-
-
+{{< gsuite src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSlG-eNaziGxpi-d4NbiQfd6RREHZ-EdShx89nTl1gZGeZ5NECAm85BfOXp5-jWVOaPC9d6pzo6vfww/pubhtml?gid=0&amp;single=true&amp;widget=true&amp;headers=false"  width="100%" height="400" >}}
 


### PR DESCRIPTION
 change width to 100% to avoid overlap with menu on tiny screen or when browser window is resized a lot smaller