### PR TITLE
docs(Copy): Remove references to "Armory Platform"

### DIFF
--- a/content/en/docs/armory-admin/diagnostics-configure.md
+++ b/content/en/docs/armory-admin/diagnostics-configure.md
@@ -1,5 +1,5 @@
 ---
-title: Configure Support Diagnostics for the Armory Platform
+title: Configure Support Diagnostics for Armory Enterprise
 linkTitle: Configure Support Diagnostics
 aliases:
   - /docs/spinnaker-install-admin-guides/admin-diagnostics/

--- a/content/en/docs/armory-admin/dinghy-enable.md
+++ b/content/en/docs/armory-admin/dinghy-enable.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Pipelines as Code in the Armory Platform
+title: Enable Pipelines as Code in Armory Enterprise
 linkTitle: Enable Pipelines as Code
 aliases:
   - /spinnaker/install_dinghy/

--- a/content/en/docs/armory-admin/integrations-sumologic.md
+++ b/content/en/docs/armory-admin/integrations-sumologic.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate a Sumo Logic Dashboard in the Armory Platform
+title: Integrate a Sumo Logic Dashboard in Armory Enterprise
 linkTitle: Integrate Sumo Logic
 aliases:
   - /docs/spinnaker-install-admin-guides/sumologic-dashboard/

--- a/content/en/docs/armory-cloud-preview/armory-cloud-admin/_index.md
+++ b/content/en/docs/armory-cloud-preview/armory-cloud-admin/_index.md
@@ -11,7 +11,7 @@ aliases:
 
 Armory Cloud is a Software as a Service (SaaS) platform for continuous delivery that integrates with your existing tools. As a SaaS solution, Armory Cloud gives you the ability to deliver software without the maintenance overhead of having to maintain your own continuous delivery tools.
 
-The three components of Armory Cloud are the Armory Cloud Console, Armory Cloud API, and the Armory Platform:
+The three components of Armory Cloud are the Armory Cloud Console, Armory Cloud API, and Armory Enterprise:
 
 - Armory Cloud Console is the administrator portal for Armory Cloud where you perform configuration tasks, such as adding a new deployment target or managing your configuration secrets. Use it to configure your Armory Cloud Platform instance and integrations with your existing tools.
 - Armory Cloud API gives you a way to programmatically configure admin settings.

--- a/content/en/docs/armory-cloud-preview/armory-cloud-admin/admin-cloud-quickstart.md
+++ b/content/en/docs/armory-cloud-preview/armory-cloud-admin/admin-cloud-quickstart.md
@@ -9,11 +9,11 @@ aliases:
 
 ## Logging in to the Armory Cloud Console 
 
-Armory provides a set of credentials to log in to the Cloud Console. These are separate from the user accounts that app developers use to access the Armory Platform UI and API. The Cloud Console is where you go to make changes to the Armory Cloud environment and what it has access to. For example, you can add deployment targets or other resources in the Cloud Console. When app developers log in to the Armory Platform, they can use these resources in their deployment pipelines.
+Armory provides a set of credentials to log in to the Cloud Console. These are separate from the user accounts that app developers use to access the Armory Enterprise UI and API. The Cloud Console is where you go to make changes to the Armory Cloud environment and what it has access to. For example, you can add deployment targets or other resources in the Cloud Console. When app developers log in to Armory Enterprise, they can use these resources in their deployment pipelines.
 
 As a design partner, Armory provides credentials for you to use for logging in to the Cloud Console.
 
-From here, you can select which environment you want to configure or open the Armory Platform for that environment.
+From here, you can select which environment you want to configure or open Armory Enterprise for that environment.
 
 ## Configuring the environment
 
@@ -131,8 +131,8 @@ Save the configuration.
 
 These are optional but provide a way for your developers to automatically trigger their deployment pipelines. -->
 
-## Accessing the Armory Platform
+## Accessing Armory Enterprise
 
-The Armory Platform is where your app developers create their delivery pipelines. Once the environments are configured, your app developers can access Armory Cloud to start deploying applications.
+Armory Enterprise is where your app developers create their delivery pipelines. Once the environments are configured, your app developers can access Armory Cloud to start deploying applications.
 
 The URL to access the Armory platform is available on the Cloud Console homepage when you click **Launch**.

--- a/content/en/docs/cloud-resources/_index.md
+++ b/content/en/docs/cloud-resources/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Cloud Resources"
 description: >
-  Armory uses cloud providers as both sources and targets for deploying software. This section is a collection of resources from cloud providers that you might find useful when installing and running the Armory Platform.
+  Armory uses cloud providers as both sources and targets for deploying software. This section is a collection of resources from cloud providers that you might find useful when installing and running Armory Enterprise.
 weight: 30
 ---

--- a/content/en/docs/cloud-resources/resources-aws.md
+++ b/content/en/docs/cloud-resources/resources-aws.md
@@ -2,7 +2,7 @@
 title: AWS Resources
 linkTitle: AWS
 description: >
-  Services used by the Armory Platform when it is deployed on Amazon Web Services - VPC, EKS, IAM, S3, Secrets Manager, Redis, Aurora.
+  Services used by Armory Enterprise when it is deployed on Amazon Web Services - VPC, EKS, IAM, S3, Secrets Manager, Redis, Aurora.
 ---
 
 ## Armory and AWS services

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -26,7 +26,7 @@ There are several methods to install Armory or open source Spinnaker:
 
 All the preceding methods share similar configurations, and you can migrate between them if your needs change.
 
