### PR TITLE
docs(seo): Install section - tweaked titles

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -1,16 +1,16 @@
 ---
-title: "Install the Armory Enterprise Platform for Spinnaker"
+title: "Install Armory Enterprise for Spinnaker"
 linkTitle: "Installation"
 weight: 5
 description: |
-  Guides for installing the Armory Enterprise Platform, a continuous delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install the Armory Enterprise Platform for Spinnaker, or use the open source Operator to install open source Spinnaker in Kubernetes.
+  Guides for installing Armory Enterprise for Spinnaker, a continuous integration and software delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install  Armory Enterprise, or use the open source Operator to install open source Spinnaker in Kubernetes.
 aliases:
   - /install_guide/install/
   - /install-guide/getting_started/
   - /docs/spinnaker/install/
 ---
 
-## Methods for installing the Armory Enterprise Platform for Spinnaker or open source Spinnaker
+## Methods for installing Spinnaker or Armory Enterprise
 
 There are several methods to install Armory or open source Spinnaker:
 

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -3,7 +3,7 @@ title: "Install Armory Enterprise for Spinnaker"
 linkTitle: "Installation"
 weight: 5
 description: |
-  Guides for installing Armory Enterprise for Spinnaker, a continuous integration and software delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install  Armory Enterprise, or use the open source Operator to install open source Spinnaker in Kubernetes.
+  Guides for deploying Armory Enterprise for Spinnaker, a continuous integration and software delivery platform built on top of Spinnaker<sup>TM</sup>, in your air-gapped, local, or cloud environment (AWS, GCP, Azure, Kubernetes, OpenShift). Use the Armory Operator for Kubernetes to install  Armory Enterprise, or use the open source Operator to install open source Spinnaker in Kubernetes.
 aliases:
   - /install_guide/install/
   - /install-guide/getting_started/

--- a/content/en/docs/installation/armory-halyard.md
+++ b/content/en/docs/installation/armory-halyard.md
@@ -2,7 +2,7 @@
 title: Armory Halyard
 weight: 3
 description: >
-  Armory-extended Halyard is a versatile command line interface (CLI) to configure and deploy Armory in Kubernetes or any cloud environment. 
+  Armory-extended Halyard is a versatile command line interface (CLI) to configure and deploy Armory Enterprise for Spinnaker in Kubernetes or any cloud environment. 
 ---
 
 {{< include "halyard-note.md" >}}

--- a/content/en/docs/installation/guide/_index.md
+++ b/content/en/docs/installation/guide/_index.md
@@ -2,7 +2,7 @@
 title: "Guides for Installing Armory Enterprise for Spinnaker"
 linkTitle: "Guides"
 description: >
-   This section details installing Armory Enterprise for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Installation instructions cover using Halyard, the Armory Operator, or the open source Operator for Kubernetes in local, cloud, and air-gapped environments.
+   This section details deploying Armory Enterprise for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Instructions cover using Halyard, the Armory Operator, or the open source Operator for Kubernetes in local, cloud, and air-gapped environments.
 weight: 5
 ---
 

--- a/content/en/docs/installation/guide/_index.md
+++ b/content/en/docs/installation/guide/_index.md
@@ -1,11 +1,11 @@
 ---
-title: "Guides for Installing the Armory Enterprise Platform for Spinnaker"
+title: "Guides for Installing Armory Enterprise for Spinnaker"
 linkTitle: "Guides"
 description: >
-   This section details installing Spinnaker or the Armory Enterprise Platform for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Installation instructions cover using Halyard, the Armory Operator, or the open source Operator for Kubernetes in local, cloud, and air-gapped environments.
+   This section details installing Armory Enterprise for Spinnaker in Kubernetes, OpenShift, Azure, Google Kubernetes Engine (GKE), and Amazon Web Sevices (AWS), including from the AWS or RedHat marketplaces. Installation instructions cover using Halyard, the Armory Operator, or the open source Operator for Kubernetes in local, cloud, and air-gapped environments.
 weight: 5
 ---
 
