### PR TITLE
docs(fix): Install/Operator - fix include file headings not in page TOC

### DIFF
--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -57,7 +57,7 @@ kube-public Active 2m26s
 kube-system Active 2m26s
 ```
 
-## {{% heading "installOperator "%}}
+## {{% heading "installOperator" %}}
 
 {{% include "armory-operator/installation.md" %}}
 

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -57,6 +57,8 @@ kube-public Active 2m26s
 kube-system Active 2m26s
 ```
 
+## {{% heading "installOperator "%}}
+
 {{% include "armory-operator/installation.md" %}}
 
 ## Create a GCS service account

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -116,6 +116,7 @@ Use the Cloud Console to [create your bucket](https://cloud.google.com/storage/d
 going to put secrets in the bucket, make sure to create a secrets directory in
 that bucket. Also, make sure that the Kubernetes service account you created can access the bucket.
 
+## {{% heading "configKustomizeInstallArmory" %}}
 {{% include "armory-operator/kustomize-patches.md" %}}
 
 ## Customize your Spinnaker installation

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -31,11 +31,13 @@ Before you use start, ensure you meet the following requirements:
 - You have `ValidatingAdmissionWebhook` enabled in the kube-apiserver. Alternatively, you can pass the `--disable-admission-controller` parameter to the to the `deployment.yaml` file that deploys the operator.
 - You have administrator rights to install the Custom Resource Definition (CRD) for Operator.
 
+## {{% heading "installOperator" %}}
 {{% include "armory-operator/installation.md" %}}
 
+## {{% heading "configKustomizeInstallArmory" %}}
 {{% include "armory-operator/kustomize-patches.md" %}}
 
-### Upgrade Armory
+## Upgrade Armory
 
 To upgrade an existing Armory deployment, perform the following steps:
 
@@ -69,7 +71,7 @@ To upgrade an existing Armory deployment, perform the following steps:
 
 
 
-### Manage Armory instances
+## Manage Armory instances
 
 The Armory Operator allows you to use `kubectl` to manager you Armory deployment.
 

--- a/content/en/includes/armory-operator/installation.md
+++ b/content/en/includes/armory-operator/installation.md
@@ -1,5 +1,6 @@
-## Install the Armory Operator
-
+<!-- this file does not contain H2 etc headings
+Hugo does not render headings in included files
+-->
 The Armory Operator has two distinct modes:
 
 - **Basic**: Installs Armory into a single namespace. This mode does not

--- a/content/en/includes/armory-operator/kustomize-patches.md
+++ b/content/en/includes/armory-operator/kustomize-patches.md
@@ -1,5 +1,6 @@
-## Configure Kustomize patches and install Armory
-
+<!-- this file does not contain H2 etc headings
+Hugo does not render headings in included files
+-->
 Many common configuration options for Armory and Spinnaker<sup>TM</sup> are available in the [`spinnaker-kustomize-patches`](https://github.com/armory/spinnaker-kustomize-patches) repository. This gives you a reliable starting point when adding and removing Armory or Spinnaker features to your cluster.
 
 To start, create your own copy of the `spinnaker-kustomize-patches` repository

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -3,6 +3,8 @@
 other = "Before you begin"
 [heading_installOperator]
 other = "Install the Armory Operator"
+[heading_configKustomizeInstallArmory]
+other = "Install Armory using Kustomize patches"
 
 # UI strings. Buttons and similar.
 


### PR DESCRIPTION
[DOC-290]

This is a workaround. Move H2 headings out of include files and into parent page so that the H2 headings are included in the page TOC.


[DOC-290]: https://armory.atlassian.net/browse/DOC-290