-> Armory does not generate default usernames and passwords for user accounts for any service. Manage these by configuring authentication and authorization for the Armory Platform.
+> Armory does not generate default usernames and passwords for user accounts for any service. Manage these by configuring authentication and authorization for Armory Enterprise.
 
 ## Guides
 

--- a/content/en/docs/plugin-guide/plugin-external-account.md
+++ b/content/en/docs/plugin-guide/plugin-external-account.md
@@ -3,7 +3,7 @@ title: External Account Plugin
 toc_hide: true
 exclude_search: true
 description: >
-  The External Account Plugin allows the Armory Platform to read accounts from external sources.
+  The External Account Plugin allows Armory Enterprise to read accounts from external sources.
 ---
 <!-- this is a private plugin German created for a customer. This unlisted page is to satisfy an auditing requirement they have. It is also hidden via robots.txt and the netlify sitemap plugin. -->
 ![Proprietary](/images/proprietary.svg)

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-23-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-23-0.md
@@ -33,7 +33,7 @@ Armory scans the codebase as we develop and release software. For information ab
 <!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
 #### Clouddriver resources
 
-There is a known issue with Clouddriver that affects the performance of the Armory Platform, causing it to consume more resources. This can lead to a situation where pods do not have enough resources to start.
+There is a known issue with Clouddriver that affects the performance of Armory Enterprise, causing it to consume more resources. This can lead to a situation where pods do not have enough resources to start.
 
 {{< include "known-issues/ki-orca-zombie-execution.md" >}}
 {{< include "known-issues/ki-lambda-ui-caching.md" >}}

--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-23-1.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-23-1.md
@@ -33,7 +33,7 @@ Armory scans the codebase as we develop and release software. For information ab
 <!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
 #### Clouddriver resources
 
-There is a known issue with Clouddriver that affects the performance of the Armory Platform, causing it to consume more resources. This can lead to a situation where pods do not have enough resources to start.
+There is a known issue with Clouddriver that affects the performance of Armory Enterprise, causing it to consume more resources. This can lead to a situation where pods do not have enough resources to start.
 
 #### Pipelines as Code Slack notifications
 

--- a/content/en/docs/spinnaker-user-guides/policy-engine-use.md
+++ b/content/en/docs/spinnaker-user-guides/policy-engine-use.md
@@ -1,5 +1,5 @@
 ---
-title: Use Policy Engine with the Armory Platform
+title: Use Policy Engine with Armory Enterprise
 linkTitle: Use Policy Engine
 description: >
   Add policies to your Open Policy Agent (OPA) instance for Spinnaker to use when it performs validation to make sure your pipelines meet your policy requirements.

--- a/content/en/docs/spinnaker-user-guides/terraform-use-integration.md
+++ b/content/en/docs/spinnaker-user-guides/terraform-use-integration.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: Use the Terraform Integration Stage
-title: Use the Terraform Integration Stage in the Armory Platform
+title: Use the Terraform Integration Stage in Armory Enterprise
 aliases:
   - /docs/spinnaker/terraform-use-integration/
 description: >
@@ -20,7 +20,7 @@ A Terraform Integration stage performs the following actions when it runs:
 
 ## Requirements
 
-Before you can use the Terraform Integration stage, verify that Armory's Terraform Integration for Spinnaker is enabled. Additionally, your Terraform code needs to be stored in either a GitHub or BitBucket repo that the Armory Platform can access. You grant access as part of the enablement process.
+Before you can use the Terraform Integration stage, verify that Armory's Terraform Integration for Spinnaker is enabled. Additionally, your Terraform code needs to be stored in either a GitHub or BitBucket repo that Armory Enterprise can access. You grant access as part of the enablement process.
 
 For more information, see [Enabling the Terraform Integration]({{< ref "terraform-enable-integration">}}).
 

--- a/content/en/docs/spinnaker-user-guides/using-dinghy.md
+++ b/content/en/docs/spinnaker-user-guides/using-dinghy.md
@@ -1,5 +1,5 @@
 ---
-title: Use Pipelines as Code in the Armory Platform
+title: Use Pipelines as Code in Armory Enterprise
 linkTitle: Use Pipelines as Code
 aliases:
   - /spinnaker/using_dinghy/

--- a/content/en/includes/agent/agent-compat-matrix.md
+++ b/content/en/includes/agent/agent-compat-matrix.md
@@ -1,4 +1,4 @@
-The Armory Agent is compatible with the Armory Platform and open source Spinnaker. It consists of a lightweight service that you deploy on Kubernetes and a plugin that you install into Spinnaker.
+The Armory Agent is compatible with Armory Enterprise and open source Spinnaker. It consists of a lightweight service that you deploy on Kubernetes and a plugin that you install into Spinnaker.
 
 | Armory (Spinnaker) Version | Armory Agent Plugin Version    | Armory Agent Version |
 |:-------------------------- |:------------------------------ |:---------------------------- |


### PR DESCRIPTION
Replaces references to "Armory Platform" with "Armory Enterprise.