### PR TITLE
chore(release): Revert autobump agent plugin version (0.10.0)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -153,12 +153,12 @@ prism_syntax_highlighting = true
 
 # Armory Agent plugin versions
 [params.kubesvc-plugin]
-agent_plug_latest-2="0.8.24"
-agent_plug_latest_spin-2="2.25.x (1.25.x)"
-agent_plug_latest-1="0.9.16"
-agent_plug_latest_spin-1="2.26.x (1.26.x)"
-agent_plug_latest="0.10.0"
-agent_plug_latest_spin="2.27.x (1.27.x)"
+agent_plug_latest-2="0.7.25"
+agent_plug_latest_spin-2="2.24.x (1.24.x)"
+agent_plug_latest-1="0.8.24"
+agent_plug_latest_spin-1="2.25.x (1.25.x)"
+agent_plug_latest="0.9.16"
+agent_plug_latest_spin="2.26.x (1.26.x)"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Reverts armory/docs#876

2.27 is not out yet.