### PR TITLE
fix(dinghy): allow for dinghy slack notifiers while github slack notifiers are false

### DIFF
--- a/content/en/armory-enterprise/armory-admin/dinghy-enable.md
+++ b/content/en/armory-enterprise/armory-admin/dinghy-enable.md
@@ -503,8 +503,9 @@ spec:
     profiles:
       dinghy:
         notifiers:
+          enabled: true
           github:
-            enabled: true       # Whether or not github notifications are enabled for Dinghy events
+            enabled: true       # (Default: true) Whether or not github notifications are enabled for Dinghy events
 ```
 
 {{% /tabbody %}}


### PR DESCRIPTION
Adding extra line to ensure Dinghy Slack notifications are enabled if the Dinghy Github notification configuration is used.

It was discovered that Dinghy's Slack notifications do not send if Dinghy's Github notifications are disabled. Slack notifications are not affected if Github notifications are enabled or left unconfigured (default enabled).

The workaround is to explicitly enable notifiers in Dinghy's profile when disabling Dinghy's Github notifications.

Duplicates https://github.com/armory/spinnaker-kustomize-patches/pull/141