### PR TITLE
Update(armory.md): More Information about Github Notifier

### DIFF
--- a/content/en/docs/installation/armory-operator/op-manifest-reference/armory.md
+++ b/content/en/docs/installation/armory-operator/op-manifest-reference/armory.md
@@ -31,6 +31,8 @@ armory:
       slack:
         enabled:
         channel:
+      github:
+        enabled:
     webhookValidationEnabledProviders:
     webhookValidations:
     - enabled:
@@ -79,7 +81,7 @@ armory:
     - `enabled`: true or false.
     - `channel`: Name of channel to send notifications to.
   - `github`:
-    - `enabled`: true or false.
+    - `enabled`: true or false. Note this will enable comments to the PR to allow for more robust feedback information from Dinghy.  May cause [issues with those using custom Github endpoints] (https://support.armory.io/support?id=kb_article&sysparm_article=KB0010290)
 - `webhookValidationEnabledProviders`: List of enabled providers for Webhook validations.
 - `webhookValidations`: Webhook validations list
   - `enabled`: true/false flag to enable this validation.


### PR DESCRIPTION
Added information missing about what the Github Notifier means for Dinghy, and an issue that has come up.
