### PR TITLE
docs(fix): Remove Cookie Consent Banner

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -15,7 +15,7 @@
     gtag('set', 'ads_data_redaction', true);
 </script>
 
-<!-- Cookiebot CMP -->
+<!-- Cookiebot CMP
 <script
     id="Cookiebot"
     src="https://consent.cookiebot.com/uc.js"
@@ -23,6 +23,7 @@
     data-blockingmode="auto"
     type="text/javascript">
 </script>
+ -->
 
 <!-- Google Analytics -->
 <script type="text/plain" data-cookieconsent="statistics">


### PR DESCRIPTION
The cookie consent banner, before it is accepted, breaks styling for gists imported with Hugo's `gist` shortcode.