### PR TITLE
docs(fix): fix heading shortcode declaration

### DIFF
--- a/content/en/docs/armory-admin/cf/add-cf-account.md
+++ b/content/en/docs/armory-admin/cf/add-cf-account.md
@@ -4,7 +4,7 @@ linkTitle: Add a Cloud Foundry Account
 description: Add a Cloud Foundry account as a cloud provider deployment target in Spinnaker.
 ---
 
-## {{< heading "prereq" >}}
+## {{% heading "prereq" %}}
 
 This document assumes the following:
 


### PR DESCRIPTION
must use `{{%%}}` or the heading doesn't render correctly in the page TOC

