### PR TITLE
docs(exposing-spinnaker): LoadBalancer typo

### DIFF
--- a/content/en/docs/armory-admin/aws/exposing-spinnaker.md
+++ b/content/en/docs/armory-admin/aws/exposing-spinnaker.md
@@ -41,7 +41,7 @@ spec:
   expose:
     type: service
     service:
-      type: loadbalancer
+      type: LoadBalancer
 ```
 
 Save and apply the configuration. After some time, you can see the LoadBalancer CNAMEs that were created:


### PR DESCRIPTION
K8s manifests are case sensitive for `type: LoadBalancer`, as `type: loadbalancer` fails to deploy. 