### PR TITLE
docs(Install): CHMOD update for Halyard Docker Install

### DIFF
--- a/content/en/docs/installation/armory-halyard.md
+++ b/content/en/docs/installation/armory-halyard.md
@@ -21,13 +21,7 @@ Running Armory-extended Halyard in Docker is convenient and portable. The daemon
 
 ### Starting Daemon
 
-> Note: In the command below, the host (local) directories mapped to the docker 
-> container will need to have permissions set on them to allow for modification 
-> from within the Docker Container.  As an example, the `~/.hal` folder within the 
-> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
-> or there will be an issue when attempting to execute a `hal deploy apply` from 
-> within the container.  These permissions should be set before executing the below 
-> commands to start the container
+{{% include "install/docker-note.md" %}}
 
 You can start Armory-extended Halyard in a Docker container with the following command:
 

--- a/content/en/docs/installation/armory-halyard.md
+++ b/content/en/docs/installation/armory-halyard.md
@@ -21,6 +21,14 @@ Running Armory-extended Halyard in Docker is convenient and portable. The daemon
 
 ### Starting Daemon
 
+> Note: In the command below, the host (local) directories mapped to the docker 
+> container will need to have permissions set on them to allow for modification 
+> from within the Docker Container.  As an example, the `~/.hal` folder within the 
+> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
+> or there will be an issue when attempting to execute a `hal deploy apply` from 
+> within the container.  These permissions should be set before executing the below 
+> commands to start the container
+
 You can start Armory-extended Halyard in a Docker container with the following command:
 
 ```bash

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -242,6 +242,14 @@ On the `Halyard machine`, start the Halyard container.
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
+> Note: In the command below, the host (local) directories mapped to the docker 
+> container will need to have permissions set on them to allow for modification 
+> from within the Docker Container.  As an example, the `~/.hal` folder within the 
+> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
+> or there will be an issue when attempting to execute a `hal deploy apply` from 
+> within the container.  These permissions should be set before executing the below 
+> commands to start the container
+
 ```bash
 docker run --name armory-halyard -it --rm \
   -v ${WORKING_DIRECTORY}/.hal:/home/spinnaker/.hal \

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -242,13 +242,7 @@ On the `Halyard machine`, start the Halyard container.
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
-> Note: In the command below, the host (local) directories mapped to the docker 
-> container will need to have permissions set on them to allow for modification 
-> from within the Docker Container.  As an example, the `~/.hal` folder within the 
-> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
-> or there will be an issue when attempting to execute a `hal deploy apply` from 
-> within the container.  These permissions should be set before executing the below 
-> commands to start the container
+{{< include "install/docker-note.md" >}}
 
 ```bash
 docker run --name armory-halyard -it --rm \

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -324,13 +324,7 @@ On the `Halyard machine`, start the Halyard container .
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
-> Note: In the command below, the host (local) directories mapped to the docker 
-> container will need to have permissions set on them to allow for modification 
-> from within the Docker Container.  As an example, the `~/.hal` folder within the 
-> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
-> or there will be an issue when attempting to execute a `hal deploy apply` from 
-> within the container.  These permissions should be set before executing the below 
-> commands to start the container
+{{< include "install/docker-note.md" >}}
 
 ```bash
 docker run --name armory-halyard -it --rm \
@@ -340,9 +334,9 @@ docker run --name armory-halyard -it --rm \
   armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
 
-Our installer currently expects to find your kubeconfig named `config` in
+The installer expects to find your kubeconfig named `config` in
 the `.kube` directory you map below.  If you've named your config something
-else, you'll need to rename or symlink the file accordingly.
+else, you need to rename or symlink the file accordingly.
 
 ## Enter the Halyard container
 

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -324,6 +324,14 @@ On the `Halyard machine`, start the Halyard container .
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
+> Note: In the command below, the host (local) directories mapped to the docker 
+> container will need to have permissions set on them to allow for modification 
+> from within the Docker Container.  As an example, the `~/.hal` folder within the 
+> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
+> or there will be an issue when attempting to execute a `hal deploy apply` from 
+> within the container.  These permissions should be set before executing the below 
+> commands to start the container
+
 ```bash
 docker run --name armory-halyard -it --rm \
   -v ${WORKING_DIRECTORY}/.hal:/home/spinnaker/.hal \
@@ -331,6 +339,10 @@ docker run --name armory-halyard -it --rm \
   -v ${WORKING_DIRECTORY}/resources:/home/spinnaker/resources \
   armory/halyard-armory:{{< param halyard-armory-version >}}
 ```
