### PR TITLE
docs(fix): SEO changes to Installation section

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -1,24 +1,25 @@
 ---
-title: "Installation"
+title: "Installating the Armory Enterprise Platform for Spinnaker"
 linkTitle: "Installation"
 weight: 5
 description: |
-  Guides for installing Armory, an enterprise continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment.
+  Guides for installing Armory, an enterprise continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install the Armory Enterprise Platform for Spinnaker, or use the open source Spinnaker Operator for Kubernetes to install open source Spinnaker.
 aliases:
   - /install_guide/install/
   - /install-guide/getting_started/
   - /docs/spinnaker/install/
 ---
 
-## Installation methods
+## Methods for installing the Armory Enterprise Platform for Spinanker or open source Spinnaker
 
-There are several methods to install Armory:
+There are several methods to install Armory or open source Spinnaker:
 
 | Method                             | Environment           | Description                                                          | Benefits                                                            |
 |------------------------------------|-----------------------|----------------------------------------------------------------------|-----------------------------------------------------------------|
 | [Armory Operator]({{< ref "operator" >}})   | Kubernetes            | Kubernetes operator that turns Armory's configuration declarative | GitOps friendly and ready for production use                                 |
 | [Armory Halyard]({{< ref "armory-halyard" >}}) | Kubernetes            | Versatile command line interface to configure and deploy Armory   | Quick Setup                                                     |
-| [Minnaker]({{< ref "minnaker" >}})             | MacOS, Linux, Windows | Spin up a whole environment on top of Rancher K3s to deploy Armory    | This is ideal if you do not have a Kubernetes cluster available and want to try out Armory |
+| [Minnaker]({{< ref "minnaker" >}})             | MacOS, Linux, Windows | Spin up a whole environment on top of Rancher K3s to deploy Armory or Spinnaker    | This is ideal if you do not have a Kubernetes cluster available and want to try out Armory or Spinnaker |
+| [Spinnaker Operator]({{< ref "operator" >}})   | Kubernetes            | An open source Kubernetes operator that turns Spinnaker's configuration declarative | GitOps friendly and ready for production use                                 |
 
 
 All the methods above share similar configurations, and you can migrate between them if your needs change.

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -16,10 +16,10 @@ There are several methods to install Armory or open source Spinnaker:
 
 | Method                             | Environment           | Description                                                          | Benefits                                                            |
 |------------------------------------|-----------------------|----------------------------------------------------------------------|-----------------------------------------------------------------|
-| [Armory Operator]({{< ref "operator" >}})   | Kubernetes            | Kubernetes operator that turns Armory's configuration declarative | GitOps friendly and ready for production use                                 |
+| [Armory Operator]({{< ref "operator" >}})   | Kubernetes            | Kubernetes Operator that turns Armory's configuration declarative | GitOps friendly and ready for production use                                 |
 | [Armory Halyard]({{< ref "armory-halyard" >}}) | Kubernetes            | Versatile command line interface to configure and deploy Armory   | Quick Setup                                                     |
 | [Minnaker]({{< ref "minnaker" >}})             | MacOS, Linux, Windows | Spin up a whole environment on top of Rancher K3s to deploy Armory or Spinnaker    | This is ideal if you do not have a Kubernetes cluster available and want to try out Armory or Spinnaker |
-| [Spinnaker Operator]({{< ref "operator" >}})   | Kubernetes            | An open source Kubernetes operator that turns Spinnaker's configuration declarative | GitOps friendly and ready for production use                                 |
+| [Operator]({{< ref "operator" >}})   | Kubernetes            | An open source Kubernetes Operator that installs open source Spinnaker | GitOps friendly and ready for production use                                 |
 
 
 All the preceding methods share similar configurations, and you can migrate between them if your needs change.

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -1,9 +1,9 @@
 ---
-title: "Installating the Armory Enterprise Platform for Spinnaker"
+title: "Installing the Armory Enterprise Platform for Spinnaker"
 linkTitle: "Installation"
 weight: 5
 description: |
-  Guides for installing the Armory Enterprise Platform, an enterprise continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install the Armory Enterprise Platform for Spinnaker, or use the open source Operator to install open source Spinnaker in Kubernetes.
+  Guides for installing the Armory Enterprise Platform, a continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install the Armory Enterprise Platform for Spinnaker, or use the open source Operator to install open source Spinnaker in Kubernetes.
 aliases:
   - /install_guide/install/
   - /install-guide/getting_started/

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -3,7 +3,7 @@ title: "Installating the Armory Enterprise Platform for Spinnaker"
 linkTitle: "Installation"
 weight: 5
 description: |
