### PR TITLE
docs(borealis): redirect to new release notes link

### DIFF
--- a/content/en/borealis/release-notes/aurora-release-notes.md
+++ b/content/en/borealis/release-notes/aurora-release-notes.md
@@ -2,6 +2,12 @@
 title: Aurora Release Notes
 description: >
   Information about new features and changes, fixes, and improvements in Project Aurora.
+manualLink: "https://armory.releases.live/ledger/embed/"
+manualLinkTarget: "_blank"
 ---
 
-<iframe width=100% height=1088 src="https://armory.releases.live/embed/?labels=Armory+Deployments+Plugin" title="Armory Changelog"></iframe> 
+<!--
+<iframe width=100% height=1088 src="https://armory.releases.live/embed/?labels=Armory+Deployments+Plugin" title="Armory Changelog"></iframe>
+-->
+
+

--- a/content/en/borealis/release-notes/borealis-release-notes.md
+++ b/content/en/borealis/release-notes/borealis-release-notes.md
@@ -2,6 +2,10 @@
 title: Borealis Release Notes
 description: >
   Information about new features and changes, fixes, and improvements in Project Borealis.
+manualLink: "https://armory.releases.live/ledger/embed/"
+manualLinkTarget: "_blank"
 ---
 
-<iframe width=100% height=1088 src="https://armory.releases.live/embed/?labels=Armory+CLI" title="Borealis Changelog"></iframe> 
+<!--
+<iframe width=100% height=1088 src="https://armory.releases.live/embed/?labels=Armory+CLI" title="Borealis Changelog"></iframe>
+-->


### PR DESCRIPTION
Can't embed the new link - CORS error because of the embedded YouTube videos (see https://github.com/armory/docs/pull/1336)

So added redirect as front matter variable. Clicking the menu link automatically loads new link in a separate tab.

https://deploy-preview-1339--armory-docs.netlify.app/borealis/release-notes/ then click on Aurora Release Notes or Borealis Release Notes. Both open a new tab to https://armory.releases.live/ledger/embed/

Resolves Jira: [DOC-561]


[DOC-561]: https://armory.atlassian.net/browse/DOC-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