### PR TITLE
docs(bug): remove reference to kustomize repo

### DIFF
--- a/content/en/armory-enterprise/installation/armory-operator/op-manifest-reference/repository.md
+++ b/content/en/armory-enterprise/installation/armory-operator/op-manifest-reference/repository.md
@@ -42,6 +42,3 @@ repository:
       - `username`: The username of the artifactory user to authenticate as.
       - `password`: The password of the artifactory user to authenticate as. Supports encrypted value.
 
-## Kustomize patch examples
-
-You can see examples in the `spinnaker-kustomize-patches` repo's [`git` folder](https://github.com/armory/spinnaker-kustomize-patches/tree/master/accounts/git).


### PR DESCRIPTION

Remove reference to spinnaker-kustomize-repo since no example exists there

Resolves Jira: [DOC-511]




[DOC-511]: https://armory.atlassian.net/browse/DOC-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