### PR TITLE
fix(releaseNotes-2.26.0): Updating available Terraform version for Terraformer to v0.15.1

### DIFF
--- a/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-26-0.md
+++ b/content/en/docs/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-26-0.md
@@ -111,7 +111,7 @@ The following changes to the Plugin Framework may affect you if you are developi
 
 ### Terraform Integration stage
 
-- The integration now supports Terraform versions up to 14.10.
+- The integration now supports Terraform versions up to 0.15.1.
 - The container for the Terraformer service now includes the GCloud SDK and `anthos-cli`.
 - All the Terraform binaries bundled as part of the integration have been updated in accordance with [HCSEC-2021-12](https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570) to address potential issues from the Codecov incident.
 


### PR DESCRIPTION
<!-- Make sure your PR title matches the following format: <type>(<scope>): <subject> -->
<!-- Include the Jira or GitHub issue associated with this work if there is one -->
<!-- If Jira, enclose the ticket in brackets. Jira-GitHub integration requires this format. -->

<!-- Share artifacts of the changes if they'd help your reviewer, e.g. a screenshot -->
Available up to 0.15.1 in 2.26.0.
https://s.armory.io/d5uALdjZ
<!-- You can delete these comments when you submit your PR. -->