-Once installed, Armory can deploy to supported providers through Clouddriver regardless of where it is installed.
+Once installed, Armory Enterprise can deploy to supported providers through Clouddriver regardless of where it is installed.
 
 See {{< linkWithTitle "air-gapped.md" >}} for additional steps you have to take if you have an air-gapped environment.

--- a/content/en/docs/installation/guide/air-gapped.md
+++ b/content/en/docs/installation/guide/air-gapped.md
@@ -1,9 +1,9 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in Air-Gapped Environments
+title: Install Armory Enterprise for Spinnaker in Air-Gapped Environments
 linkTitle: Air-Gapped Environments
 weight: 1
 description: >
-  Options for installing the Armory Enterprise Platform for Spinnaker in an environment that is isolated from the internet.
+  Options for deploying Armory Enterprise for Spinnaker in an environment that is isolated from the internet.
 ---
 
 ## Overview of air-gapped environments

--- a/content/en/docs/installation/guide/aws-container-marketplace.md
+++ b/content/en/docs/installation/guide/aws-container-marketplace.md
@@ -1,16 +1,16 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in AWS from the AWS Container Marketplace
+title: Install Armory Enterprise for Spinnaker from the AWS Container Marketplace
 linkTitle: Install from AWS Marketplace
 weight: 2
 aliases:
   - /spinnaker/aws_container_marketplace/
   - /spinnaker/aws-container-marketplace/
 description: >
-  Use the Armory Operator from the AWS Container Marketplace to install the Armory Enterprise Platform for Spinnaker in your Amazon Kubernetes (EKS) cluster.
+  Use the Armory Operator from the AWS Container Marketplace to deploy Armory Enterprise for Spinnaker in your Amazon Kubernetes (EKS) cluster.
 
 ---
 
-{{% alert title="Note" %}}This document is intended for users who have purchased the Armory AWS Container Marketplace offering. It will not work if you have not subscribed to the Armory Container Marketplace offering.
+{{% alert title="Note" %}}This document is intended for users who have purchased Armory's AWS Container Marketplace offering. It will not work if you have not subscribed to the Armory Container Marketplace offering.
 
 Please contact [Armory](mailto:hello@armory.io) if you're interested in an AWS Marketplace Private Offer.{{% /alert %}}
 

--- a/content/en/docs/installation/guide/configure-halyard.md
+++ b/content/en/docs/installation/guide/configure-halyard.md
@@ -8,7 +8,7 @@ description: >
 
 ---
 
-## Overview
+## Overview of Armory Halyard
 
 Armory-extended Halyard can be configured via `/opt/spinnaker/config/halyard.yml`. If you run the Docker image, you can provide your own configuration by mounting the file or directory to the container. If you're running the Armory Operator, you can also configure the behavior of the internal Halyard by creating a Kubernetes ConfigMap and mounting it to the Halyard container.
 

--- a/content/en/docs/installation/guide/install-on-aks.md
+++ b/content/en/docs/installation/guide/install-on-aks.md
@@ -1,5 +1,5 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in the Azure Kubernetes Service (AKS)
+title: Install Armory Enterprise for Spinnaker in the Azure Kubernetes Service (AKS)
 linkTitle: "Install in AKS"
 weight: 5
 aliases:
@@ -8,10 +8,10 @@ aliases:
   - /spinnaker-install-admin-guides/install_on_aks/
   - /spinnaker-install-admin-guides/install-on-aks/
 description: >
-  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to install the Armory Enterprise Platform for Spinnaker in the Azure Kubernetes Service (AKS).
+  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to deploy Armory Enterprise for Spinnaker in the Azure Kubernetes Service (AKS).
 ---
 
-## Overview of installing Armory in AKS
+## Overview of installing Armory Enterprise in AKS
 
 This guide walks you through creating and using the following Azure resources:
 
