### PR TITLE
Docs(build): Icon shortcodes

### DIFF
--- a/content/en/docs/zz-contribute/shortcodes/index.md
+++ b/content/en/docs/zz-contribute/shortcodes/index.md
@@ -206,3 +206,16 @@ Usage:
 {{< /rawhtml >}}  
 
 See the {{< linkWithTitle pacrd-crd-docs.md >}} for an example.
+
+## Icons
+
+Search for icons at [Font Awesome](https://fontawesome.com/icons/)
+
+```md
+1. Click **{{< icon "play" >}} Start Manual Execution**. 
+```
+
+Renders to:
+
+1. Click **{{< icon "play" >}} Start Manual Execution**. 
+

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -1,0 +1,2 @@
+{{- $iconName := .Get 0 -}}
+<i class="fas fa-{{ $iconName }}"></i>


### PR DESCRIPTION
Adds the `icon` shortcode to our docs layout, and an example in the shortcodes documentation..
