### PR TITLE
docs(shortcode): add heading shortcode

### DIFF
--- a/content/en/docs/zz-contribute/shortcodes/index.md
+++ b/content/en/docs/zz-contribute/shortcodes/index.md
@@ -22,6 +22,27 @@ alert, swaggerui, imgproc
 
 location:  `docs/layouts/shortcodes`
 
+## Heading
+This shortcode works in conjunction with the `i118n/en.toml` file, which contains key/value pairs for common headings.
+
+Usage:
+
+```markdown
+#### {{%/* heading "prereq" */%}}
+```
+
+Renders:
+
+#### {{% heading "prereq" %}}
+
+Another example:
+
+```markdown
+#### {{%/* heading "installOperator" */%}}
+```
+
+#### {{% heading "installOperator" %}}
+
 ### Hyperlink with page title
 
 You can use `linkWithTitle` to replace a markdown hyperlink.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,4 +1,8 @@
-
+# common headings
+[heading_prereq]
+other = "Before you begin"
+[heading_installOperator]
+other = "Install the Armory Operator"
 
 # UI strings. Buttons and similar.
 

--- a/layouts/shortcodes/heading.html
+++ b/layouts/shortcodes/heading.html
@@ -1,0 +1,4 @@
+<!-- heading -->
+{{- $heading := .Get 0 -}}
+{{- $heading := printf "heading_%s" $heading -}}
+{{- T $heading | safeHTML -}}


### PR DESCRIPTION
Resolves issue:  [DOC-303]

- Create shortcode for rendering headings that should have common text.
- Put entries in i118n/en.toml
- Add example to zz-contribute/shortcodes/index.md


[DOC-303]: https://armory.atlassian.net/browse/DOC-303