### PR TITLE
docs(pr-template): add line

### DIFF
--- a/.github/pull_request_template.m
+++ b/.github/pull_request_template.m
@@ -1,5 +1,6 @@
 <!-- Make sure your PR title matches the following format: <type>(<scope>): <subject> -->
 <!-- Include the Jira or GitHub issue associated with this work if there is one -->
+<!-- If Jira, enclose the ticket in brackets example: [DOC-123] -->
 Resolves issue: 
 
 <!-- Share artifacts of the changes if they'd help your reviewer, e.g. a screenshot -->


### PR DESCRIPTION
add line on how to format the jira ticket so the Jira-GH integration recognizes it

<!-- Make sure your PR title matches the following format: <type>(<scope>): <subject> -->
<!-- Include the Jira or GitHub issue associated with this work if there is one -->
Resolves issue: 

<!-- Share artifacts of the changes if they'd help your reviewer, e.g. a screenshot -->
