### PR TITLE
chore(release): divide OSS from Armory operator and add release notes.

### DIFF
--- a/content/en/docs/release-notes/rn-armory-operator/_index.md
+++ b/content/en/docs/release-notes/rn-armory-operator/_index.md
@@ -1,12 +1,10 @@
 ---
-title: "Armory Operator Release Notes"
-layout: release-notes-all
+title: "Armory Operator Release Notes" 
+layout: release-notes-operator
 description: >
   The Armory Operator is an extended version of the Open Source [Spinnaker Operator](https://www.armory.io/blog/spinnaker-operator/), a Kubernetes operator that deploys and manages Spinnaker using familiar tools.
 ---
 
 > You can find [Armory's releases notes here]({{< ref "rn-armory-spinnaker" >}}).
-
-## List of Armory Operator Releases
 
 <!-- Hugo/docsy auto generates a list of the child pages here. The front matter configures it to go from newest to oldest --!>

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-5.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-5.md
@@ -1,11 +1,11 @@
 ---
-title: v1.2.3 Armory Operator
+title: v1.2.5 Armory Operator
 toc_hide: true
-version: 01.02.03
-description: Release notes for Armory Operator v1.2.3
+version: 01.02.05
+description: Release notes for Armory Operator v1.2.4
 ---
 
-## 03/01/2021 Release Notes
+## 03/17/2021 Release Notes
 
 ## Security
 
@@ -16,4 +16,4 @@ No known issues.
 
 ### Armory Operator
 
-* feat(docker): adding ecr utility to get an ecr token
+* chore(release): upgrade to oss operator 1.2.5

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-5.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-5.md
@@ -16,4 +16,4 @@ No known issues.
 
 ### Armory Operator
 
-* chore(release): upgrade to oss operator 1.2.5
+* chore(release): upgrade to oss operator 1.2.4

--- a/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-5.md
+++ b/content/en/docs/release-notes/rn-armory-operator/armory-operator-v1-2-5.md
@@ -2,7 +2,7 @@
 title: v1.2.5 Armory Operator
 toc_hide: true
 version: 01.02.05
-description: Release notes for Armory Operator v1.2.4
+description: Release notes for Armory Operator v1.2.5
 ---
 
 ## 03/17/2021 Release Notes

--- a/content/en/docs/release-notes/rn-armory-operator/oss-operator-v1-2-3.md
+++ b/content/en/docs/release-notes/rn-armory-operator/oss-operator-v1-2-3.md
@@ -1,0 +1,24 @@
+---
+title: v1.2.3 OSS Operator
+toc_hide: true
+version: 01.02.03
+description: Release notes for OSS Operator v1.2.3
+---
+
+## 03/01/2021 Release Notes
+
+## Security
+
+Armory scans the codebase as we develop and release software. For information about CVE scans for this release, contact your Armory account representative.
+
+## Known Issues
+No known issues.
+
+### Spinnaker Operator
+
+* fix(timeout): avoid revalidation when patching status
+* chore(cve): fix for CVE-2020-13757
+* feat(validator/aws): add aws account validator
+* fix(validation): validate primary account for kubernetes provider
+* fix(expose): override public service port
+* chore(halyard): Updated halyard version

--- a/content/en/docs/release-notes/rn-armory-operator/oss-operator-v1-2-4.md
+++ b/content/en/docs/release-notes/rn-armory-operator/oss-operator-v1-2-4.md
@@ -1,11 +1,11 @@
 ---
-title: v1.2.3 Armory Operator
+title: v1.2.4 OSS Operator
 toc_hide: true
-version: 01.02.03
-description: Release notes for Armory Operator v1.2.3
+version: 01.02.04
+description: Release notes for OSS Operator v1.2.4
 ---
 
-## 03/01/2021 Release Notes
+## 03/17/2021 Release Notes
 
 ## Security
 
@@ -16,4 +16,4 @@ No known issues.
 
 ### Armory Operator
 
-* feat(docker): adding ecr utility to get an ecr token
+* feat(health-check): increase timeout and validate ready replicas for SpinnakerService status

--- a/layouts/docs/release-notes-operator.html
+++ b/layouts/docs/release-notes-operator.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+        {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+            {{ partial "reading-time.html" . }}
+        {{ end }}
+	{{ .Content }}
+        {{ partial "list-operator-release-notes.html" . }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+</div>
+{{ end }}

--- a/layouts/partials/list-operator-release-notes.html
+++ b/layouts/partials/list-operator-release-notes.html
@@ -1,0 +1,34 @@
+<div class="section-index">
+  {{ $pages := (where .Site.Pages "Section" .Section).ByParam "version" }}
+  {{ $pagesReverse := $pages.Reverse }}
+  {{ $parent := .Page }}
+
+  <div>Armory Operator:</div>
+
+  <ul>
+    {{ range $pagesReverse }}
+      {{ if eq .Parent $parent }}
+
+        {{ if in .Title "Armory" }}
+          <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
+        {{end}}
+
+      {{end}}
+    {{ end }}
+  </ul>
+  <div>OSS Operator:</div>
+  <ul>
+    {{ range $pagesReverse }}
+      {{ if eq .Parent $parent }}
+
+        {{ if in .Title "OSS" }}
+        <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
+        {{end}}
+
+      {{end}}
+    {{ end }}
+  </ul>
+
+  <div>Versions older than the last 3 minor versions can be found in the <a href="archive">Armory Release Notes Archive</a>.</div>
+
+</div>

--- a/layouts/partials/list-operator-release-notes.html
+++ b/layouts/partials/list-operator-release-notes.html
@@ -29,6 +29,4 @@
     {{ end }}
   </ul>
 
-  <div>Versions older than the last 3 minor versions can be found in the <a href="archive">Armory Release Notes Archive</a>.</div>
-
 </div>


### PR DESCRIPTION
This PR divides the OSS and Armory Operator release notes.


Before:

![Image 2021-03-17 at 6 11 16 PM](https://user-images.githubusercontent.com/16300174/111554543-30beb180-874c-11eb-8a7a-b55bb562b9f5.jpg)


After:

![Image 2021-03-17 at 6 12 57 PM](https://user-images.githubusercontent.com/16300174/111554702-69f72180-874c-11eb-8ead-c85b0299f7cf.jpg)