@@ -30,7 +30,7 @@ See [Next Steps](#next-steps) for resources related to these topics.
 
 > This document focuses on Armory's extended Spinnaker for enterprises and uses the Armory-extended version of Halyard (referred to as 'Halyard' in this doc). You can install open source Spinnaker by using an open source Halyard container and a corresponding open source Spinnaker version.
 
-## Prerequisites for installing Armory
+## Prerequisites for installing Armory Enterprise
 
 To follow the steps described in this guide, make sure you have met the following prerequisites:
 

--- a/content/en/docs/installation/guide/install-on-aws.md
+++ b/content/en/docs/installation/guide/install-on-aws.md
@@ -1,5 +1,5 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in Amazon Web Services (AWS)
+title: Install Armory Enterprise for Spinnaker in Amazon Web Services (AWS)
 linkTitle: "Install in AWS"
 weight: 5
 aliases:
@@ -12,7 +12,7 @@ aliases:
   - /spinnaker_install_admin_guides/install-on-aws/
   - /spinnaker-install-admin-guides/install-on-aws/
 description: >
-  Use Armory-extended Halyard to install the Armory Enterprise Platform for Spinnaker in an AWS Kubernetes cluster or in an on-prem Kubernetes cluster with access to Amazon Secure Storage Service.
+  Use Armory-extended Halyard to deploy Armory Enterprise for Spinnaker in an AWS Kubernetes cluster or in an on-prem Kubernetes cluster with access to Amazon Secure Storage Service (S3).
 ---
 
 ## Overview of installing Armory in AWS

--- a/content/en/docs/installation/guide/install-on-gke-operator.md
+++ b/content/en/docs/installation/guide/install-on-gke-operator.md
@@ -1,25 +1,27 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in the Google Kubernetes Engine (GKE) Using the Armory Operator
+title: Install Armory Enterprise for Spinnaker in the Google Kubernetes Engine (GKE) using the Armory Operator
 linkTitle: "Install in GKE using Operator"
 weight: 5
 aliases:
   - /spinnaker-install-admin-guides/install-on-gke-operator/
 description: >
-  Use the Armory Operator to install the Armory Enterprise Platform for Spinnaker in your Google Kubernetes Engine (GKE) cluster.
+  Use the Armory Operator to deploy Armory Enterprise for Spinnaker in your Google Kubernetes Engine (GKE) cluster.
 ---
+
+## Overview of installing Armory Enterprise for Spinnaker
 
 This guide contains instructions for installing Armory on a Google Kubernetes Engine (GKE) cluster using the [Armory Operator]({{< ref "operator" >}}). Refer to the [Armory Operator Reference]({{< ref "operator-config" >}}) for manifest entry details.
 
 > If you want to install Spinnaker<sup>TM</sup>, use the open source Operator, which you can download from its GitHub [repo](https://github.com/armory/spinnaker-operator).
 
-## Prerequisites for installing Armory and the Armory Operator
+## Prerequisites for installing Armory Enterprise and the Armory Operator
 
 * You have a machine configured to use the `gcloud` CLI tool and a recent
   version of the `kubectl` tool
 * You have logged into the `gcloud` CLI and have permissions to create GKE
   clusters and a service account
 
-## Armory installation summary
+## Armory Enterprise installation summary
 
 Installing Armory using the Armory Operator consists of the following steps:
 

--- a/content/en/docs/installation/guide/install-on-gke.md
+++ b/content/en/docs/installation/guide/install-on-gke.md
@@ -1,5 +1,5 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in the Google Kubernetes Engine (GKE)
+title: Install Armory Enterprise for Spinnaker in the Google Kubernetes Engine (GKE)
 linkTitle: "Install in GKE"
 weight: 5
 aliases:
@@ -8,7 +8,7 @@ aliases:
   - /spinnaker-install-admin-guides/install_on_gke/
   - /spinnaker-install-admin-guides/install-on-gke/
 description: >
-  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to install the Armory Enterprise Platform for Spinnaker in your Google Kubernetes Engine (GKE) cluster.
+  Use Armory-extended Halyard and Armory's Spinnaker<sup>TM</sup> tools CLI to deploy Armory Enterprise for Spinnaker in your Google Kubernetes Engine (GKE) cluster.
 ---
 
 ## Overview of installing Armory

--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -1,16 +1,16 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker in Kubernetes
+title: Install Armory Enterprise for Spinnaker in Kubernetes
 linkTitle: Install in Kubernetes
 weight: 3
 aliases:
   - /spinnaker-install-admin-guides/install-on-k8s/
 description: >
-  Use Armory-extended Halyard or the Armory Operator to install the Armory Enterprise Platform for Spinnaker in Kubernetes.
+  Use Armory-extended Halyard or the Armory Operator to deploy Armory Enterprise for Spinnaker in Kubernetes.
 ---
 
-## Overview
+## Overview of installing Armory Enterprise for Spinnaker in Kubernetes
 
-This guide describes the initial installation of Armory in Kubernetes. You can choose between two different installation methods: Armory Operator or Halyard. By the end of this guide, you will have an instance of Armory up and running on your Kubernetes cluster.  The document does not fully cover the following:
+This guide describes the initial installation of Armory Enterprise in Kubernetes. You can choose between two different installation methods: Armory Operator or Halyard. By the end of this guide, you will have an instance of Armory Enterprise up and running on your Kubernetes cluster.  The document does not fully cover the following:
 
 * TLS Encryption
 * Authentication/Authorization
@@ -19,11 +19,11 @@ This guide describes the initial installation of Armory in Kubernetes. You can c
 
 See [Next Steps](#next-steps) for information related to these topics.
 
-> This document focuses on Armory but can be adapted to install Open Source Spinnaker<sup>TM</sup> by using Open Source Operator or a different Halyard container, and a corresponding different Spinnaker version.
+> This document focuses on Armory Enterprise but can be adapted to install Open Source Spinnaker<sup>TM</sup> by using Open Source Operator or a different Halyard container, and a corresponding different Spinnaker version.
 
 ## Choosing an installation method
 
-There are two recommended ways of installing Armory: using the [Armory Operator]({{< ref "operator" >}}) or using [Halyard](https://www.spinnaker.io/setup/install/halyard/).
+There are two recommended ways of installing Armory Enterprise: using the [Armory Operator]({{< ref "operator" >}}) or using [Halyard](https://www.spinnaker.io/setup/install/halyard/).
 
 {{< tabs name="install-methods" >}}
 {{% tab name="Armory Operator" %}}

--- a/content/en/docs/installation/guide/install-redhat-marketplace.md
+++ b/content/en/docs/installation/guide/install-redhat-marketplace.md
@@ -1,9 +1,9 @@
 ---
-title: Install the Armory Enterprise Platform for Spinnaker on OpenShift Using the Armory Operator
+title: Install Armory Enterprise for Spinnaker on OpenShift using the Armory Operator
 linkTitle: Install on OpenShift
 weight: 5
 description: >
-  Use the Armory Operator from the Red Hat Marketplace to install the Armory Enterprise Platform for Spinnaker in your OpenShift cluster.
+  Use the Armory Operator from the Red Hat Marketplace to deploy Armory Enterprise for Spinnaker in your OpenShift cluster.
 ---
 
 > This document is intended for users who have purchased the Armory Red Hat Marketplace offering. It will not work if you have not purchased the Armory Operator. Please contact [Armory](mailto:hello@armory.io) if you're interested in a Red Hat Marketplace Private Offer.

--- a/content/en/docs/installation/guide/operator-k3s.md
+++ b/content/en/docs/installation/guide/operator-k3s.md
@@ -1,9 +1,9 @@
 ---
-title: Install Spinnaker or the Armory Enterprise Platform for Spinnaker in Lightweight Kubernetes Using the Armory Operator 
+title: Install Armory Enterpriese for Spinnaker in Lightweight Kubernetes using the Armory Operator
 linkTitle: Install in AWS EC2 using Operator
 weight: 50
 description: >
-  Use the Armory Operator to install Spinnaker or the Armory Enterprise Platform for Spinnaker in a Lightweight Kubernetes (K3s) instance running on an AWS EC2 virtual machine.
+  Use the Armory Operator to deploy Spinnaker or Armory Enterprise for Spinnaker in a Lightweight Kubernetes (K3s) instance running on an AWS EC2 virtual machine. This environment is for proofs of concept and development.
 ---
 
 ## Overview of installing Armory for proofs of concept work

--- a/content/en/docs/installation/guide/upgrade-oss-to-armory.md
+++ b/content/en/docs/installation/guide/upgrade-oss-to-armory.md
@@ -1,15 +1,15 @@
 ---
-title: Upgrade Spinnaker to the Armory Enterprise Platform for Spinnaker
+title: Upgrade Spinnaker to Armory Enterprise for Spinnaker
 weight: 10
 aliases:
   - /spinnaker-install-admin-guides/upgrade-oss-to-armory/
 description: >
-  Upgrade your open source Spinnaker installation to the Armory Enterprise Platform for Spinnaker using Armory-extended Halyard.
+  Upgrade your open source Spinnaker deployment to Armory Enterprise for Spinnaker using Armory-extended Halyard.
 ---
 
-## Overview of upgrading Spinnaker to the Armory Enterprise Platform for Spinnaker
+## Overview of upgrading Spinnaker to Armory Enterprise for Spinnaker
 
-The the Armory Enterprise Platform for Spinnaker is installed with Armory-extended Halyard, very similarly to the way Open Source Spinnaker<sup>TM</sup> is installed with Open Source Halyard. These are the key differences:
+Armory Enterprise for Spinnaker is installed with Armory-extended Halyard, very similarly to the way Open Source Spinnaker<sup>TM</sup> is installed with Open Source Halyard. These are the key differences:
 
 * Armory-extended Halyard installs Armory's Enterprise distribution of Spinnaker; Open Source Halyard installs Open Source Spinnaker.
 * Armory versions are one major version ahead of Open Source. For example, Armory 2.18.x maps to Open Source Spinnaker 1.18.x.

--- a/content/en/docs/installation/guide/upgrade-spinnaker.md
+++ b/content/en/docs/installation/guide/upgrade-spinnaker.md
@@ -1,10 +1,10 @@
 ---
-title: Upgrade or Downgrade the Armory Enterprise Platform for Spinnaker Version
+title: Upgrade or Downgrade Armory Enterprise for Spinnaker Version
 weight: 10
 aliases:
   - /docs/spinnaker-install-admin-guides/upgrade-spinnaker/
 description: >
-  Update or rollback your Armory Enterprise Platform for Spinnaker version installed with Armory-extended Halyard.
+  Update or rollback your Armory Enterprise for Spinnaker version deployed with Armory-extended Halyard.
 ---
 
 ## Determining the target version

--- a/content/en/docs/installation/minnaker.md
+++ b/content/en/docs/installation/minnaker.md
@@ -1,12 +1,12 @@
 ---
-title: Install Spinnaker on Lightweight Kubernetes Using Minnaker
+title: Install Spinnaker on Lightweight Kubernetes using Minnaker
 linkTitle: Minnaker
 weight: 4
 description: >
-  Install Spinnaker or the Armory Enterprise Platform for Spinnaker in less than 10 minutes in a lightweight Kubernetes environment using the all-in-one, open source command line tool called Minnaker.
+  Install Spinnaker or Armory Enterprise for Spinnaker in less than 10 minutes in a Lightweight Kubernetes (k3s) environment using the all-in-one, open source command line tool called Minnaker.
 ---
 
-## Install Spinnaker Using Minnaker
+## Install Spinnaker in 10 minutes using Minnaker
 
 Armory Minnaker is an easy to use installation script that leverages the power of **Kubernetes** with the simplicity of a _Virtual Machine_. Minnaker makes it easy to install Spinnaker and lets you scale your deployment into a medium to large deployment down the road.
 

--- a/content/en/docs/installation/operator-reference/operator-config.md
+++ b/content/en/docs/installation/operator-reference/operator-config.md
@@ -2,7 +2,7 @@
 title: Armory Operator Configuration
 weight: 1
 description: >
-  This guide describes the fields in `SpinnakerService` CRD and example manifests.
+  This guide describes the fields in `SpinnakerService` CRD that you need to deploy Armory Enterprise for Spinnaker on Kubernetes.
 aliases:
   - /operator_reference/operator-config/
 ---

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -3,7 +3,7 @@ title: Install Armory Enterprise for Spinnaker Using the Armory Operator
 linkTitle: Armory Operator
 weight: 1
 description: >
-  The Armory Operator is a Kubernetes Operator that makes it easy to install, deploy, and upgrade any version of Spinnaker or Armory Enterprise for Spinnaker.
+  The Armory Operator is a Kubernetes Operator that makes it easy to deploy, upgrade, or remove any version of Spinnaker or Armory Enterprise for Spinnaker.
 aliases:
   - /docs/spinnaker/operator/
 ---

--- a/content/en/docs/installation/operator.md
+++ b/content/en/docs/installation/operator.md
@@ -1,17 +1,24 @@
 ---
-title: Using the Armory Operator to Install and Manage the Armory Enterprise Platform for Spinnaker
+title: Install Armory Enterprise for Spinnaker Using the Armory Operator
 linkTitle: Armory Operator
 weight: 1
 description: >
-  The Armory Operator is a Kubernetes Operator that makes it easy to install, deploy, and upgrade any version of Spinnaker or the Armory Enterprise Platform for Spinnaker.
+  The Armory Operator is a Kubernetes Operator that makes it easy to install, deploy, and upgrade any version of Spinnaker or Armory Enterprise for Spinnaker.
 aliases:
   - /docs/spinnaker/operator/
 ---
 
+## Two types of Kubernetes Operators for installing Spinnaker
+
+* The open source Spinnaker Operator for Kubernetes installs open source Spinnaker<sup>TM</sup>. You can download the Operator from its GitHub [repo](https://github.com/armory/spinnaker-operator).
+* The Armory Operator installs Armory Enterprise for Spinnaker. This Operator processes configuration entries for proprietary enterprise features.
+
+Most of the configuration is the same between the open source and proprietary types of Operators.
+
 ## Advantages of using the Armory Operator
 
-- Manage the Armory Enterprise Platform with `kubectl` like other applications.
-- Expose the Armory Enterprise Platform via `LoadBalancer` or `Ingress` (optional)
+- Manage Armory Enterprise with `kubectl` like other applications.
+- Expose Armory Enterprise via `LoadBalancer` or `Ingress` (optional)
 - Keep secrets separate from your configuration. Store your config in `git` and have an easy GitOps workflow.
 - Validate your configuration before applying it (with webhook validation).
 - Store Spinnaker secrets in [Kubernetes secrets](https://github.com/armory/spinnaker-operator/blob/master/doc/managing-spinnaker.md#secrets-in-kubernetes-secrets).
@@ -19,7 +26,6 @@ aliases:
 - Define Kubernetes accounts in `SpinnakerAccount` objects and store kubeconfig inline, in Kubernetes secrets, in s3, or GCS **(Experimental)**.
 - Deploy Armory in an Istio controlled cluster **(Experimental)**
 
-> This guide uses the Armory Operator, which installs the Armory Enterprise Platform. The open source Operator installs open source Spinnaker<sup>TM</sup>. You can download the open source Operator from its GitHub [repo](https://github.com/armory/spinnaker-operator).
 
 ## Requirements for using the Armory Operator
 
@@ -37,9 +43,9 @@ Before you use start, ensure you meet the following requirements:
 ## {{% heading "configKustomizeInstallArmory" %}}
 {{% include "armory-operator/kustomize-patches.md" %}}
 
-## Upgrade Armory
+## Upgrade Armory Enterprise
 
-To upgrade an existing Armory deployment, perform the following steps:
+To upgrade an existing Armory Enterprise deployment, perform the following steps:
 
 1. Change the `version` field in `deploy/spinnaker/basic/SpinnakerService.yml`  file to the target version for the upgrade.
 2. Apply the updated manifest:
@@ -71,11 +77,11 @@ To upgrade an existing Armory deployment, perform the following steps:
 
 
 
-## Manage Armory instances
+## Manage Armory Enterprise instances
 
-The Armory Operator allows you to use `kubectl` to manager you Armory deployment.
+The Armory Operator allows you to use `kubectl` to manager your Armory Enterprise deployment.
 
-**List Armory instances**
+**List Armory Enterprise instances**
 
 ```bash
 kubectl get spinnakerservice --all-namespaces
@@ -83,27 +89,27 @@ kubectl get spinnakerservice --all-namespaces
 
 The short name `spinsvc` is also available.
 
-**Describe Armory instances**
+**Describe Armory Enterprise instances**
 
 ```bash
 kubectl -n <namespace> describe spinnakerservice spinnaker
 ```
 
 
-**Delete Armory instances**
+**Delete Armory Enterprise instances**
 
 ```bash
 kubectl -n <namespace> delete spinnakerservice spinnaker
 ```
 
 
-## Manage configuration
+## Manage Armory Enterprise configuration in a Kubernetes manifest
 
 ### Kustomize
 
-Because Armory's configuration is now a Kubernetes manifest, you can manage `SpinnakerService` and related manifests in a consistent and repeatable way with [Kustomize](https://kustomize.io/).
+Because Armory Enterprise's configuration is now a Kubernetes manifest, you can manage `SpinnakerService` and related manifests in a consistent and repeatable way with [Kustomize](https://kustomize.io/).
 
-See the example [here](https://github.com/armory-io/spinnaker-operator/tree/master/deploy/spinnaker/kustomize).
+The `spinnaker-kustomize-patches` [repo](https://github.com/armory/spinnaker-kustomize-patches) has many configuration examples.
 
 ```bash
 kubectl create ns spinnaker
@@ -117,13 +123,13 @@ There are many more possibilities:
 
 See this [repo](https://github.com/armory/spinnaker-kustomize-patches) for examples of common setups that you can adapt to your needs.
 
-### Secret Management
+### Secret management
 
 You can store secrets in one of the [supported secret engine]({{< ref "secrets#supported-secret-engines" >}}).
 
 #### Kubernetes Secret
 
-With the Operator, you can also reference secrets stored in existing Kubernetes secrets in the same namespace as Spinnaker.
+With the Armory Operator, you can also reference secrets stored in existing Kubernetes secrets in the same namespace as Spinnaker.
 
 The format is:
 - `encrypted:k8s!n:<secret name>!k:<secret key>` for string values. These are added as environment variable to the Spinnaker deployment.
@@ -184,9 +190,9 @@ spec:
 
 ### GitOps
 
-Armory can deploy manifests or kustomize packages. You can configure Armory to redeploy itself (or use a separate Armory) with a trigger on the git repository containing its configuration.
+Armory Enterprise can deploy manifests or Kustomize packages. You can configure Armory Enterprise to redeploy itself (or use a separate Armory Enterprise) with a trigger on the git repository containing its configuration.
 
-A change to Armory's configuration follows:
+A change to Armory Enterprise's configuration follows:
 
 > Pull Request --> Approval --> Configuration Merged --> Pipeline Trigger in Spinnaker --> Deploy Updated SpinnakerService
 
@@ -194,7 +200,7 @@ This process is auditable and reversible.
 
 ## Accounts CRD (Experimental)
 
-Operator has a CRD for Armory accounts. `SpinnakerAccount` is defined in an object - separate from the main Spinnaker config - so its creation and maintenance can be automated.
+The Operator has a CRD for Armory Enterprise accounts. `SpinnakerAccount` is defined in an object - separate from the main Spinnaker config - so its creation and maintenance can be automated.
 
 To read more about this CRD, see [SpinnakerAccount](https://github.com/armory/spinnaker-operator/blob/master/doc/spinnaker-accounts.md).
 


### PR DESCRIPTION
Changed 'install' to 'deploy' in description since titles contain 'install'

Change Armory Enterprise Platform for Spinnaker to Armory Enterprise for Spinnaker.

[DOC-312] partial



[DOC-312]: https://armory.atlassian.net/browse/DOC-312