### PR TITLE
docs(operator): fix incorrect path in operator cluster install

### DIFF
--- a/content/en/includes/armory-operator/op-install-cluster.md
+++ b/content/en/includes/armory-operator/op-install-cluster.md
@@ -29,7 +29,7 @@ You can find the Operator's deployment configuration in `spinnaker-operator/depl
 
 1. Create the namespace for the Operator:
 
-   In `cluster` mode, if you want to use a namespace other than `spinnaker-operator`, you need to edit the namespace in `deploy/operator/kustomize/role_binding.yaml`.
+   In `cluster` mode, if you want to use a namespace other than `spinnaker-operator`, you need to edit the namespace in `deploy/operator/cluster/role_binding.yaml`.
 
    ```bash
    kubectl create ns spinnaker-operator
@@ -38,7 +38,7 @@ You can find the Operator's deployment configuration in `spinnaker-operator/depl
 1. Install the Operator:
 
    ```bash
-   kubectl -n spinnaker-operator apply -f deploy/operator/kustomize
+   kubectl -n spinnaker-operator apply -f deploy/operator/cluster
    ```
 
 1. Verify that the Operator is running:


### PR DESCRIPTION
in quickstart, change deploy/operator/kustomize to deploy/operator/cluster

Resolves Jira: DOC-393