-  Guides for installing Armory, an enterprise continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install the Armory Enterprise Platform for Spinnaker, or use the open source Spinnaker Operator for Kubernetes to install open source Spinnaker.
+  Guides for installing the Armory Enterprise Platform, an enterprise continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install the Armory Enterprise Platform for Spinnaker, or use the open source Operator to install open source Spinnaker in Kubernetes.
 aliases:
   - /install_guide/install/
   - /install-guide/getting_started/

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -10,7 +10,7 @@ aliases:
   - /docs/spinnaker/install/
 ---
 
-## Methods for installing the Armory Enterprise Platform for Spinanker or open source Spinnaker
+## Methods for installing the Armory Enterprise Platform for Spinnaker or open source Spinnaker
 
 There are several methods to install Armory or open source Spinnaker:
 
@@ -22,9 +22,9 @@ There are several methods to install Armory or open source Spinnaker:
 | [Spinnaker Operator]({{< ref "operator" >}})   | Kubernetes            | An open source Kubernetes operator that turns Spinnaker's configuration declarative | GitOps friendly and ready for production use                                 |
 
 
-All the methods above share similar configurations, and you can migrate between them if your needs change.
+All the preceding methods share similar configurations, and you can migrate between them if your needs change.
 
-> Armory does not generate default hardcoded usernames and passwords for user accounts for any service. Manage these by configuring authentication and authorization for the Armory Platform.
+> Armory does not generate default usernames and passwords for user accounts for any service. Manage these by configuring authentication and authorization for the Armory Platform.
 
 ## Guides
 

--- a/content/en/docs/installation/guide/_index.md
+++ b/content/en/docs/installation/guide/_index.md
@@ -1,7 +1,8 @@
 ---
-title: "Guides"
+title: "Guides for Installing the Armory Enterprise Platform for Spinnaker"
+linkTitle: "Guides"
 description: >
-   This section details installing Armory in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS Marketplace. Instructions cover using Halyard and the Armory Operator in local, cloud, and air-gapped environments.
+   This section details installing Spinnaker or the Armory Enterprise Platform for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Installation instructions cover using Halyard, the Armory Operator, or the Spinnaker Operator for Kubernetes in local, cloud, and air-gapped environments.
 weight: 5
 ---
 

--- a/content/en/docs/installation/guide/_index.md
+++ b/content/en/docs/installation/guide/_index.md
@@ -2,7 +2,7 @@
 title: "Guides for Installing the Armory Enterprise Platform for Spinnaker"
 linkTitle: "Guides"
 description: >
-   This section details installing Spinnaker or the Armory Enterprise Platform for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Installation instructions cover using Halyard, the Armory Operator, or the Spinnaker Operator for Kubernetes in local, cloud, and air-gapped environments.
+   This section details installing Spinnaker or the Armory Enterprise Platform for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Installation instructions cover using Halyard, the Armory Operator, or the open source Operator for Kubernetes in local, cloud, and air-gapped environments.
 weight: 5
 ---
 

--- a/content/en/docs/installation/guide/_index.md
+++ b/content/en/docs/installation/guide/_index.md
@@ -8,4 +8,4 @@ weight: 5
 
 Once installed, Armory can deploy to supported providers through Clouddriver regardless of where it is installed.
 
-See [Air-gapped Environments]({{< ref "air-gapped" >}}) for additional steps you have to take if you have an air-gapped environment.
+See {{< linkWithTitle "air-gapped.md" >}} for additional steps you have to take if you have an air-gapped environment.

--- a/content/en/docs/installation/guide/air-gapped.md
+++ b/content/en/docs/installation/guide/air-gapped.md
@@ -3,7 +3,7 @@ title: Installing the Armory Enterprise Platform for Spinnaker in Air-Gapped Env
 linkTitle: Air-Gapped Environments
 weight: 1
 description: >
-  Options for installing Armory in an environment that is isolated from the internet.
+  Options for installing the Armory Enterprise Platform for Spinnaker in an environment that is isolated from the internet.
 ---
 
 ## Overview of air-gapped environments

--- a/content/en/docs/installation/guide/air-gapped.md
+++ b/content/en/docs/installation/guide/air-gapped.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory in Air-Gapped Environments
+title: Installing the Armory Enterprise Platform for Spinnaker in Air-Gapped Environments
 linkTitle: Air-Gapped Environments
 weight: 1
 description: >

