### PR TITLE
docs(cookie): remove google scripts from head-end

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,6 +46,12 @@ resampleFilter = "CatmullRom"
 quality = 75
 anchor = "smart"
 
+# Google Analytics configuration
+[services]
+[services.googleAnalytics]
+# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
+id = "UA-79996712-5"
+
 # Language configuration
 
 [languages]
@@ -173,7 +179,7 @@ footer_about_disable = false
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/armory/docs/issues/new">tell us how we can improve</a>.'
+yes = 'Thank you for letting us know!'
 no = 'Sorry to hear that. Please <a href="https://github.com/armory/docs/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,38 +1,4 @@
-<!-- Google Consent Mode -->
-<script data-cookieconsent="ignore">
-    window.dataLayer = window.dataLayer || [];
-​
-    function gtag() {
-        dataLayer.push(arguments);
-    }
-​
-    gtag('consent', 'default', {
-        ad_storage: 'denied',
-        analytics_storage: 'denied',
-        wait_for_update: 500,
-    });
-​
-    gtag('set', 'ads_data_redaction', true);
-</script>
-
-<!-- Cookiebot CMP
-<script
-    id="Cookiebot"
-    src="https://consent.cookiebot.com/uc.js"
-    data-cbid="dbb13ff5-899a-4802-a583-6a53788cb99b"
-    data-blockingmode="auto"
-    type="text/javascript">
-</script>
- -->
-
-<!-- Google Analytics -->
-<script type="text/plain" data-cookieconsent="statistics">
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-79996712-5', 'auto');
-  ga('send', 'pageview');
-</script>
-
-<script type="text/plain" data-cookieconsent="statistics">
+<script type="text/javascript">
   (function(){
     window.ldfdr = window.ldfdr || {};
     (function(d, s, ss, fs){
@@ -47,7 +13,7 @@
   })();
 </script>
 
-<script type="text/plain" data-cookieconsent="statistics">
+<script type="text/javascript">
   (function(i,s,o,g,r,a,m){i['SLScoutObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
Resolves Jira: [DOC-410]

- change to use theme implementation of Google Analytics: add [services.googleAnalytics] to config.toml
- remove google analytics and cookiebot scripts from head-end
- remove `data-cookieconsent` from remaining cookies and change type to `text/javascript`


[DOC-410]: https://armory.atlassian.net/browse/DOC-410