### PR TITLE
docs(policy-engine): Make the policy engine plugin init container documentation clearer

### DIFF
--- a/content/en/docs/plugin-guide/plugin-policy-engine.md
+++ b/content/en/docs/plugin-guide/plugin-policy-engine.md
@@ -44,7 +44,7 @@ In addition to the plugin, you need access to an Open Policy Agent (OPA) deploym
 You can use the sample configuration to install the plugin, but keep the following in mind:
 
 - The `patchesStrategicMerge` section for each service is unique. Do not reuse the snippet from one service for the other services.
-- Make sure to replace `<PLUGIN_VERSION>` with the version of the plugin you want to use. For a list of versions, see [Release notes](#release-notes).
+- Make sure to replace `<PLUGIN_VERSION>` with the version of the plugin you want to use without the `v` prefix. For a list of versions, see [Release notes](#release-notes).
 
 ```yaml
 apiVersion: spinnaker.armory.io/v1alpha2

--- a/content/en/docs/plugin-guide/plugin-policy-engine.md
+++ b/content/en/docs/plugin-guide/plugin-policy-engine.md
@@ -239,7 +239,7 @@ spec:
        mountPath: /opt/spinnaker/lib/local-plugins
    ```
 
-4. Configure Halyard by updating your  `.hal/config` file. Use the following snippet and replace `<PLUGIN VERSION>` with the [plugin version](#release-notes) you want to use: 
+4. Configure Halyard by updating your `.hal/config` file. Use the following snippet and replace `<PLUGIN VERSION>` with the [plugin version](#release-notes) you want to use without the `v` prefix: 
 
    ```yaml
    deploymentConfigurations:


### PR DESCRIPTION
# What
Update the Policy Engine plugin documentation to inform the user that the init container policy-engine-plugin image tag should not include the `v` prefix.

# Why
So users don't use the wrong Docker image tag.