--- a/content/en/docs/installation/guide/aws-container-marketplace.md
+++ b/content/en/docs/installation/guide/aws-container-marketplace.md
@@ -6,7 +6,7 @@ aliases:
   - /spinnaker/aws_container_marketplace/
   - /spinnaker/aws-container-marketplace/
 description: >
-  Use the Armory Operator from the AWS Container Marketplace to install Armory in your Amazon Kubernetes (EKS) cluster.
+  Use the Armory Operator from the AWS Container Marketplace to install the Armory Enterprise Platform for Spinnaker in your Amazon Kubernetes (EKS) cluster.
 
 ---
 

--- a/content/en/docs/installation/guide/aws-container-marketplace.md
+++ b/content/en/docs/installation/guide/aws-container-marketplace.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory in AWS from the AWS Container Marketplace
+title: Installing the Armory Enterprise Platform for Spinnaker in AWS from the AWS Container Marketplace
 linkTitle: Install from AWS Marketplace
 weight: 2
 aliases:

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory in AKS
+title: Installing the Armory Enterprise Platform for Spinnaker in AKS
 linkTitle: "Install in AKS"
 weight: 5
 aliases:

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -8,7 +8,7 @@ aliases:
   - /spinnaker-install-admin-guides/install_on_aks/
   - /spinnaker-install-admin-guides/install-on-aks/
 description: >
-  This guide describes how to install Armory in the Azure Kubernetes Service (AKS).
+  This guide describes how to install the Armory Enterprise Platform for Spinnaker in the Azure Kubernetes Service (AKS).
 ---
 
 ## Overview of installing Armory in AKS

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -1,5 +1,5 @@
 ---
-title: Installing the Armory Enterprise Platform for Spinnaker in AKS
+title: Installing the Armory Enterprise Platform for Spinnaker in the Azure Kubernetes Service
 linkTitle: "Install in AKS"
 weight: 5
 aliases:
@@ -8,7 +8,7 @@ aliases:
   - /spinnaker-install-admin-guides/install_on_aks/
   - /spinnaker-install-admin-guides/install-on-aks/
 description: >
-  This guide describes how to install the Armory Enterprise Platform for Spinnaker in the Azure Kubernetes Service (AKS).
+  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to install the Armory Enterprise Platform for Spinnaker in the Azure Kubernetes Service (AKS).
 ---
 
 ## Overview of installing Armory in AKS

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -12,7 +12,7 @@ aliases:
   - /spinnaker_install_admin_guides/install-on-aws/
   - /spinnaker-install-admin-guides/install-on-aws/
 description: >
-  This guide describes how to install Armory in an AWS Kubernetes cluster or in an on-prem Kubernetes cluster with access to S3.
+  This guide describes how to install the Armory Enterprise Platform for Spinnaker in an AWS Kubernetes cluster or in an on-prem Kubernetes cluster with access to S3.
 ---
 
 ## Overview of installing Armory in AWS

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Armory Enterprise Platform for Spinnaker in Amazon Web Services
 linkTitle: "Install in AWS"
-weight: 4
+weight: 5
 aliases:
   - /spinnaker_install_admin_guides/install_on_eks/
   - /spinnaker_install_admin_guides/install-on-eks/
@@ -12,7 +12,7 @@ aliases:
   - /spinnaker_install_admin_guides/install-on-aws/
   - /spinnaker-install-admin-guides/install-on-aws/
 description: >
-  This guide describes how to install the Armory Enterprise Platform for Spinnaker in an AWS Kubernetes cluster or in an on-prem Kubernetes cluster with access to S3.
+  Use Armory-extended Halyard to install the Armory Enterprise Platform for Spinnaker in an AWS Kubernetes cluster or in an on-prem Kubernetes cluster with access to Amazon Secure Storage Service.
 ---
 
 ## Overview of installing Armory in AWS

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory in Amazon Web Services
+title: Installing the Armory Enterprise Platform for Spinnaker in Amazon Web Services
 linkTitle: "Install in AWS"
 weight: 4
 aliases:

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -5,7 +5,7 @@ weight: 7
 aliases:
   - /spinnaker-install-admin-guides/install-on-gke-operator/
 description: >
