### PR TITLE
doc(operator) Fix the openssl ca signing of gate certificate

### DIFF
--- a/content/en/docs/armory-admin/api-endpoint.md
+++ b/content/en/docs/armory-admin/api-endpoint.md
@@ -257,6 +257,7 @@ Gate's eventual fully-qualified domain name (FQDN) as the Common Name (CN).
    CA_KEY_PASSWORD=SOME_PASSWORD_FOR_CA_KEY
 
    openssl x509 \
+     -sha256 \
      -req \
      -days 365 \
      -in gate.csr \


### PR DESCRIPTION
When signing the gate certificate request without the `-sha256` argument being supplied to the OpenSSL command, an invalid JKS will be created and cause the gate pod to fail.

For example (From the docs):

```bash
openssl x509 \
  -req \
  -days 365 \
  -in client.csr \
  -CA ca.crt \
  -CAkey ca.key \
  -CAcreateserial \
  -out client.crt \
  -passin pass:${CA_KEY_PASSWORD}
```

When you import the key to a JKS you will get the following warning:-

```bash
Warning:
<gate> uses the SHA1withRSA signature algorithm which is considered a security risk. This algorithm will be disabled in a future update.
```

When the JKS is loaded into the pod, an exception will be thrown `Invalid keystore format`. When inspecting the JKS file using **keytools** you get the following error:-

```bash
bash-5.0$ keytool -list -keystore /opt/gate/secrets/spin-gate-secrets/gate.jks -storepass XXXXX
keytool error: java.io.IOException: Integrity check failed: java.security.NoSuchAlgorithmException: Algorithm HmacPBESHA256 not available
```

However, when signing the gate certificate request with the `-sha256` argument, the JKS is created correctly. I generated a JKS using the command from the example above with the exception of adding `-sha256`:-

```bash
bash-5.0$ keytool -list    -keystore /opt/gate/secrets/spin-gate-secrets/gate.jks    -storepass XXXXX
Keystore type: PKCS12
Keystore provider: SUN

Your keystore contains 2 entries

gate, Apr 26, 2021, PrivateKeyEntry, 
Certificate fingerprint (SHA-256): 12:45:8D:38:6C:91:9B:05:36:66:CC:A0:48:1C:01:32:46:1F:FC:60:3B:92:AD:1E:8B:76:2E:3E:C7:FE:C2:6D
ca, Apr 26, 2021, trustedCertEntry, 
Certificate fingerprint (SHA-256): DD:D2:A4:4C:E9:E4:06:2D:5B:68:CA:8A:49:BC:D1:74:50:7D:A5:F8:79:E6:D3:03:83:3C:8C:28:D0:3C:4F:50
```