### PR TITLE
doc(agent): Plugin docker registry has not been renamed yet

### DIFF
--- a/content/en/docs/armory-agent/armory-agent-quick.md
+++ b/content/en/docs/armory-agent/armory-agent-quick.md
@@ -90,7 +90,7 @@ spec:
                 spec:
                   initContainers:
                   - name: armory-agent-plugin
-                    image: docker.io/armory/agent-k8s-spinplug:<version> # must be compatible with your Armory Enterprise version
+                    image: docker.io/armory/kubesvc-plugin:<version> # must be compatible with your Armory Enterprise version
                     volumeMounts:
                       - mountPath: /opt/plugin/target
                         name: armory-agent-plugin-vol


### PR DESCRIPTION
Noticed during agent training session that we only renamed the docker registry for the agent service, but we're still missing renaming for the agent plugin.