### PR TITLE
docs(agent): add known issue about whitespace in permissions to Agent release notes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
 
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/google/docsy

--- a/content/en/docs/armory-agent/agent-options.md
+++ b/content/en/docs/armory-agent/agent-options.md
@@ -78,7 +78,7 @@ kubernetes:
         - READ: ['role1', 'role2']
         - WRITE: ['role3', 'role4']
 ```
-
+Please ensure that there are no whitespaces in the role configurations under the READ or WRITE tags. Having whitespaces in the configuration does not apply the permissions and all users will have access to the account. This is a known error and is being investigated.
 
 ## Restricted environments
 

--- a/content/en/docs/armory-agent/agent-options.md
+++ b/content/en/docs/armory-agent/agent-options.md
@@ -78,7 +78,8 @@ kubernetes:
         - READ: ['role1', 'role2']
         - WRITE: ['role3', 'role4']
 ```
-Please ensure that there are no whitespaces in the role configurations under the READ or WRITE tags. Having whitespaces in the configuration does not apply the permissions and all users will have access to the account. This is a known error and is being investigated.
+
+>Make sure that there are no whitespaces in the role configurations under the `READ` or `WRITE` tags. The permissions are not applied if there are whitespaces in the configuration. This means that all users will have access to the account.
 
 ## Restricted environments
 

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-25.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-25.md
@@ -9,3 +9,7 @@ version: 00.05.25
 
 * Updated the base image to Debian 10.10
 * Added release notes automation for Armory documentation. Previously, the release notes were only available on the GitHub release page.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-26.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-26.md
@@ -7,16 +7,20 @@ version: 00.05.26
 
 ## New features and improvements
 
-* You can now control the Agent's behavior when a failed request to the Kubernetes API server occurs:
+You can now control the Agent's behavior when a failed request to the Kubernetes API server occurs:
 
-   ```yaml
-   kubernetes:
-     retries:
-       enabled: true         # (Optional, boolean, default: true). Enable or disable retries when the Agent makes a failed request to the Kubernetes API server.
-       maxRetries: 3         # (Optional, integer, default: 3): The number of times that the Agent will try the same request if it fails.
-       backOffMs: 3000       # (Optional, integer, default: 3000): How much time (in milliseconds) to wait between retry attempts.
-       retryAnyError: false  # (Optional, boolean, default: false): Optional. If true, Agent will retry when encountering any error from the Kubernetes API server. If false, Agent will only retry if the error contains any item from `retryableErrors.`
-       retryableErrors:      # (Optional, list of strings, default: "timeout", "deadline exceeded"): Optional. If the error from the Kubernetes API server contains any item from this list, the request will be retried. Requires `retryAnyError` to be `false`.
-       - "timeout"
-       - "deadline exceeded"
-   ```
+```yaml
+kubernetes:
+ retries:
+   enabled: true         # (Optional, boolean, default: true). Enable or disable retries when the Agent makes a failed request to the Kubernetes API server.
+   maxRetries: 3         # (Optional, integer, default: 3): The number of times that the Agent will try the same request if it fails.
+   backOffMs: 3000       # (Optional, integer, default: 3000): How much time (in milliseconds) to wait between retry attempts.
+   retryAnyError: false  # (Optional, boolean, default: false): Optional. If true, Agent will retry when encountering any error from the Kubernetes API server. If false, Agent will only retry if the error contains any item from `retryableErrors.`
+   retryableErrors:      # (Optional, list of strings, default: "timeout", "deadline exceeded"): Optional. If the error from the Kubernetes API server contains any item from this list, the request will be retried. Requires `retryAnyError` to be `false`.
+   - "timeout"
+   - "deadline exceeded"
+```
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-27.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-27.md
@@ -8,3 +8,7 @@ version: 00.05.27
 ## New features and improvements
 
 * You can now control the format of the logs that Agent prints to the console. In the Agent config file, set `logging.format` to either `text` (default) or `json`.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-28.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-28.md
@@ -5,6 +5,10 @@ version: 00.05.28
 
 ---
 
