### PR TITLE
docs(theme): Update to latest Docsy theme release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -87,6 +87,11 @@ weight = 1
   weight = 8
   url = "https://www.armory.io/blog/"
 
+
+# print support
+[outputs]
+section = [ "HTML", "RSS", "print" ]
+
 # Everything below this are Site Params
 
 [params]
@@ -180,6 +185,10 @@ enable = false
 # Enable Mermaid diagrams
 [params.mermaid]
 enable = true
+
+# disable showing TOC in printable view
+[params.print]
+disable_toc = true
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -53,7 +53,7 @@ other = "This the multi-page, printable view of this section."
 [print_click_to_print]
 other = "Click here to print"
 [print_show_regular]
-other = "Return to the regular view of this page."
+other = "Return to the regular view of the section index."
 [print_entire_section]
 other = "Print entire section"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -53,7 +53,7 @@ other = "This the multi-page, printable view of this section."
 [print_click_to_print]
 other = "Click here to print"
 [print_show_regular]
-other = "Return to the regular view of the section index."
+other = "Return to the regular view of this section index"
 [print_entire_section]
 other = "Print entire section"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -46,3 +46,14 @@ other = "Create documentation issue"
 other = "Create project issue"
 [post_posts_in]
 other = "Posts in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page, printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page."
+[print_entire_section]
+other = "Print entire section"
+


### PR DESCRIPTION
This includes Print section functionality. Readers should still use their browser's print function to print a single page.

Default message at top of print view:  https://s.armory.io/JruqPZr5

I customized to add how to print a single page: https://s.armory.io/geuojK6m

Which do you like better? 