### PR TITLE
docs(chore): add release notes templates that sort by date

### DIFF
--- a/content/en/docs/release-notes/rn-armory-halyard/_index.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/_index.md
@@ -7,7 +7,8 @@ aliases:
   - /halyard-versions/
   - /halyard-version/
   - /halyard-release-notes/
-simple_list_reverse: true
+layout: release-notes-no-archive
+semver_list: true
 ---
 
 > You can find [Armory's releases notes here]({{< ref "rn-armory-spinnaker" >}}).
@@ -21,4 +22,4 @@ Armory-extended Halyard  is an extended version of Halyard that deploys Armory f
 ```
 
 ## List of extended Halyard Releases
-<!-- Hugo/docsy auto generates a list of the child pages here. The front matter configures it to go from newest to oldest --!> 
+<!-- Hugo/docsy auto generates a list of the child pages here. The front matter configures it to go from newest to oldest --!>

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-0.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-0.md
@@ -1,5 +1,6 @@
 ---
 title: v1.6.0 Armory Halyard
+date: 2019-06-18
 toc_hide: true
 aliases:
   - armory-halyard_v1.6.0
@@ -14,7 +15,7 @@ aliases:
 
 - `hal shutdown` returns an `Error 400` message. We will be submitting a PR to OSS Spinnaker to resolve this.
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - chore(gradle): move to gradle5 (#220)
  - fix(release): point to armory-commons/master branch (#218)
  - chore(dependency): add kork dep to halyard-armory (#214)

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-1.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-1.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.6.1 Armory Halyard
+date: 2019-06-19
 toc_hide: true
 aliases:
   - armory-halyard_v1.6.1
@@ -17,9 +18,9 @@ This release updates `kubectl` to `1.12.9` and fixes the version displayed from 
 
 ## Known Issues
 
-- `hal shutdown` returns an `Error 400` message. A PR has been submitted to OSS Spinnaker to resolve this. 
+- `hal shutdown` returns an `Error 400` message. A PR has been submitted to OSS Spinnaker to resolve this.
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - chore(build): Upgrade kubectl to 1.12.9 (#227)
  - fix(build): Fix version returned in hal --version (#226)
 

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-2.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-2.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.6.2 Armory Halyard
+date: 2019-06-25
 toc_hide: true
 aliases:
   - armory-halyard_v1.6.2
@@ -13,13 +14,13 @@ aliases:
 
 ## Highlights
 
-This release fixes a regression introduced in `1.6.1` where `aws-iam-authenticator` was not installed properly. 
+This release fixes a regression introduced in `1.6.1` where `aws-iam-authenticator` was not installed properly.
 
 ## Known Issues
 
 - None
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - No Changes
 
 ##  Halyard Community Contributions

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-3.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-3.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.6.3 Armory Halyard
+date: 2019-07-16
 toc_hide: true
 aliases:
   - armory-halyard_v1.6.3
@@ -13,7 +14,7 @@ aliases:
 
 ## Highlights
 
-This release: 
+This release:
 * Enables secrets to pass through to Go services (Dinghy and Terraformer)
 * Adds Slack notifications for Dinghy
 
@@ -21,7 +22,7 @@ This release:
 
 - None
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - feat(secrets/go): Enable secrets to pass through to Go services that support it (#237)
  - feat(web): add ability to generate json for providers (#236)
  - feat(dinghy): Enable Slack notifications from Dinghy (#235)

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-4.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-4.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.6.4 Armory Halyard
+date: 2019-08-09
 toc_hide: true
 aliases:
   - armory-halyard_v1.6.4
@@ -13,7 +14,7 @@ aliases:
 
 ## Highlights
 
-This release: 
+This release:
 * Brings Halyard Armory in line with OSS Halyard 1.22
 * Enables logging on all HA Clouddriver services
 
@@ -24,8 +25,8 @@ Halyard fails to generate the Secrets config block for some service profiles.
 
 Please upgrade to `Armory-extended Halyard 1.6.5`.
 
-## Armory-extended Halyard 
- - fix(logging): add logback to all clouddriver HA profiles (#246) 
+## Armory-extended Halyard
+ - fix(logging): add logback to all clouddriver HA profiles (#246)
  - chore(release): pin 1_6_x to a later commit (#243)
  - fix(installer): Avoid changing existing customer UUID on hal armory init (#241)
  - feat(aws): upgrade awscli (#240)

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-5.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-6-5.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.6.5 Armory Halyard
+date: 2019-08-26
 toc_hide: true
 aliases:
   - armory-halyard_v1.6.5
@@ -19,11 +20,11 @@ This release addresses a problem where the Secrets config block was not generate
 ## Known Issues
 - This release has no known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - fix(secrets): fix secrets config block in service yamls (#252)
  - feat(artifactory): Move to artifactory for plugins and updated gradle work (#248)
  - chore(terraformer): Remove 'alpha' flag (#250)
  - fix(logging): add logback to all clouddriver HA profiles (#246)
- 
+
 ##  Halyard Community Contributions
 - No changes

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-7-0.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-7-0.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.7.0 Armory Halyard
+date: 2019-09-13
 toc_hide: true
 aliases:
   - armory-halyard_v1.7.0
@@ -20,7 +21,7 @@ This release has a bug which prevents `kubeconfig` files from being read from re
 
 Please upgrade to `halyard-armory` `1.7.1`
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
 No Changes
 
 ##  Halyard Community Contributions

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-7-1.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-7-1.md
@@ -1,6 +1,7 @@
 ---
 
-title: v1.7.1 Armory Halyard
+title: v1.07.1 Armory Halyard
+date: 2019-09-17
 toc_hide: true
 aliases:
   - armory-halyard_v1.7.1
@@ -17,7 +18,7 @@ This release fixes an issue which prevented `halyard` from reading local `kubeco
 ## Known Issues
 No known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
 - fix(kubeconfig): Get contents of local kubeconfig files #1425
 
 ##  Halyard Community Contributions

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-7-2.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-7-2.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.7.2 Armory Halyard
+date: 2019-10-09
 toc_hide: true
 aliases:
   - armory-halyard_v1.7.2
@@ -48,7 +49,7 @@ hal deploy apply
 ## Known Issues
 No known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - feat(deploy): Allow BOMs in GCS via spinnaker.config.input.gcs.enabled (#268)
  - fix(bom): Expire BOM cache after 1m (#267)
  - feat(gitlab): Add Dinghy config for Gitlab (#266)

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-0.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-0.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.8.0 Armory Halyard
+date: 2019-11-21
 toc_hide: true
 aliases:
   - armory-halyard_v1.8.0
@@ -19,7 +20,7 @@ In addition to support for configuring `git/repo` artifact types, this release i
 ## Known Issues
 No known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - fix(halconfigParser): access halconfigPath via new method (#278)
  - chore(testing): add additional integration tests (#275)
  - feat(docker): add gcloud to container (#274)

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-1.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-1.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.8.1 Armory Halyard
+date: 2020-01-06
 toc_hide: true
 aliases:
   - armory-halyard_v1.8.1
@@ -14,7 +15,7 @@ aliases:
 ## Known Issues
 No known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  - feat(plugin): Send plugin configs to deck (#273)
 
 ##  Halyard Community Contributions

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-2.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-2.md
@@ -1,6 +1,6 @@
 ---
-
 title: v1.8.2 Armory Halyard
+date: 2020-02-19
 toc_hide: true
 aliases:
   - armory-halyard_v1.8.2
@@ -14,7 +14,7 @@ aliases:
 ## Known Issues
 No known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  No Changes
 
 ## Halyard Community Contributions
@@ -39,4 +39,4 @@ No known issues
  - feat(huaweicloud): add provider of huaweicloud (#1476)
  - fix(deployments): Fixed k8s manifests templates generating invalid yaml (#1456)
  - Revert "feat(huaweicloud): first commit for huaweicloud (#1461)" (#1473)
- 
+

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-3.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-8-3.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.8.3 Armory Halyard
+date: 2020-04-02
 toc_hide: true
 aliases:
   - armory-halyard_v1.8.3
@@ -15,7 +16,7 @@ Armory-extended Halyard  1.8.3 is the minimum version required to deploy Armory 
 
 ## Known Issues
 
-### Plugins 
+### Plugins
 
 When you try to deploy Spinnaker using Halyard 1.8.3, you encounter the following error:
 
@@ -25,9 +26,9 @@ Validation in Global:
   "plugins" (class
 ```
 
-**Workaround** 
+**Workaround**
 
-Remove the top level key for Plugins in your Halconfig. 
+Remove the top level key for Plugins in your Halconfig.
 
 ### Secrets
 
@@ -37,7 +38,7 @@ Secrets are stored decrypted at rest in the Pods of the Spinnaker services.
 Upgrade to Armory-extended Halyard 1.9.0 or later.
 
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
  No Changes
 
 ## Halyard Community Contributions

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-0.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-0.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.9.0 Armory Halyard
+date: 2020-04-23
 toc_hide: true
 aliases:
   - armory-halyard_v1.9.0
@@ -8,7 +9,7 @@ aliases:
 
 ## 04/23/2020 Release Notes
 
-This version is required to deploy Armory 2.19+. 
+This version is required to deploy Armory 2.19+.
 
 
 ## Known Issue
@@ -17,15 +18,15 @@ This version is required to deploy Armory 2.19+.
 
 There is a known issue where Armory-extended Halyard 1.9.0 fails to install Armory 2.18.1. The Pod for Echo enters a crash loop.
 
-**Workaround** 
+**Workaround**
 
-Use Armory-extended Halyard  1.8.3 if you want to install Armory 2.18.1. 
+Use Armory-extended Halyard  1.8.3 if you want to install Armory 2.18.1.
 
 ## Highlights
 
 Armory's extended Halyard 1.9.0 resolves an issue where secrets are stored decrypted at rest in the Pods of the Spinnaker services.
 
-##  Armory-extended Halyard 
+##  Armory-extended Halyard
 - fix(secrets): have services decrypt their own secrets
 - chore(build): bump OSS Halyard to 1.34.0
 - Changes to add enabled/disabled to webhooks validation
@@ -36,7 +37,7 @@ Armory's extended Halyard 1.9.0 resolves an issue where secrets are stored decry
 
 
 
-## Halyard Community Contributions 
+## Halyard Community Contributions
 You can see the full changelog here: [version-1.32.0...version-1.34.0](https://github.com/spinnaker/halyard/compare/version-1.32.0...version-1.34.0)
 
 - chore(java11): Compile with Java 11 (but targeting Java 8) (#1608)

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-1.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-1.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.9.1 Armory Halyard
+date: 2020-05-14
 toc_hide: true
 aliases:
   - armory-halyard_v1.9.1
@@ -16,12 +17,12 @@ No known issues
 Armory-extended Halyard 1.9.1 resolves an issue where the Echo Pod in Armory 2.18 remained in a crash loop state.
 
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
 - fix(plugins): Use Armory version to detect if plugins are supported
 - chore(cve): CVE fixes
 
 
-## Halyard Community Contributions 
+## Halyard Community Contributions
 You can see the full changelog here: [version-1.34.0...version-1.35.3](https://github.com/spinnaker/halyard/compare/version-1.34.0...version-1.35.3)
 
 - chore(dependencies): Autobump korkVersion (#1609) …

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-4.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-4.md
@@ -1,6 +1,7 @@
 ---
 
 title: v1.9.4 Armory Halyard
+date: 2020-05-21
 toc_hide: true
 ---
 
@@ -12,7 +13,7 @@ No known issues
 ### Known Issues
 No known issues
 
-## Armory-extended Halyard 
+## Armory-extended Halyard
 
 - fix(cve): Security fix for CVE-2020-1945
 - Upgrade OSS Halyard to 1.36.0

--- a/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-5.md
+++ b/content/en/docs/release-notes/rn-armory-halyard/armory-halyard-v1-9-5.md
@@ -1,6 +1,8 @@
 ---
 
 title: v1.9.5 Armory Halyard
+date: 2020-09-30
+hal_version: 1.09.50
 toc_hide: true
 ---
 
@@ -12,10 +14,10 @@ No known issues
 ### Known Issues
 No known issues
 
-## Armory-extended Halyard 
- 
+## Armory-extended Halyard
+
 - Upgrade OSS Halyard to 1.39.0
-- fix(cve): Security fix for CVE-2020-7692 
+- fix(cve): Security fix for CVE-2020-7692
 - fix(cve): Security fix for CVE-2020-5410
 - feat(secrets): add vault namespace support
-- feat(dinghy): Changes for repository processing in dinghy 
+- feat(dinghy): Changes for repository processing in dinghy

--- a/content/en/docs/release-notes/rn-armory-operator/_index.md
+++ b/content/en/docs/release-notes/rn-armory-operator/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Armory Operator Release Notes"
-simple_list_reverse: true
+layout: release-notes-all
 ---
 
 > You can find [Armory's releases notes here]({{< ref "rn-armory-spinnaker" >}}).

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-0-3.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-0-3.md
@@ -1,7 +1,7 @@
 ---
-
 title: v1.0.3 Armory Operator
 toc_hide: true
+date: 2020-08-03
 ---
 
 ## 08/03/2020 Release Notes

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-1-0.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-1-0.md
@@ -1,6 +1,7 @@
 ---
 title: v1.1.0 Armory Operator
 toc_hide: true
+date: 2020-08-11
 ---
 
 ## 08/11/2020 Release Notes
@@ -29,13 +30,13 @@ This will be addressed in a patch release for the `1.1.x` release line.
 
 ### Ingress Support
 
-`spec.expose.type: ingress`. When `ingress` is selected, the Operator tries to find an ingress rule 
+`spec.expose.type: ingress`. When `ingress` is selected, the Operator tries to find an ingress rule
 in the same namespace as Spinnaker that points to Gate or Deck. It will then compute these services' hostnames using either `spec.rules[].host` or `status.loadBalancer.ingress[0].hostname`.
 
 Both `extensions` and `networking.k8s.io` ingresses are supported and queried.
 
 For Gate, the Operator also checks for the path and sets up Spinnaker to support relative paths.
- 
+
 The following example sets up Spinnaker's UI (Deck) at `http://acme.com` and API (Gate) at `http://acme.com/api`:
 
 ```yaml

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-1-1.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-1-1.md
@@ -1,7 +1,7 @@
 ---
-
 title: v1.1.1 Armory Operator
 toc_hide: true
+date: 2020-08-13
 ---
 
 ## 08/13/2020 Release Notes
@@ -17,6 +17,6 @@ No known issues.
 
 ### Spinnaker Operator
 
-* fix(test): Added ingress permissions to role used in tests 
+* fix(test): Added ingress permissions to role used in tests
 * fix(expose/ingress): solve issue for spinsvc status URL
 

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-1-2.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-1-2.md
@@ -1,7 +1,7 @@
 ---
-
 title: v1.1.2 Armory Operator
 toc_hide: true
+date: 2020-09-30
 ---
 
 ## 09/30/2020 Release Notes
@@ -13,7 +13,7 @@ No known issues.
 
 * chore(release): upgrade to oss operator 1.1.2
 * chore(license): update LICENSES
-* fix(helm): solve error assigning version to Helm Chart 
+* fix(helm): solve error assigning version to Helm Chart
 * feat(ubi): add build for ubi images
 
 ### Spinnaker Operator

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-0.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-0.md
@@ -1,7 +1,7 @@
 ---
-
 title: v1.2.0 Armory Operator
 toc_hide: true
+date: 2020-10-07
 ---
 
 ## 10/07/2020 Release Notes

--- a/layouts/docs/release-notes-all.html
+++ b/layouts/docs/release-notes-all.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+        {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+            {{ partial "reading-time.html" . }}
+        {{ end }}
+	{{ .Content }}
+        {{ partial "list-all-release-notes.html" . }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+</div>
+{{ end }}

--- a/layouts/docs/release-notes-no-archive.html
+++ b/layouts/docs/release-notes-no-archive.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+        {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+            {{ partial "reading-time.html" . }}
+        {{ end }}
+	{{ .Content }}
+        {{ partial "list-release-notes-no-archive.html" . }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+</div>
+{{ end }}

--- a/layouts/partials/list-all-release-notes.html
+++ b/layouts/partials/list-all-release-notes.html
@@ -1,0 +1,13 @@
+<div class="section-index">
+  {{ $pages := (where .Site.Pages "Section" .Section).ByDate }}
+  {{ $pagesReverse := (where .Site.Pages "Section" .Section).ByDate.Reverse }}
+  {{ $parent := .Page }}
+
+  <ul>
+    {{ range $pagesReverse }}
+      {{ if eq .Parent $parent }}
+            <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
+      {{end}}
+    {{ end }}
+  </ul>
+</div>

--- a/layouts/partials/list-release-notes-no-archive.html
+++ b/layouts/partials/list-release-notes-no-archive.html
@@ -1,0 +1,52 @@
+<div class="section-index">
+  {{ $pages := (where .Site.Pages "Section" .Section).ByDate }}
+  {{ $pagesReverse := (where .Site.Pages "Section" .Section).ByDate.Reverse }}
+  {{ $parent := .Page }}
+
+  <ul>
+    {{ $semverActiveMajor := 10000 }}
+    {{ $semverActiveMinor := 10000 }}
+    {{ $semverActivePatch := 10000 }}
+
+    {{$displayedTitles := slice }}
+
+    {{ range $pagesReverse }}
+      {{ if eq .Parent $parent }}
+
+        {{/* this will pickout the first {major}.{minor}.{patch} numbers */}}
+        {{ $semverSlice := findRE "[0-9]+" .Title }}
+
+        {{ if and (ge (len $semverSlice) 3) (lt (len $displayedTitles) 3) }}
+          {{if and (le ( index $semverSlice 0 ) $semverActiveMajor) (lt ( index $semverSlice 1 ) $semverActiveMinor)  }}
+            {{ $semverActiveMajor = index $semverSlice 1 }}
+            {{ $semverActiveMinor = index $semverSlice 1 }}
+            {{ $semverActivePatch = index $semverSlice 2 }}
+            {{ $displayedTitles = $displayedTitles | append .Title }}
+            <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
+          {{end}}
+        {{end}}
+      {{end}}
+    {{ end }}
+  </ul>
+  <div>Versions listed below will soon be deprecated:</div>
+  <ul>
+
+    {{$displayedMinoredVersions := 0}}
+
+    {{ range $pagesReverse }}
+      {{ if and (eq .Parent $parent) (not (in $displayedTitles .Title)) }}
+
+        {{/* this will pickout the first {major}.{minor}.{patch} numbers */}}
+        {{ $semverSlice := findRE "[0-9]+" .Title }}
+
+        {{ if and (ge (len $semverSlice) 3)  (lt $displayedMinoredVersions 1) }}
+          {{if ge (index $semverSlice 1) $semverActiveMinor }}
+            {{ $displayedTitles = $displayedTitles | append .Title }}
+            <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
+          {{end}}
+        {{end}}
+      {{end}}
+    {{ end }}
+  </ul>
+
+</div>


### PR DESCRIPTION
Add partials and layouts for halyard and operator. Both sort by date,
which requires "date: yyyy-mm-dd" in the front matter. The issue with
the list-recent-release-notes is that it sorts pages by weight and then
title, which causes the Halyard release notes to not be in the correct
order because the title is a string. For example, v1.10.0 appears as
older than 1.9.4. PR #309 illustrates this. https://s.armory.io/jkuDzEzk

Creating the underlying structural fix here and will incorporate into PR #309 after this PR is merged.

I incorporated the templates into PR 309 locally so you can see the results.
Screenshot of Halyard release notes using this new structure:
https://s.armory.io/p9uwvXlP

Operator release notes:
https://s.armory.io/6quPdELk


Eventually we should convert the Armory release notes to use the sort by date, which requires adding the "date" front matter to all files and also changing the template the section index page uses.