### PR TITLE
docs(releases): remove broken OSS link

### DIFF
--- a/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-0.md
+++ b/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-0.md
@@ -106,10 +106,6 @@ Note that registration does not automatically turn on Armory Diagnostics. This m
 For more information, see [Environment Registration]({{< ref "ae-instance-reg" >}}).
 
 
-###  Spinnaker Community Contributions
-
-There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
-[Spinnaker v1.27.0](https://www.spinnaker.io/changelogs/1.27.0-changelog/) changelog for details.
 
 ## Detailed updates
 

--- a/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-1.md
+++ b/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-1.md
@@ -111,12 +111,6 @@ For more information, see [Instance Registration]({{< ref "ae-instance-reg" >}})
 {{< include "breaking-changes/bc-plug-version-lts-227.md" >}}
 
 
-
-###  Spinnaker Community Contributions
-
-There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
-[Spinnaker v1.27.0](https://www.spinnaker.io/changelogs/1.27.0-changelog/) changelog for details.
-
 ## Detailed updates
 
 ### Bill Of Materials (BOM)

--- a/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-2.md
+++ b/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-2.md
@@ -51,12 +51,6 @@ This release includes a security fix. For more information, see the Critical Not
 
 This release includes a security fix. For more information, see the Critical Notification that Armory's Support Team sent out on 14 December 2021, contact your Armory account rep, or see this (login required) Support article: https://support.armory.io/support?id=kb_article_view&sysparm_article=KB0010520.
 
-
-###  Spinnaker Community Contributions
-
-There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
-[Spinnaker v1.27.0](https://www.spinnaker.io/changelogs/1.27.0-changelog/) changelog for details.
-
 ## Detailed updates
 
 ### Bill Of Materials (BOM)


### PR DESCRIPTION
Temporarily remove the broken links. Step 2 is to add the lists we generate in a collapsed details block