### PR TITLE
docs(fix): Revert "chore(operator): release notes for Armory Operato…

### DIFF
--- a/content/en/armory-enterprise/release-notes/rn-armory-operator/armory-operator-v1-6-0.md
+++ b/content/en/armory-enterprise/release-notes/rn-armory-operator/armory-operator-v1-6-0.md
@@ -1,8 +1,8 @@
 ---
-title: v1.6.1 Armory Operator
+title: v1.6.0 Armory Operator
 toc_hide: true
-version: 01.06.01
-description: Release notes for Armory Operator v1.6.1
+version: 01.06.00
+description: Release notes for Armory Operator v1.6.0
 ---
 
 ## 2022/01/26 Release Notes
@@ -22,5 +22,3 @@ Operator now supports the following configuration options for sidecars: `resourc
 ### Armory Operator
 
 * feat(sidecars): Support resources and startup|readiness probes
-* feat(artifacts/bitbucket): Support token credentials
-* chore(halyard) Update halyard version


### PR DESCRIPTION
…r 1.6.1"

This reverts commit 36aa5fd3c5582f6d343bdc0e08ef8f3ff216e924.

