### PR TITLE
docs(agent): add redirect to install since quickstart deleted

### DIFF
--- a/content/en/ae/armory-agent/armory-agent-install/_index.md
+++ b/content/en/ae/armory-agent/armory-agent-install/_index.md
@@ -5,6 +5,8 @@ description: >
   Learn how to install the Armory Agent in your Kubernetes and Armory Enterprise environments.
 weight: 30
 no_list: true
+aliases:
+  - /armory-agent/armory-agent-quick/
 ---
 ![Proprietary](/images/proprietary.svg)
 


### PR DESCRIPTION
https://cloud-armory.slack.com/archives/CH4RVCCTS/p1639092622035700
Chris Tan let us know that the old quickstart link gets a 404

To test:
https://docs.armory.io/ae/armory-agent/armory-agent-quick/#compatibility-matrix
should redirect to
https://docs.armory.io/ae/armory-agent/armory-agent-install/#compatibility-matrix