### PR TITLE
docs(agent): Remove Spinnaker version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,11 +146,11 @@ prism_syntax_highlighting = true
 # Armory Agent plugin versions
 [params.kubesvc-plugin]
 agent_plug_latest-2="0.6.7"
-agent_plug_latest_spin-2="2.23.x (1.23.x)"
+agent_plug_latest_spin-2="2.23.x"
 agent_plug_latest-1="0.7.6"
-agent_plug_latest_spin-1="2.24.x (1.24.x)"
+agent_plug_latest_spin-1="2.24.x"
 agent_plug_latest="0.8.5"
-agent_plug_latest_spin="2.25.x (1.25.x)"
+agent_plug_latest_spin="2.25.x"
 
 # User interface configuration
 [params.ui]

--- a/content/en/includes/agent/agent-compat-matrix.md
+++ b/content/en/includes/agent/agent-compat-matrix.md
@@ -1,6 +1,6 @@
 The Armory Agent is compatible with Armory Enterprise and open source Spinnaker. It consists of a lightweight service that you deploy on Kubernetes and a plugin that you install into Spinnaker.
 
-| Armory (Spinnaker) Version | Armory Agent Plugin Version    | Armory Agent Version |
+| Armory Enterprise Version | Armory Agent Plugin Version    | Armory Agent Version |
 |:-------------------------- |:------------------------------ |:---------------------------- |
 | {{<param kubesvc-plugin.agent_plug_latest_spin-2>}} | {{<param kubesvc-plugin.agent_plug_latest-2>}} | {{<param kubesvc-version>}} |
 | {{<param kubesvc-plugin.agent_plug_latest_spin-1>}} | {{<param kubesvc-plugin.agent_plug_latest-1>}} | {{<param kubesvc-version>}} |


### PR DESCRIPTION
The Agent is not open source, and Sales has no option for selling the Agent outside of Armory Enterprise. Remove Spinnaker version so people don't think they can use it outside of AE.

Resolves Jira: DOC-367

