### PR TITLE
docs(hugo): Modify updated line in footer.

### DIFF
--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,0 +1,1 @@
+{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">({{ .AbbreviatedHash }})</a>{{end }}


### PR DESCRIPTION
This PR overrides `page-meta-lastmod.html` provided by the Docsy theme to remove the commit subject line from the "Last Updated" line in the page footer.