### PR TITLE
docs(seo): configure sitemap plugin in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -78,12 +78,17 @@
   to = "/docs/armory-admin/armory-agent/"
   force = true
 
-
+# https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]
 package = "@netlify/plugin-sitemap"
 
   [plugins.inputs]
   buildDir = "public"
   exclude =[
-    '/docs/plugin-guide/plugin-appname/'
+    './public/docs/plugin-guide/plugin-appname/',
+    './public/docs/plugin-guide/plugin-policy-engine/'
   ]
+  # append missing trailing slash to prettyURL
+  trailingSlash = true
+  changeFreq= daily
+  priority = 0.5

--- a/netlify.toml
+++ b/netlify.toml
@@ -79,6 +79,7 @@
   force = true
 
 
+# https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]
 package = "@netlify/plugin-sitemap"
 
@@ -90,5 +91,5 @@ package = "@netlify/plugin-sitemap"
   ]
   # append missing trailing slash to prettyURL
   trailingSlash = true
-  changeFreq = daily
+  changeFreq = "daily"
   priority = 0.5

--- a/netlify.toml
+++ b/netlify.toml
@@ -78,7 +78,7 @@
   to = "/docs/armory-admin/armory-agent/"
   force = true
 
-# https://github.com/netlify-labs/netlify-plugin-sitemap
+
 [[plugins]]
 package = "@netlify/plugin-sitemap"
 
@@ -90,5 +90,5 @@ package = "@netlify/plugin-sitemap"
   ]
   # append missing trailing slash to prettyURL
   trailingSlash = true
-  changeFreq= daily
+  changeFreq = daily
   priority = 0.5

--- a/netlify.toml
+++ b/netlify.toml
@@ -91,5 +91,5 @@ package = "@netlify/plugin-sitemap"
   ]
   # append missing trailing slash to prettyURL
   trailingSlash = true
-  changeFreq = "daily"
+  changeFreq = "weekly"
   priority = 0.5


### PR DESCRIPTION
https://github.com/netlify-labs/netlify-plugin-sitemap

add trailing slash to url
change frequency to daily

Also, the pages in the `exclude` weren't being excluded from the generated site map, so changed format of pages.

To test, look for "plugin-appname" and "plugin-policy-engine" in https://deploy-preview-357--armory-docs.netlify.app/sitemap.xml  Neither entry should be in the sitemap.xml

https://www.sitemaps.org/protocol.html

https://armory.atlassian.net/browse/DOC-265