-  Learn how to install Armory or Spinnaker in a Google Kubernetes Engine cluster using the Armory Operator.
+  Learn how to install Spinnaker or the Armory Enterprise Platform for Spinnaker in a Google Kubernetes Engine cluster using the Armory Operator.
 ---
 
 This guide contains instructions for installing Armory on a Google Kubernetes Engine (GKE) cluster using the [Armory Operator]({{< ref "operator" >}}). Refer to the [Armory Operator Reference]({{< ref "operator-config" >}}) for manifest entry details.

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory in the Google Kubernetes Engine using the Armory Operator
+title: Installing the Armory Enterprise Platform for Spinnaker in the Google Kubernetes Engine using the Armory Operator
 linkTitle: "Install in GKE using Operator"
 weight: 7
 aliases:

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -1,11 +1,11 @@
 ---
-title: Installing the Armory Enterprise Platform for Spinnaker in the Google Kubernetes Engine using the Armory Operator
+title: Installing the Armory Enterprise Platform for Spinnaker in the Google Kubernetes Engine Using the Armory Operator
 linkTitle: "Install in GKE using Operator"
-weight: 7
+weight: 5
 aliases:
   - /spinnaker-install-admin-guides/install-on-gke-operator/
 description: >
-  Learn how to install Spinnaker or the Armory Enterprise Platform for Spinnaker in a Google Kubernetes Engine cluster using the Armory Operator.
+  Use the Armory Operator to install the Armory Enterprise Platform for Spinnaker in your Google Kubernetes Engine (GKE) cluster.
 ---
 
 This guide contains instructions for installing Armory on a Google Kubernetes Engine (GKE) cluster using the [Armory Operator]({{< ref "operator" >}}). Refer to the [Armory Operator Reference]({{< ref "operator-config" >}}) for manifest entry details.

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -1,7 +1,7 @@
 ---
-title: Installing the Armory Enterprise Platform for Spinnaker in GKE
+title: Installing the Armory Enterprise Platform for Spinnaker in the Google Kubernetes Engine
 linkTitle: "Install in GKE"
-weight: 6
+weight: 5
 aliases:
   - /spinnaker_install_admin_guides/install_on_gke/
   - /spinnaker_install_admin_guides/install-on-gke/

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory in GKE
+title: Installing the Armory Enterprise Platform for Spinnaker in GKE
 linkTitle: "Install in GKE"
 weight: 6
 aliases:

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -8,7 +8,7 @@ aliases:
   - /spinnaker-install-admin-guides/install_on_gke/
   - /spinnaker-install-admin-guides/install-on-gke/
 description: >
-  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to install Armory in your Google Kubernetes Engine (GKE) cluster.
+  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to install the Armory Enterprise Platform for Spinnaker in your Google Kubernetes Engine (GKE) cluster.
 ---
 
 ## Overview of installing Armory

--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -1,11 +1,11 @@
 ---
-title: Installing the Armory Enterprise Platform for Spinnaker on Kubernetes
+title: Installing the Armory Enterprise Platform for Spinnaker in Kubernetes
 linkTitle: Install in Kubernetes
 weight: 3
 aliases:
   - /spinnaker-install-admin-guides/install-on-k8s/
 description: >
-  Use Armory-extended Halyard or the Armory Operator to install Armory on Kubernetes.
+  Use Armory-extended Halyard or the Armory Operator to install the Armory Enterprise Platform for Spinnaker in Kubernetes.
 ---
 
 ## Overview

--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Armory on Kubernetes
+title: Installing the Armory Enterprise Platform for Spinnaker on Kubernetes
 linkTitle: Install in Kubernetes
 weight: 3
 aliases:

--- a/content/en/docs/installation/guide/install-redhat-marketplace.md
+++ b/content/en/docs/installation/guide/install-redhat-marketplace.md
@@ -1,5 +1,5 @@
 ---
-title: Install on OpenShift using the Armory Operator from the Red Hat Marketplace
+title: Installing the Armory Enterprise Platform for Spinnaker on OpenShift using the Armory Operator from the Red Hat Marketplace
 linkTitle: Install on OpenShift
 weight: 2
 description: >

--- a/content/en/docs/installation/guide/install-redhat-marketplace.md
+++ b/content/en/docs/installation/guide/install-redhat-marketplace.md
@@ -3,7 +3,7 @@ title: Installing the Armory Enterprise Platform for Spinnaker on OpenShift usin
 linkTitle: Install on OpenShift
 weight: 2
 description: >
-  Use the Armory Operator from the Red Hat Marketplace to install Armory in your OpenShift cluster.
+  Use the Armory Operator from the Red Hat Marketplace to install the Armory Enterprise Platform for Spinnaker in your OpenShift cluster.
 ---
 
 > This document is intended for users who have purchased the Armory Red Hat Marketplace offering. It will not work if you have not purchased the Armory Operator. Please contact [Armory](mailto:hello@armory.io) if you're interested in a Red Hat Marketplace Private Offer.