+
+Our installer currently expects to find your kubeconfig named `config` in
+the `.kube` directory you map below.  If you've named your config something
+else, you'll need to rename or symlink the file accordingly.
 
 ## Enter the Halyard container
 

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -233,6 +233,14 @@ On the `Halyard machine`, start the Halyard container.
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
+> Note: In the command below, the host (local) directories mapped to the docker 
+> container will need to have permissions set on them to allow for modification 
+> from within the Docker Container.  As an example, the `~/.hal` folder within the 
+> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
+> or there will be an issue when attempting to execute a `hal deploy apply` from 
+> within the container.  These permissions should be set before executing the below 
+> commands to start the container
+
 ```bash
 docker run --name armory-halyard -it --rm \
   -v ${WORKING_DIRECTORY}/.hal:/home/spinnaker/.hal \

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -233,13 +233,7 @@ On the `Halyard machine`, start the Halyard container.
 
 *If you want to install OSS Spinnaker instead, use `gcr.io/spinnaker-marketplace/halyard:stable` for the Docker Halyard image reference in substitution of `armory/halyard-armory:<image_version>` in the commands below*
 
-> Note: In the command below, the host (local) directories mapped to the docker 
-> container will need to have permissions set on them to allow for modification 
-> from within the Docker Container.  As an example, the `~/.hal` folder within the 
-> *host (local) system directory* will need writable permissions (`chmod 777 ~/.hal`), 
-> or there will be an issue when attempting to execute a `hal deploy apply` from 
-> within the container.  These permissions should be set before executing the below 
-> commands to start the container
+{{< include "install/docker-note.md" >}}
 
 ```bash
 docker run --name armory-halyard -it --rm \

--- a/content/en/docs/spinnaker-user-guides/deploying.md
+++ b/content/en/docs/spinnaker-user-guides/deploying.md
@@ -37,7 +37,7 @@ Press the '+' on the right to create a new load balancer, you may need to select
 
 We'll enter 'prod' into the 'Stack' field because our environment contains dev, stage, and prod.
 
-Set the [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}), which maps to our pre-created security group, set the correct forwarding ports and most importantly set the healthcheck.
+Set the [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) grouping by tagging VPCs so that they will appear in the VPC dropdown selection in Spinnaker (this change may take some time to cache and reflect in Spinnaker).  Set your Firewall which maps to the pre-created security group, set the correct forwarding ports and most importantly set the healthcheck. 
 
 Now we can hit create.
 
@@ -58,7 +58,9 @@ We'll be shown the option to copy a configuration from a currently running serve
 
 ![](/images/ezgif.com-gif-maker-(3).gif)
 
-Let's select the same **VPC Subnet** type as the ELB we just made. Remember to input 'prod' to the **Stack** field since that is what was used when creating the ELB.
+Let's select the same **VPC Subnet** type as the ELB we just made. Remember to input 'prod' to the **Stack** field since that is what was used when creating the ELB.  
+
+Note: If the ELB steps above were skipped and do not see the VPCs grouping available or a new VPC group needs to be made, please be advised to follow the instructions at [VPC Subnet Type]({{< ref "aws-subnets-configure" >}}) and tag your VPCs so that they will be available for selection in the dropdown.
 
 For this example, we'll use a Red/Black (also known as Blue/Green) **deployment strategy**. Leave 3 **maximum server groups** alive for normal services allows you to manually rollback in case of emergency easily.
 

--- a/content/en/includes/install/docker-note.md
+++ b/content/en/includes/install/docker-note.md
@@ -1,0 +1,4 @@
+>Before you execute the command below, you need to set permissions on the host (local) directories mapped to the Docker container. These directories must allow for modification from within the container.  The `~/.hal` folder within
+the *host (local) system directory* needs write permissions (`chmod 777
+~/.hal`), or you will encounter issues when attempting to execute a `hal deploy
+apply` from within the container.


### PR DESCRIPTION
There was a change that removed a step to advise to add permissions to the .hal directory.  I'm adding this note back in, because while the error message when you do not set the permissions properly explains exactly what to do, it's not a good experience for someone to hit the error and then make the change after.

We've found this is a consistent section that all our junior support candidates get stuck on.