### PR TITLE
docs(infra): escape character in example

### DIFF
--- a/.github/pull_request_template.m
+++ b/.github/pull_request_template.m
@@ -1,6 +1,6 @@
 <!-- Make sure your PR title matches the following format: <type>(<scope>): <subject> -->
 <!-- Include the Jira or GitHub issue associated with this work if there is one -->
-<!-- If Jira, enclose the ticket in brackets example: [DOC-123] -->
+<!-- If Jira, enclose the ticket in square brackets example: \[DOC-123\] without the escape backslash though -->
 Resolves issue: 
 
 <!-- Share artifacts of the changes if they'd help your reviewer, e.g. a screenshot -->


### PR DESCRIPTION
<!-- Make sure your PR title matches the following format: <type>(<scope>): <subject> -->
<!-- Include the Jira or GitHub issue associated with this work if there is one -->
<!-- If Jira, enclose the ticket in brackets example:  -->
Resolves issue: 
[DOC-298]

<!-- Share artifacts of the changes if they'd help your reviewer, e.g. a screenshot -->


[DOC-298]: https://armory.atlassian.net/browse/DOC-298