### PR TITLE
docs(fix): add section redirect

### DIFF
--- a/content/en/docs/armory-admin/policy-engine/policy-engine-use/packages/spinnaker.deployment/tasks.before/cleanupArtifacts.md
+++ b/content/en/docs/armory-admin/policy-engine/policy-engine-use/packages/spinnaker.deployment/tasks.before/cleanupArtifacts.md
@@ -355,4 +355,4 @@ deny["Artifactss may not be cleaned up from production accounts"] {
 | ---------------------------- | -------- | ---------------------------------------------- |
 | `input.deploy.account`       | `string` | The account being deployed to.       |
 | `input.deploy.credentials`   | `string` | The credentials to use to access the account.  |
-| `input.deploy.manifests[].*` | `*`      | The entire Kubernetest manifest to be removed. |
+| `input.deploy.manifests[].*` | `*`      | The entire Kubernetes manifest to be removed. |

--- a/content/en/docs/armory-admin/policy-engine/policy-engine-use/packages/spinnaker.deployment/tasks.before/deployManifest.md
+++ b/content/en/docs/armory-admin/policy-engine/policy-engine-use/packages/spinnaker.deployment/tasks.before/deployManifest.md
@@ -1,7 +1,7 @@
 ---
 title: "spinnaker.deployment.tasks.before.deployManifest"
 linkTitle: "deployManifest"
-description: "Policy checks that run immediately before a task deploys a spinnaker manifest."
+description: "Policy checks that run immediately before a task deploys a Spinnaker manifest."
 ---
 
 
@@ -187,7 +187,7 @@ deny["Manifest is missing a required annotation"] {
 | `input.deploy.enableTraffic`     | `boolean` | Allow Armory Enterprise to associate each ReplicaSet deployed in this stage with one or more services and manage traffic based on your selected rollout strategy options. |
 | `input.deploy.manifest`          | `[array]` | An array of the manifests being deployed                                                                       |
 | `input.deploy.manifestArtifact`  |           | The name of the artifact from which the manifest should be read.                                               |
-| `input.deploy.manifests[].*`     | `*`       | The entire Kubernetest manifest to be deployed.                                                                |
+| `input.deploy.manifests[].*`     | `*`       | The entire Kubernetes  manifest to be deployed.                                                                |
 | `input.deploy.moniker.app`       | `string`  | The name of the application being deployed                                                                     |
 | `input.deploy.moniker.cluster`   | `string`  | The name of the cluster you are deploying to.                                                                  |
 | `input.deploy.moniker.detail`    |           |                                                                                                                |

--- a/netlify.toml
+++ b/netlify.toml
@@ -84,6 +84,9 @@
   to = "/docs/armory-admin/armory-agent/"
   force = true
 
+[[redirects]]
+  from ="/docs/spinnaker-user-guides/policy-engine-use/packages/*"
+  to = "/docs/armory-admin/policy-engine/policy-engine-use/packages/:splat"
 
 # https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]


### PR DESCRIPTION
* Adds a section redirect for the files that got moved in https://github.com/armory/docs/pull/764
  * For example: https://docs.armory.io/docs/spinnaker-user-guides/policy-engine-use/packages/spinnaker.deployment/tasks.before/deploymanifest/
* Fixes typos