### PR TITLE
chore(docs): Armory Agent quickstart and troubleshooting REVERT

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -100,12 +100,6 @@ privacy_policy = "https://www.armory.io/privacy-policy"
 terms_of_service = "https://www.armory.io/terms-of-service"
 terms_and_conditions = "https://www.armory.io/terms-and-conditions"
 
-[params.kubesvc-plugin]
-latestVersion2="0.2.3"
-latestVersion3="0.3.13"
-latestVersion4="0.4.8"
-latestVersion5="0.5.0-rc.14"
-
 # First one is picked as the Twitter card image if not set on page.
 # images = ["images/project-illustration.png"]
 

--- a/content/en/docs/armory-agent/_index.md
+++ b/content/en/docs/armory-agent/_index.md
@@ -46,10 +46,7 @@ In infrastructure mode, multiple Agent deployments handle different groups of Ku
 
 ### Agent mode
 
-In this mode, the Agent acts as a piece of infrastructure. It authenticates  using a [service account token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens). You use
-[RBAC service account permissions](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#service-account-permissions) to configure what the Agent is authorized to do.
-
-If Spinnaker is unable to communicate with the Agent, Spinnaker attempts to reconnect during a defined grace period. If Spinnaker still can't communicate with the Agent after the grace period has expired, the Agent's cluster is removed from Spinnaker. 
+In this mode, the Agent acts as a piece of infrastructure. It is provisioned with a `serviceAccount` properly scoped to what you want Spinnaker to do. The cluster will disappear from Spinnaker after a grace period when the cluster is deleted or when the Agent is stopped.
 
 ![Agent mode](/images/armory-agent/agent-mode.png)
 

--- a/content/en/docs/armory-agent/agent-troubleshooting.md
+++ b/content/en/docs/armory-agent/agent-troubleshooting.md
@@ -24,7 +24,7 @@ Clouddriver's log should have the following messages:
 ```
 
 
-In Infrastructure or Agent modes, you can test the gRPC endpoints with the
+In infrastructure or agent modes, you can test the gRPC endpoints with the
 [`grpcurl`](https://github.com/fullstorydev/grpcurl) utility.
 
 ```bash
@@ -53,7 +53,7 @@ time="2020-10-02T22:22:14Z" level=info msg="connecting to spin-clouddriver-grpc:
 # Connection successful
 time="2020-10-02T22:22:14Z" level=info msg="connected to spin-clouddriver-grpc:9091"
 
-# Showing the UID of the agent, that's what will show in Clouddriver
+# Showing the UID of the agent, that's what will show in clouddriver
 time="2020-10-02T22:22:14Z" level=info msg="connecting to Spinnaker: 9bece238-a429-40aa-8fad-285c72f56859"
 ...
 
@@ -67,36 +67,7 @@ time="2020-10-02T22:22:27Z" level=info msg="starting agentCreator account-01"
 
 Common errors:
 
-- `io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception: HTTP/2 client preface string missing or corrupt. Hex dump for received bytes: 160301011901000115030383b0f1d28d2a75383e4e1f98f4`
-  When connecting to Spinnaker<sup>TM</sup> as a service, make sure to set `clouddriver.insecure: true` or provide certificates so the plugin can terminate TLS.
-- `org.springframework.jdbc.BadSqlGrammarException: jOOQ; bad SQL grammar [update kubesvc_assignments set reachable = ?, last_updated = ? where cd_id = ?]; nested exception is java.sql.SQLSyntaxErrorException: Table 'clouddriver.kubesvc_assignments' doesn't exist`
-  The plugin by default tries to automatically create the tables it needs after printing this error message.
-  This can be ignored, and in case of any issue, another error message should follow later in the logs.
-- `Parameter 1 of method getRedisClusterRecipient in io.armory.kubesvc.config.KubesvcClusterConfiguration required a bean of type 'com.netflix.spinnaker.kork.jedis.RedisClientDelegate' that could not be found.`
-  Make sure `redis.enabled: true` is set in Clouddriver's profile. For a more limited solution, keep only one Clouddriver instance and set `kubesvc.cluster: local` in Clouddriver's profile
-- `Parameter 0 of method sqlTableMetricsAgent in com.netflix.spinnaker.config.SqlCacheConfiguration required a bean of type 'org.jooq.DSLContext' that could not be found.`
-  Make sure `sql.enabled: true` is set in Clouddriver's profile
-- `Parameter 2 of constructor in io.armory.kubesvc.agent.KubesvcCachingAgentDispatcher required a bean of type 'com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials$Factory' that could not be found.`
-  Make sure `providers.kubernetes.enabled: true` is set.
-- `Assigning accounts to Kubesvc enabled Clouddrivers (caching)` multiple times in Clouddriver & `[..] is unreachable [..] getting credentials: exec: fork/exec /usr/local/bin/aws: exec format error`
-  Currently only static tokens are available. Generate a kubeconfig that uses a token from a SA with permissions to the cluster instead.
-
-  ```bash
-  kubectl create sa kubesvc -n default # replace default with a relevant namespace
-  kubectl create clusterrolebinding kubesvc --serviceaccount default:kubesvc --clusterrole cluster-admin # or make a proper rbac role
-  TOKEN_SECRET="$(kubectl get sa kubesvc -n default -o jsonpath='{.secrets.*.name}')"
-  TOKEN="$(kubectl get secret "$TOKEN_SECRET" -n default -o jsonpath='{.data.token}' | base64 --decode)"
-  # Replace your kubeconfig from
-  # users:
-  # - user:
-  #     exec:
-  # to
-  # users:
-  # - user:
-  #     token: $TOKEN_SECRET
-  # Remember to replace $TOKEN_SECRET with the actual contents from the command above
-  ```
-
+- When connecting to Spinnaker<sup>TM</sup> as a service, make sure to set `clouddriver.insecure: true` or provide certificates so the plugin can terminate TLS.
 
 ## Tips
 
@@ -104,4 +75,4 @@ Common errors:
 
 - For better availability, you can run Agent deployments in [different availability zones](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
 
-- Restarting the Agent won't cause direct outages, provided it is limited in time (less than 30s). No operation can happen while no Agent is connected to Spinnaker. Caching is asynchronous and other operations are retried `kubesvc.operations.retry.maxRetries` times. Furthermore, restarts are generally fast, and the Agent resumes where it left off.
+- Restarting the Agent won't cause direct outages provided it is limited in time (less than 30s). No operation can happen while no Agent is connected to Spinnaker. Caching is asynchronous and other operations are retried `kubesvc.operations.retry.maxRetries` times. Furthermore, restarts are generally fast and the Agent resumes where it left off.

--- a/content/en/docs/armory-agent/armory-agent-quick.md
+++ b/content/en/docs/armory-agent/armory-agent-quick.md
@@ -51,16 +51,7 @@ patchesStrategicMerge:
 
 ```
 
-You can then set the [plugin options]({{< ref "agent-plugin-options" >}}) in `agent-plugin/config.yaml`.
-
-* For topologies like [Infrastructure mode](({{< ref "armory-agent#infrastructure-mode" >}})) and [Agent mode](({{< ref "armory-agent#infrastructure-mode" >}})), in which the Agent is installed in a different cluster from Spinnaker, you should configure TLS through a load balancer.
-* For Spinnaker installations with one Clouddriver instance and no Redis, you can use `kubesvc.cluster`. However, a Spinnaker installation with Redis is recommended.
-* When running Spinnaker in [HA](https://spinnaker.io/reference/halyard/high-availability/), make sure to modify the following files:
-
-  * `agent-service/kustomization.yaml` according to its comments
-  * `agent-plugin/clouddriver-plugin.yaml` and `agent-plugin/config.yaml` references to Clouddriver should be to HA versions (i.e: -rw, -ro, etc)
-
-When you're ready, deploy with:
+You can then set the [plugin options]({{< ref "agent-plugin-options" >}}) in `agent-plugin/config.yaml`. When you're ready, deploy with:
 
 ```bash
 kustomize build . | kubectl apply -f -
@@ -97,11 +88,11 @@ Create the directory structure described below with `kustomization.yaml`, `kubes
 ```
 
 ```yaml
-# ./kustomization.yaml
+# ./kustomization.yaml  
 
 # Namespace where you want to deploy the agent
 namespace: spinnaker
-bases:
+bases:  
   - https://armory.jfrog.io/artifactory/manifests/kubesvc/armory-agent-{{<param kubesvc-version>}}-kustomize.tar.gz
 
 configMapGenerator:
@@ -114,7 +105,7 @@ secretGenerator:
   - name: kubeconfigs-secret
     files:
     # a list of all needed kubeconfigs
-    - kubecfgs/kubecfg-account01.yaml
+    - kubecfgs/kubecfg-account01.yaml  
     - ...
     - kubecfgs/kubecfg-account1000.yaml
 ```
@@ -130,12 +121,9 @@ kubernetes:
     # as mounted from the `kubeconfigs-secret` Kubernetes secret
     kubeconfigFile: /kubeconfigfiles/kubecfg-account01.yaml
     ...
-  - ...
+  - ...    
 ...
 ```
-
-* For installations without gRPC TLS connections, you should include `clouddriver.insecure: true` in the Agent options.
-* For HA, make sure to set `clouddriver.grpc: clouddriver-ha-grpc-service.yaml:9091`
 
 With the directory structure in place, deploy the Agent service:
 
@@ -148,7 +136,8 @@ kustomize build </path/to/directory> | kubectl apply -f -
 If you prefer to manage manifests directly, download all the manifests:
 
 ```bash
-AGENT_VERSION={{<param kubesvc-version>}} && curl -s https://armory.jfrog.io/artifactory/manifests/kubesvc/armory-agent-$AGENT_VERSION-kustomize.tar.gz | tar -xJvf -
+AGENT_VERSION = {{<param kubesvc-version>}} && \
+curl -s https://armory.jfrog.io/artifactory/manifests/kubesvc/armory-agent-$AGENT_VERSION-kustomize.tar.gz | tar -xJvf -
 ```
 
 - Change the version of the Agent in `kustomization.yaml`

--- a/content/en/includes/agent/agent-compat-matrix.md
+++ b/content/en/includes/agent/agent-compat-matrix.md
@@ -2,8 +2,8 @@ The Armory Agent is compatible with the Armory Platform and open source Spinnake
 
 | Armory (Spinnaker) Version | Armory Agent Plugin Version    | Armory Agent Version |
 |:-------------------------- |:------------------------------ |:---------------------------- |
-| 2.19.x (1.19.x)            | {{<param kubesvc-plugin.latestVersion2>}} | {{<param kubesvc-version>}} |
-| 2.20.x (1.20.x)            | {{<param kubesvc-plugin.latestVersion3>}} | {{<param kubesvc-version>}} |
-| 2.21.x (1.21.x)            | {{<param kubesvc-plugin.latestVersion4>}} | {{<param kubesvc-version>}} |
-| 2.22.x (1.22.x)            | {{<param kubesvc-plugin.latestVersion5>}} | {{<param kubesvc-version>}} |
+| 2.19.x (1.19.x)            | 0.2.3 Latest | 0.2.0 |
+| 2.20.x (1.20.x)            | 0.3.10 Latest | 0.2.0 |
+| 2.21.x (1.21.x)            | 0.4.5 Latest | 0.2.0 |
+| 2.22.x (1.22.x)            | 0.5.0 Latest | 0.2.0 |
 


### PR DESCRIPTION
Reverts armory/docs#257

Search bar disappeared, probably because config.toml was modified and Hugo doesn't like something about the change.