### PR TITLE
docs(fix): move dinghy github notifications config to spec.spinnakerC…

### DIFF
--- a/content/en/armory-enterprise/armory-admin/dinghy-enable.md
+++ b/content/en/armory-enterprise/armory-admin/dinghy-enable.md
@@ -500,13 +500,11 @@ metadata:
   name: spinnaker
 spec:
   spinnakerConfig:
-    config:
-      armory:
-        dinghy:
-          enabled: true
-          notifiers:
-            github:
-              enabled: true       # Whether or not github notifications are enabled for Dinghy events
+    profiles:
+      dinghy:
+        notifiers:
+          github:
+            enabled: true       # Whether or not github notifications are enabled for Dinghy events
 ```
 
 {{% /tabbody %}}


### PR DESCRIPTION
…onfig.profiles from spec.spinnakerConfig.config.armory.dinghy

Github notifiers config needs to be in `spec.spinnakerConfig.profiles` instead of `spec.spinnakerConfig.config.armory.dinghy`, otherwise Operator doesn't deploy and throws a parsing error:

```
{"level":"error","ts":1643909569.002362,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"spi
nnakerservice-controller","request":"sunnytesting/spinnaker","error":"got halyard response status 500, response: Unrecognized field \"github\" (class io.armory.halyard.config.model.v1.dinghy.Notifiers), not marked as ignorable (one known property: \"slack\"])\n at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.halyard.config.model.v1.node.ArmoryDeploymentConfiguration[\"armory\"]->io.armory.halyard.config.model.v1.node.Armory[\"dinghy\"]->io.armory.halyard.config.model.v1.dinghy.Dinghy[\"notifiers\"]->io.armory.halyard.config.model.v1.dinghy.Notifiers[\"github\"])","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/opt/spinnaker-operator/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/opt/spinnaker-operator/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:218\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/opt/spinnaker-operator/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:192\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/opt/spinnaker-operator/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:171\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/opt/spinnaker-operator/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/opt/spinnaker-operator/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/opt/spinnaker-operator/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

When it's under `spec.spinnakerConfig.profiles`, Operator accepts the config, deploys Spinnaker and Dinghy acknowledges in logs that Github notifications are disabled (they're enabled by default):

```
time="2022-02-03T17:39:37Z" level=info msg="Github notifications disabled"
```