### PR TITLE
docs(agent): add supported versions section

### DIFF
--- a/content/en/docs/armory-agent/_index.md
+++ b/content/en/docs/armory-agent/_index.md
@@ -101,3 +101,8 @@ You can also mix deployment strategies if you have complex Kubernetes infrastruc
 - Run in target clusters
 - Run next to traditional Spinnaker Kubernetes accounts
 
+## Supported versions
+
+{{< include "agent/agent-compat-matrix.md" >}}
+
+For a full list of previous releases, see this [page](https://armory.jfrog.io/artifactory/manifests/).


### PR DESCRIPTION
* Reuses the include file from the compatibility matrix from the quickstart and puts it under a Supported Versions section title to satisfy a customer requirement.
* Adds a link to artifactory (the same link used to download Agent) if people want to see a full version list
