### PR TITLE
docs(fix): fix space bug in linkWithTitle shortcode 

### DIFF
--- a/content/en/docs/zz-contribute/shortcodes/index.md
+++ b/content/en/docs/zz-contribute/shortcodes/index.md
@@ -10,7 +10,7 @@ draft: true
 
 gist, youtube, figure, ref, relref and more
 
-For how to use the `gist` shortcode, see {{< linkWithTitle "gist-vs-codeblock.md" >}} and {{< linkWithTitle "entire-gist.md" >}}
+For how to use the `gist` shortcode, see {{< linkWithTitle "gist-vs-codeblock.md" >}} and {{< linkWithTitle "entire-gist.md" >}}.
 
 ## Docsy theme shortcodes
 
@@ -38,11 +38,15 @@ If you want to use the page's front matter title as the text of the hyperlink, y
 ```markdown
 
 See the {{</* linkWithTitle best-practices.md */>}} page...
+
+Look at this page: {{</* linkWithTitle best-practices.md */>}}.
 ```
 
 Renders as:
 
 See the {{< linkWithTitle best-practices.md >}} page...
+
+See this page: {{< linkWithTitle agent-troubleshooting.md >}}.
 
 ### Google suite shortcode
 

--- a/layouts/shortcodes/linkWithTitle.html
+++ b/layouts/shortcodes/linkWithTitle.html
@@ -1,4 +1,3 @@
 {{- $fileName := .Get 0 -}}
 {{ with .Site.GetPage $fileName }}
-<a href="{{ .Permalink }}"}>{{ .Title }}</a>
-{{ end }}
+<a href="{{.Permalink}}"}>{{.Title}}</a>{{ end }}


### PR DESCRIPTION
[DOC-280]

[DOC-280]: https://armory.atlassian.net/browse/DOC-280