--- a/content/en/docs/installation/guide/install-redhat-marketplace.md
+++ b/content/en/docs/installation/guide/install-redhat-marketplace.md
@@ -1,7 +1,7 @@
 ---
-title: Installing the Armory Enterprise Platform for Spinnaker on OpenShift using the Armory Operator from the Red Hat Marketplace
+title: Installing the Armory Enterprise Platform for Spinnaker on OpenShift Using the Armory Operator
 linkTitle: Install on OpenShift
-weight: 2
+weight: 5
 description: >
   Use the Armory Operator from the Red Hat Marketplace to install the Armory Enterprise Platform for Spinnaker in your OpenShift cluster.
 ---

--- a/content/en/docs/installation/guide/operator-k3s.md
+++ b/content/en/docs/installation/guide/operator-k3s.md
@@ -1,9 +1,9 @@
 ---
-title: Installing the Armory Enterprise Platform for Spinnaker in Lightweight Kubernetes (K3s) using the Armory Operator
+title: Installing Spinnaker or the Armory Enterprise Platform for Spinnaker in Lightweight Kubernetes (K3s) using the Armory Operator
 linkTitle: Install in AWS EC2 using Operator
 weight: 50
 description: >
-  Use the Armory Operator to install Armory in a lightweight Kubernetes (K3s) instance running on an AWS EC2 virtual machine.
+  Use the Armory Operator to install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes (K3s) instance running on an AWS EC2 virtual machine.
 ---
 
 ## Overview of installing Armory for proofs of concept work

--- a/content/en/docs/installation/guide/operator-k3s.md
+++ b/content/en/docs/installation/guide/operator-k3s.md
@@ -1,5 +1,5 @@
 ---
-title: Install Armory in Lightweight Kubernetes (K3s) using the Armory Operator
+title: Installing the Armory Enterprise Platform for Spinnaker in Lightweight Kubernetes (K3s) using the Armory Operator
 linkTitle: Install in AWS EC2 using Operator
 weight: 50
 description: >

--- a/content/en/docs/installation/guide/operator-k3s.md
+++ b/content/en/docs/installation/guide/operator-k3s.md
@@ -1,9 +1,9 @@
 ---
-title: Installing Spinnaker or the Armory Enterprise Platform for Spinnaker in Lightweight Kubernetes (K3s) using the Armory Operator
+title: Using the Armory Operator to Install Spinnaker or the Armory Enterprise Platform for Spinnaker in Lightweight Kubernetes
 linkTitle: Install in AWS EC2 using Operator
 weight: 50
 description: >
-  Use the Armory Operator to install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes (K3s) instance running on an AWS EC2 virtual machine.
+  Use the Armory Operator to install Spinnaker or the Armory Enterprise Platform for Spinnaker in a Lightweight Kubernetes (K3s) instance running on an AWS EC2 virtual machine.
 ---
 
 ## Overview of installing Armory for proofs of concept work

--- a/content/en/docs/installation/guide/quickstart/_index.md
+++ b/content/en/docs/installation/guide/quickstart/_index.md
@@ -1,7 +1,7 @@
 ---
-title: "AWS QuickStart"
+title: QuickStart for Deploying to AWS from Spinnaker
 linkTitle: "AWS QuickStart"
-weight: 2
+weight: 45
 description: >
-  This section contains guides that show you how to configure AWS for Spinnaker, install Spinnaker on AWS, and deploy an application from Spinnaker to AWS.
+  This section contains guides that show you how to configure AWS for Spinnaker and deploy an application from Spinnaker to AWS.
 ---

--- a/content/en/docs/installation/guide/upgrade-oss-to-armory.md
+++ b/content/en/docs/installation/guide/upgrade-oss-to-armory.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade Open Source Spinnaker to Armory
+title: Upgrading Open Source Spinnaker to Armory
 aliases:
   - /spinnaker-install-admin-guides/upgrade-oss-to-armory/
 description: >

--- a/content/en/docs/installation/guide/upgrade-oss-to-armory.md
+++ b/content/en/docs/installation/guide/upgrade-oss-to-armory.md
@@ -1,14 +1,14 @@
 ---
-title: Upgrading Open Source Spinnaker to Armory
+title: Upgrading Open Source Spinnaker to the Armory Enterprise Platform for Spinnaker
 aliases:
   - /spinnaker-install-admin-guides/upgrade-oss-to-armory/
 description: >