-### New
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}
+
+## Fixes
 
 - Resolve resource mapping for non discovered kinds during agent startup. This allows operations to complete even if there is a failure when reading a specific kind during startup as long as the agent has permissions to read it.

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-29.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-29.md
@@ -8,3 +8,7 @@ version: 00.05.29
 ## Fixes
 *   Resolved an issue that occurred when watching Kubernetes kinds. The Agent now checks for both `list` and `watch` permissions. Previously, the Agent only checked for `list` permission, which resulted in errors like the following not being filtered out: `Failed to watch *unstructured.Unstructured: unknown`.
 
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}
+

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-30.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-30.md
@@ -18,3 +18,7 @@ clouddriver:
 ```
 
 Note that the `kubesvc.cache.operationWaitMs` config for the Agent Plugin should be set so that it does not time out before the retries are complete.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-31.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-5-31.md
@@ -8,3 +8,7 @@ version: 00.05.31
 ## Feature
 
 Added support for operations that don’t specify an `apiGroup`. The group can now be derived from existing groups of the given kind.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-0.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-0.md
@@ -9,3 +9,7 @@ version: 00.06.00
 
 * The configuration file for Agent has been renamed from `kubesvc.{yml|yaml}` to `armory-agent.{yml|yaml}`. Additionally, its location changed from `/opt/spinnaker/config` to `/opt/armory/config`. The old config file is still used if `armory-agent.{yml|yaml}` is not present, but users are encouraged to move to the new naming convention.
 * Agent docker images are now published to `armory/agent-k8s` on Docker Hub. Previously, the images were published to `armory/kubesvc`.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-1.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-1.md
@@ -8,3 +8,7 @@ version: 00.06.01
 ## New features and improvements
 
 * The user that runs inside the Agent pod is now `armory`. Previously, the user was `spinnaker`.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-2.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-2.md
@@ -17,4 +17,8 @@ helm install armory-agent armory-charts/agent-k8s-full \
 
 All configuration options available in the `armory-agent.yml` config file can be passed as values to Helm under the `config` section.
 
-For more information, see [Install the Agent servoce]({{< ref "armory-agent-quick#install-the-agent-service" >}}).
+For more information, see [Install the Agent service]({{< ref "armory-agent-quick#install-the-agent-service" >}}).
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-3.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-3.md
@@ -5,6 +5,10 @@ version: 00.06.03
 
 ---
 
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}
+
 ## Fixes
 
 * Fixed the Helm chart name. The chart is now named `agent-k8s-full`.

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-4.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-4.md
@@ -2,7 +2,6 @@
 title: v0.6.4 Armory Agent Service (2021-09-29)
 toc_hide: true
 version: 00.06.04
-
 ---
 
 ## Known Issues

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-4.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-4.md
@@ -5,7 +5,11 @@ version: 00.06.04
 
 ---
 
-### Fixes
+## Known Issues
 
-- Fixed in issue that prevented Helm from installing when a kubeconfig is not provided.
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}
+
+## Fixes
+
+- Fixed an issue that prevented Helm from installing when a kubeconfig is not provided.
 

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-5.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-5.md
@@ -5,6 +5,10 @@ version: 00.06.05
 
 ---
 
-### New
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}
+
+## Fixes
 
 - Resolve resource mapping for non discovered kinds during agent startup. This allows operations to complete even if there is a failure when reading a specific kind during startup as long as the agent has permissions to read it.

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-6.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-6.md
@@ -5,5 +5,9 @@ version: 00.06.06
 
 ---
 
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}
+
 ## Fixes
 *  Resolved an issue that occurred when watching Kubernetes kinds. The Agent now checks for both `list` and `watch` permissions. Previously, the Agent only checked for `list` permission, which resulted in errors like the following not being filtered out: `Failed to watch *unstructured.Unstructured: unknown`.

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-7.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-7.md
@@ -18,3 +18,7 @@ clouddriver:
 ```
 
 Note that the `kubesvc.cache.operationWaitMs` config for the Agent Plugin should be set so that it does not time out before the retries are complete.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-8.md
+++ b/content/en/docs/release-notes/rn-armory-agent/agent-service/agent-service-v-0-6-8.md
@@ -8,3 +8,7 @@ version: 00.06.08
 ## Feature
 
 Added support for operations that don’t specify an `apiGroup`. The group can now be derived from existing groups of the given kind.
+
+## Known Issues
+
+{{< include "release-notes/agent/ki-permissions-whitespace.md" >}}

--- a/content/en/includes/release-notes/agent/ki-permissions-whitespace.md
+++ b/content/en/includes/release-notes/agent/ki-permissions-whitespace.md
@@ -1,0 +1,14 @@
+### Kubernetes account permissions format
+<!-- SUPPORT-3482 -->
+```yaml
+kubernetes:
+  accounts:
+    - name: my-k8s-account
+      permissions:
+        - READ: ['role1', 'role2']
+        - WRITE: ['role3', 'role4']
+```
+
+Make sure that there are no whitespaces in the role configurations under the `READ` and `WRITE` tags. The permissions are not applied if there are whitespaces in the configuration. This means that all users will have access to the defined account.
+
+**Affected versions**: all versions


### PR DESCRIPTION
Add known issue about whitespaces in Agent role permission configuration causing the permissions to not be applied.

Partial Jira: [SUPPORT-3482]




[SUPPORT-3482]: https://armory.atlassian.net/browse/SUPPORT-3482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