### PR TITLE
fix(secrets/s3): consistent convention for secret path

### DIFF
--- a/content/en/docs/armory-admin/Secrets/secrets-s3.md
+++ b/content/en/docs/armory-admin/Secrets/secrets-s3.md
@@ -49,5 +49,5 @@ encrypted:s3!r:us-west-2!b:mybucket!f:spinnaker-secrets.yml!k:github.password
 
 And to reference the content of our kubeconfig file:
 ```yaml
-encryptedFile:s3!f:mykubeconfig!r:us-west-2!b:mybucket
+encryptedFile:s3!r:us-west-2!b:mybucket!f:mykubeconfig
 ```


### PR DESCRIPTION
ensure the syntax follows the convention of (gets more specific as we go on) `secretEngine > region > bucket > file > key`