### PR TITLE
docs(admin): Append to file

### DIFF
--- a/content/en/docs/armory-admin/hostname-deck-gate-configure.md
+++ b/content/en/docs/armory-admin/hostname-deck-gate-configure.md
@@ -106,7 +106,7 @@ in the `profiles` directory.
    ```bash
    # Make the gate-local.yml file in the profile directory
 
-   tee /home/spinnaker/.hal/default/profiles/gate-local.yml <<-'EOF'
+   tee -a /home/spinnaker/.hal/default/profiles/gate-local.yml <<-'EOF'
    healthEndpoint: /api/v1/health
    EOF
    ```


### PR DESCRIPTION
Resolves GitHub issue: #341 

As @IxDay pointed out, the second `tee` in the Haylard tab overwrites the additions made in the first instance. Adding the `-a` (`--append`) flag resolves.