### PR TITLE
docs(nginx): fix dead nginx-ingress install links

### DIFF
--- a/content/en/docs/installation/guide/install-on-k8s.md
+++ b/content/en/docs/installation/guide/install-on-k8s.md
@@ -835,8 +835,8 @@ Both of these are configurable with Armory Enterprise, but the NGINX ingress con
 Then, install the NGINX ingress controller AWS-specific service:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/aws/service-l4.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/aws/patch-configmap-l4.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.30.0/deploy/static/provider/aws/service-l4.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.30.0/deploy/static/provider/aws/patch-configmap-l4.yaml
 ```
 
 ### Set up an Ingress for `spin-deck` and `spin-gate`


### PR DESCRIPTION
Resolves https://github.com/armory/spinnaker-operator/issues/178

Fixed two links in k8s install docs and added version hardlink so it won't die later.