### PR TITLE
docs(contrib): add page on using config parameters

### DIFF
--- a/content/en/docs/zz-contribute/markdown-elements.md
+++ b/content/en/docs/zz-contribute/markdown-elements.md
@@ -1,8 +1,8 @@
 ---
-title: "Smoke Test"
+title: "Markdown Examples"
 draft: true
 description: >
-  Markdown stuff - change to draft before publication
+  Headers, tables, lists, images
 ---
 
 

--- a/content/en/docs/zz-contribute/using-params.md
+++ b/content/en/docs/zz-contribute/using-params.md
@@ -1,0 +1,47 @@
+---
+title: "Using Parameters"
+draft: true
+description: >
+  Add a parameter to `config.toml` and then use it in Markdown pages.
+---
+
+You can add a new global parameter to `config.toml` in the `[params]` section.
+
+You use the Hugo `param` shortcode to display the value of the parameter.
+
+
+```markdown
+
+The latest Armory version is {{</* param armory-version */>}}.
+```
+
+Renders as:
+
+The latest Armory version is {{< param armory-version >}}.
+
+
+You can use the `param` shortcode inside codeblock as well.
+
+```markdown
+latestHalyard: {{</* param halyard-armory-version */>}}
+latestSpinnaker: {{</* param armory-version */>}}
+versions:
+- version: {{</* param armory-version */>}}
+  alias: OSS Release <ossVersion> # The corresponding OSS version can be found in the Release Notes
+  changelog: <Link to Armory Release Notes for this version>
+  minimumHalyardVersion: 1.2.0
+  lastUpdate: "1568853000000"
+```
+
+Renders as:
+
+```yaml
+latestHalyard: {{< param halyard-armory-version >}}
+latestSpinnaker: {{< param armory-version >}}
+versions:
+- version: {{< param armory-version >}}
+  alias: OSS Release <ossVersion> # The corresponding OSS version can be found in the Release Notes
+  changelog: <Link to Armory Release Notes for this version>
+  minimumHalyardVersion: 1.2.0
+  lastUpdate: "1568853000000"
+```


### PR DESCRIPTION
this is only visible when you build locally with `hugo server -D`