-  Upgrade your open source Spinnaker installation to Armory using Armory-extended Halyard.
+  Upgrade your open source Spinnaker installation to the Armory Enterprise Platform for Spinnaker using Armory-extended Halyard.
 ---
 
-## Overview of upgrading Spinnaker to Armory
+## Overview of upgrading Spinnaker to the Armory Enterprise Platform for Spinnaker
 
-The Armory platform is installed with Armory-extended Halyard, very similarly to the way Open Source Spinnaker<sup>TM</sup> is installed with Open Source Halyard. These are the key differences:
+The the Armory Enterprise Platform for Spinnaker is installed with Armory-extended Halyard, very similarly to the way Open Source Spinnaker<sup>TM</sup> is installed with Open Source Halyard. These are the key differences:
 
 * Armory-extended Halyard installs Armory's Enterprise distribution of Spinnaker; Open Source Halyard installs Open Source Spinnaker.
 * Armory versions are one major version ahead of Open Source. For example, Armory 2.18.x maps to Open Source Spinnaker 1.18.x.

--- a/content/en/docs/installation/guide/upgrade-oss-to-armory.md
+++ b/content/en/docs/installation/guide/upgrade-oss-to-armory.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Open Source Spinnaker to the Armory Enterprise Platform for Spinnaker
+weight: 10
 aliases:
   - /spinnaker-install-admin-guides/upgrade-oss-to-armory/
 description: >

--- a/content/en/docs/installation/guide/upgrade-spinnaker.md
+++ b/content/en/docs/installation/guide/upgrade-spinnaker.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade or Rollback the Armory Version
+title: Upgrading or Downgrading the Armory Version
 aliases:
   - /docs/spinnaker-install-admin-guides/upgrade-spinnaker/
 description: >

--- a/content/en/docs/installation/guide/upgrade-spinnaker.md
+++ b/content/en/docs/installation/guide/upgrade-spinnaker.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading or Downgrading the Armory Enterprise Platform for Spinnaker Version
+weight: 10
 aliases:
   - /docs/spinnaker-install-admin-guides/upgrade-spinnaker/
 description: >

--- a/content/en/docs/installation/guide/upgrade-spinnaker.md
+++ b/content/en/docs/installation/guide/upgrade-spinnaker.md
@@ -1,9 +1,9 @@
 ---
-title: Upgrading or Downgrading the Armory Version
+title: Upgrading or Downgrading the Armory Enterprise Platform for Spinnaker Version
 aliases:
   - /docs/spinnaker-install-admin-guides/upgrade-spinnaker/
 description: >
-  Update or rollback your Armory version installed with Armory-extended Halyard.
+  Update or rollback your Armory Enterprise Platform for Spinnaker version installed with Armory-extended Halyard.
 ---
 
 ## Determining the target version

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -8,7 +8,7 @@ description: >
 
 ## Overview of Minnaker
 
-Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_.  The Kubernetes environment that gets installed on your behalf is based on [Rancher's K3s](https://k3s.io/).  You do not need to know how to setup Kubernetes! Minnaker takes care of the hard parts for you, allowing you to get up and running with Armory in under 10 minutes.  Check out [our video](https://youtu.be/jg8vJEzcuAA) on running Armory across all of the public clouds including VMWare Fusion locally.  
+Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_.  The Kubernetes environment that gets installed on your behalf is based on [Rancher's K3s](https://k3s.io/).  You do not need to know how to set up Kubernetes. Minnaker takes care of the hard parts for you, allowing you to get up and running with Spinnaker or the Armory Enterprise Platform in under 10 minutes.  Check out [our video](https://youtu.be/jg8vJEzcuAA) on running Armory across all of the public clouds including VMWare Fusion locally.  
 
 Minnaker makes it easy to get up and running today and lets you scale your deployment into a medium to large deployment down the road.
 
@@ -19,6 +19,6 @@ Minnaker makes it easy to get up and running today and lets you scale your deplo
 
 Your VM should have 4 vCPUs, 16G of memory and 30G of HDD space.
 
-### Getting Started
+### Getting started
 
 Check out the [GitHub project](https://github.com/armory/minnaker) for more information. After you install Minnaker, use the [AWS Quick Start]({{< ref "Armory-Spinnaker-Quickstart-1" >}}) to learn how to configure Armory to deploy to AWS.

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -2,7 +2,7 @@
 title: Minnaker
 weight: 4
 description: >
-  Minnaker is an all-in-one, open source command line tool to install Armory or Spinnaker<sup>TM</sup> in a lightweight Kubernetes environment.
+  Install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes environment using an all-in-one, open source command line tool.
 ---
 
 ## Overview of Minnaker

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -8,9 +8,11 @@ description: >
 
 ## Overview of Minnaker
 
-Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_.  The Kubernetes environment that gets installed on your behalf is based on [Rancher's K3s](https://k3s.io/).  You do not need to know how to set up Kubernetes. Minnaker takes care of the hard parts for you, allowing you to get up and running with Spinnaker or the Armory Enterprise Platform in under 10 minutes.  Check out [our video](https://youtu.be/jg8vJEzcuAA) on running Armory across all of the public clouds including VMWare Fusion locally.  
+Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_. Minnaker makes it easy to get up and running today and lets you scale your deployment into a medium to large deployment down the road.
 
-Minnaker makes it easy to get up and running today and lets you scale your deployment into a medium to large deployment down the road.
+The Kubernetes environment that gets installed on your behalf is based on [Rancher's K3s](https://k3s.io/). You do not need to know how to set up Kubernetes. Minnaker takes care of the hard parts for you, allowing you to get Spinnaker up and running in under 10 minutes.
+
+Watch _Spinnaker in 10 minutes or less with Project Minnaker_ for a demo of using Minnaker to install Spinnaker on cloud platforms as well as VMWare Fusion running locally.  
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/jg8vJEzcuAA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -3,7 +3,7 @@ title: Minnaker: All-In-One Spinnaker on Lightweight Kubernetes
 linkTitle: Minnaker
 weight: 4
 description: >
-  Install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes environment using an all-in-one, open source command line script.
+  Install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes environment using the all-in-one, open source command line tool called Minnaker.
 ---
 
 ## Overview of Minnaker

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -1,5 +1,5 @@
 ---
-title: Minnaker - All-In-One Spinnaker on Lightweight Kubernetes
+title: Minnaker/:/ All-In-One Spinnaker on Lightweight Kubernetes
 linkTitle: Minnaker
 weight: 4
 description: >

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -1,5 +1,5 @@
 ---
-title: Minnaker: All-In-One Spinnaker on Lightweight Kubernetes
+title: Minnaker - All-In-One Spinnaker on Lightweight Kubernetes
 linkTitle: Minnaker
 weight: 4
 description: >

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -1,5 +1,5 @@
 ---
-title: Minnaker/:/ All-In-One Spinnaker on Lightweight Kubernetes
+title: Minnaker -- All-In-One Spinnaker on Lightweight Kubernetes
 linkTitle: Minnaker
 weight: 4
 description: >

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -1,13 +1,14 @@
 ---
-title: Minnaker
+title: Minnaker: All-In-One Spinnaker on Lightweight Kubernetes
+linkTitle: Minnaker
 weight: 4
 description: >
-  Install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes environment using an all-in-one, open source command line tool.
+  Install Spinnaker or the Armory Enterprise Platform for Spinnaker in a lightweight Kubernetes environment using an all-in-one, open source command line script.
 ---
 
 ## Overview of Minnaker
 
-Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_.  The Kubernetes environmnent that gets installed on your behalf is based on [Rancher's K3s](https://k3s.io/).  You do not need to know how to setup Kubernetes! Minnaker takes care of the hard parts for you, allowing you to get up and running with Armory in under 10 minutes.  Check out [our video](https://youtu.be/jg8vJEzcuAA) on running Armory across all of the public clouds including VMWare Fusion locally.  
+Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_.  The Kubernetes environment that gets installed on your behalf is based on [Rancher's K3s](https://k3s.io/).  You do not need to know how to setup Kubernetes! Minnaker takes care of the hard parts for you, allowing you to get up and running with Armory in under 10 minutes.  Check out [our video](https://youtu.be/jg8vJEzcuAA) on running Armory across all of the public clouds including VMWare Fusion locally.  
 
 Minnaker makes it easy to get up and running today and lets you scale your deployment into a medium to large deployment down the road.
 

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -1,5 +1,5 @@
 ---
-title: Using the Armory Operator for Kubernetes to install and manage the Armory Enterprise Platform for Spinnaker
+title: Using the Armory Operator to Install and Manage the Armory Enterprise Platform for Spinnaker
 linkTitle: Armory Operator
 weight: 1
 description: >

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -12,7 +12,7 @@ aliases:
 
 - Manage the Armory Enterprise Platform with `kubectl` like other applications.
 - Expose the Armory Enterprise Platform via `LoadBalancer` or `Ingress` (optional)
-- Keep secrets separate from your config. Store your config in `git` and have an easy Gitops workflow.
+- Keep secrets separate from your configuration. Store your config in `git` and have an easy GitOps workflow.
 - Validate your configuration before applying it (with webhook validation).
 - Store Spinnaker secrets in [Kubernetes secrets](https://github.com/armory/spinnaker-operator/blob/master/doc/managing-spinnaker.md#secrets-in-kubernetes-secrets).
 - Gain total control over Armory Enterprise Platform manifests with [`kustomize` style patching](https://github.com/armory/spinnaker-operator/blob/master/doc/options.md#speckustomize)
@@ -29,7 +29,7 @@ Before you use start, ensure you meet the following requirements:
   - If you do not have a cluster already, consult guides for [Google](https://cloud.google.com/kubernetes-engine/docs/quickstart), [Amazon](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-console.html), or [Microsoft](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal) clouds.
 - You have admission controllers enabled in Kubernetes (`-enable-admission-plugins`).
 - You have `ValidatingAdmissionWebhook` enabled in the kube-apiserver. Alternatively, you can pass the `--disable-admission-controller` parameter to the to the `deployment.yaml` file that deploys the operator.
-- You have admin rights to install the Custom Resource Definition (CRD) for Operator.
+- You have administrator rights to install the Custom Resource Definition (CRD) for Operator.
 
 {{% include "armory-operator/installation.md" %}}
 
@@ -233,7 +233,7 @@ The migration process from Halyard to Operator can be completed in 7 steps:
 
 3. Export Armory profiles.
 
-   If you have configured Armory profiles, you will need to migrate these profiles to the `SpinnakerService` manifest.
+   If you have configured Armory profiles, you need to migrate these profiles to the `SpinnakerService` manifest.
 
    First, identify the current profiles under  `~/.hal/default/profiles`
 

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -1,24 +1,25 @@
 ---
-title: Armory Operator
+title: Using the Armory Operator for Kubernetes to install and manage the Armory Enterprise Platform for Spinnaker
+linkTitle: Armory Operator
 weight: 1
 description: >
-  The Armory Operator is a Kubernetes Operator that makes it easy to install, deploy, and upgrade any version of Armory or Spinnaker.
+  The Armory Operator is a Kubernetes Operator that makes it easy to install, deploy, and upgrade any version of Spinnaker or the Armory Enterprise Platform for Spinnaker.
 aliases:
   - /docs/spinnaker/operator/
 ---
 
 ## Advantages of using the Armory Operator
 
-- Manage Armory with `kubectl` like other applications.
-- Expose Armory via `LoadBalancer` or `Ingress` (optional)
+- Manage the Armory Enterprise Platform with `kubectl` like other applications.
+- Expose the Armory Enterprise Platform via `LoadBalancer` or `Ingress` (optional)
 - Keep secrets separate from your config. Store your config in `git` and have an easy Gitops workflow.
 - Validate your configuration before applying it (with webhook validation).
 - Store Spinnaker secrets in [Kubernetes secrets](https://github.com/armory/spinnaker-operator/blob/master/doc/managing-spinnaker.md#secrets-in-kubernetes-secrets).
-- Gain total control over Armory manifests with [`kustomize` style patching](https://github.com/armory/spinnaker-operator/blob/master/doc/options.md#speckustomize)
+- Gain total control over Armory Enterprise Platform manifests with [`kustomize` style patching](https://github.com/armory/spinnaker-operator/blob/master/doc/options.md#speckustomize)
 - Define Kubernetes accounts in `SpinnakerAccount` objects and store kubeconfig inline, in Kubernetes secrets, in s3, or GCS **(Experimental)**.
 - Deploy Armory in an Istio controlled cluster **(Experimental)**
 
-> This guide uses the Armory Operator, which installs Armory. The open source Operator installs open source Spinnaker<sup>TM</sup>. You can download the open source Operator from the GitHub [repo](https://github.com/armory/spinnaker-operator).
+> This guide uses the Armory Operator, which installs the Armory Enterprise Platform. The open source Operator installs open source Spinnaker<sup>TM</sup>. You can download the open source Operator from its GitHub [repo](https://github.com/armory/spinnaker-operator).
 
 ## Requirements for using the Armory Operator
 


### PR DESCRIPTION
link title remains the same
update description
add Spinnaker Operator to table
SEO updates so Minnaker shows up in "install spinnaker" search
Change "Armory" to "Armory Enterprise Platform for Spinnaker"


Resolves issue: [DOC-301]






[DOC-301]: https://armory.atlassian.net/browse/DOC-301