### PR TITLE
docs(borealis): [DOC-570] add avm and cli cheat sheets

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -2,11 +2,13 @@ API
 Armory
 Armory Agent
 Armory Operator
+Armory Version Manager
 artifactory
 Artifactory
 Astra
 AWS
 Bitbucket
+Borealis
 CLI
 clouddriver
 Clouddriver
@@ -61,6 +63,8 @@ namespaces
 OpenShift
 Orca
 Postgres
+powershell
+Project Borealis
 Prometheus
 rawdata
 Redis
@@ -82,6 +86,7 @@ tabbody
 yml
 .yaml
 yaml
+zsh
 {{< heading "prereq" >}}
 {{% heading "prereq" %}}
 {{% heading "nextSteps" %}}

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -2,6 +2,7 @@ API
 Armory
 Armory Agent
 Armory Operator
+Armory Version Manager
 artifactory
 Artifactory
 Astra
@@ -63,7 +64,9 @@ namespaces
 OpenShift
 Orca
 Postgres
+powershell
 Prometheus
+Project Borealis
 rawdata
 Redis
 Release Notes
@@ -85,6 +88,7 @@ tabbody
 yml
 .yaml
 yaml
+zsh
 {{< heading "prereq" >}}
 {{% heading "prereq" %}}
 {{% heading "nextSteps" %}}

--- a/content/en/borealis/Reference/avm-cheat.md
+++ b/content/en/borealis/Reference/avm-cheat.md
@@ -12,8 +12,8 @@ The Armory Version Manager (AVM) binary is `avm`. Usage is `avm [command]`. Run 
 
 **Global Flags**
 
-- `-h, --help`: Help.
-- `-v, --verbose`: Verbose output.
+- `-h, --help`: Help
+- `-v, --verbose`: Verbose output
 
 ## AVM autocomplete
 
@@ -25,12 +25,12 @@ Generate the autocompletion script for `avm` for the specified shell.
 
 **Available Commands**
 
-- bash
-- fish
-- powershell
-- zsh
+- `bash`
+- `fish`
+- `powershell`
+- `zsh`
 
-Use `avm completion [command] --help` for more information about a command.
+See each available command's help for details on how to use the generated script.
 
 ## AVM help
 
@@ -42,7 +42,7 @@ Lists the usage and available commands.
 
 ## List CLI versions
 
-### list
+### `list`
 
 Lists the installed CLI versions.
 
@@ -50,7 +50,7 @@ Lists the installed CLI versions.
 
 `avm list [flags]`
 
-### listall
+### `listall`
 
 Lists the available CLI versions.
 
@@ -120,6 +120,11 @@ using version: v0.19.1
 
 ## Get the AVM version
 
+This command returns the Armory Version Manager version. Use [`armory version`]({{< ref "cli-cheat#get-the-cli-version">}}) to determine the CLI version you are using.
+
 **Usage**
 
 `avm version [flags]`
+
+</br>
+</br>

--- a/content/en/borealis/Reference/avm-cheat.md
+++ b/content/en/borealis/Reference/avm-cheat.md
@@ -58,7 +58,7 @@ Lists the available CLI versions.
 
 ## Install or update the CLI
 
-Install an Armory CLI version. If the version is omitted, the AVM installs the latest version and links to it as default.
+Install an Armory CLI version and create a symlink. If the version is omitted, the AVM installs the latest version.
 
 **Usage**
 
@@ -68,14 +68,55 @@ Install an Armory CLI version. If the version is omitted, the AVM installs the l
 
 - ` -d, --default`: Set version as default
 
-## Use the specified CLI version
+**Examples**
 
-Set the specified CLI version as default. This changes the symlink but does not update your path.
+To upgrade to a specific version:
+
+```bash
+avm install v0.24.0
+```
+
+To upgrade to the latest version:
+
+```bash
+avm install
+```
+
+## Set the default CLI version
+
+Set the specified CLI version as default. This command first checks to make sure the specified version has been installed. Then it updates the symlink.
 
 **Usage**
 
 `avm use [version] [flags]`
 
+**Example**
+
+Get a list of installed versions:
+
+```bash
+avm list
+```
+
+Output is similar to:
+
+```bash
+v0.19.0
+v0.19.1
+v0.25.1 [default]
+```
+
+Set version "v0.19.1" as default:
+
+```bash
+avm use v0.19.1
+```
+
+Output is similar to:
+
+```bash
+using version: v0.19.1
+```
 
 ## Get the AVM version
 

--- a/content/en/borealis/Reference/avm-cheat.md
+++ b/content/en/borealis/Reference/avm-cheat.md
@@ -1,0 +1,84 @@
+---
+title: Armory Version Manager Cheatsheet
+linktitle: AVM Cheatsheet
+description: >
+  This page contains a list of commonly used AVM commands and flags.
+exclude_search: true
+---
+
+## Armory Version Manager usage
+
+The Armory Version Manager (AVM) binary is `avm`. Usage is `avm [command]`. Run `avm help` to see a list of commands.
+
+**Global Flags**
+
+- `-h, --help`: Help.
+- `-v, --verbose`: Verbose output.
+
+## AVM autocomplete
+
+Generate the autocompletion script for `avm` for the specified shell.
+
+**Usage**
+
+`avm completion [command]`
+
+**Available Commands**
+
+- bash
+- fish
+- powershell
+- zsh
+
+Use `avm completion [command] --help` for more information about a command.
+
+## AVM help
+
+Lists the usage and available commands.
+
+**Usage**
+
+`avm help`
+
+## List CLI versions
+
+### list
+
+Lists the installed CLI versions.
+
+**Usage**
+
+`avm list [flags]`
+
+### listall
+
+Lists the available CLI versions.
+
+`avm listall [flags]`
+
+## Install or update the CLI
+
+Install an Armory CLI version. If the version is omitted, the AVM installs the latest version and links to it as default.
+
+**Usage**
+
+`avm install [version] [flags]`
+
+**Flags**
+
+- ` -d, --default`: Set version as default
+
+## Use the specified CLI version
+
+Set the specified CLI version as default. This changes the symlink but does not update your path.
+
+**Usage**
+
+`avm use [version] [flags]`
+
+
+## Get the AVM version
+
+**Usage**
+
+`avm version [flags]`

--- a/content/en/borealis/Reference/cli-cheat.md
+++ b/content/en/borealis/Reference/cli-cheat.md
@@ -12,9 +12,9 @@ The CLI binary is `armory`. Usage is `armory [command]`. Run `armory help` to se
 
 **Global Flags**
 
-- `-h, --help`: Help.
+- `-h, --help`: Help
 - `-o, --output`: Set the output type. Available options are `json` and `yaml`. The default is plain text.
-- `-v, --verbose`: Verbose output.
+- `-v, --verbose`: Verbose output
 
 ## CLI autocomplete
 
@@ -26,12 +26,12 @@ Generate the autocompletion script for `armory` for the specified shell.
 
 **Available Commands**
 
-- bash
-- fish
-- powershell
-- zsh
+- `bash`
+- `fish`
+- `powershell`
+- `zsh`
 
-Use `armory completion [command] --help` for more information about a command.
+See each available command's help for details on how to use the generated script.
 
 ## CLI help
 
@@ -82,7 +82,7 @@ When you execute the `armory logout` command, a prompt appears for user confirma
 - `-a, --authToken`: (Optional) The authentication token to use rather than `clientId` and `clientSecret` or user login.
 - `-c, --clientId`: (Optional) The Client ID for connecting to Project Borealis.
 - `-f, --file`: (Required) The path to the deployment file.
-- `-n, --application`: (Optional) The application name for deployment.
+- `-n, --application`: (Optional) The app name for deployment.
 - `-s, --clientSecret`: (Optional) The Client Secret for connecting to Project Borealis.
 
 Use only one of the following ways to authenticate your deployment: `armory login` **or** `--clientId` and `--clientSecret` **or** `--authToken`.

--- a/content/en/borealis/Reference/cli-cheat.md
+++ b/content/en/borealis/Reference/cli-cheat.md
@@ -1,0 +1,136 @@
+---
+title: CLI Cheatsheet
+linktitle: CLI Cheatsheet
+description: >
+  This page contains a list of commonly used CLI commands and flags.
+exclude_search: true
+---
+
+## CLI usage
+
+The CLI binary is `armory`. Usage is `armory [command]`. Run `armory help` to see a list of commands.
+
+**Global Flags**
+
+- `-h, --help`: Help.
+- `-o, --output`: Set the output type. Available options are `json` and `yaml`. The default is plain text.
+- `-v, --verbose`: Verbose output.
+
+## CLI autocomplete
+
+Generate the autocompletion script for `armory` for the specified shell.
+
+**Usage**
+
+`armory completion [command]`
+
+**Available Commands**
+
+- bash
+- fish
+- powershell
+- zsh
+
+Use `armory completion [command] --help` for more information about a command.
+
+## CLI help
+
+Lists the usage and available commands.
+
+**Usage**
+
+`armory help`
+
+## Log into Project Borealis
+
+**Usage**
+
+`armory login [flags]`
+
+**Flags**
+- `-e, --envName`: (Optional) The name of your Borealis environment. Names with spaces must be enclosed in single or double quotes.
+
+**Example**
+
+If your environment is named `dev`, execute:
+
+`armory login -e dev`
+
+If your environment is named `dev team`, execute:
+
+`armory login -e 'dev team'`
+
+If you don't include your environment, the command returns with a list of environments. You must select one to continue.
+
+## Log out of Project Borealis
+
+**Usage**
+
+`armory logout [envName]`
+
+`envName` is optional.
+
+When you execute the `armory logout` command, a prompt appears for user confirmation.
+
+## Deploy an application
+
+**Usage**
+
+`armory deploy start [flags]`
+
+**Flags**
+- `-a, --authToken`: (Optional) The authentication token to use rather than `clientId` and `clientSecret` or user login.
+- `-c, --clientId`: (Optional) The Client ID for connecting to Project Borealis.
+- `-f, --file`: (Required) The path to the deployment file.
+- `-n, --application`: (Optional) The application name for deployment.
+- `-s, --clientSecret`: (Optional) The Client Secret for connecting to Project Borealis.
+
+Use only one of the following ways to authenticate your deployment: `armory login` **or** `--clientId` and `--clientSecret` **or** `--authToken`.
+
+
+**Example**
+
+You are in the directory where your deployment file is located. To deploy your app, execute:
+
+`armory deploy start -f deploy.yaml`
+
+## Generate a blue/green deployment template
+
+Generate a customizable Kubernetes blue/green deployment template.
+
+**Usage**
+
+`armory template kubernetes bluegreen`
+
+**Example**
+
+To generate a template and save the output to a file:
+
+`armory template kubernetes bluegreen > deploy-bluegreen.yaml`
+
+## Generate a canary deployment template
+
+Generate a customizable Kubernetes canary deployment template.
+
+**Usage**
+
+`armory template kubernetes canary [flags]`
+
+**Flags**
+
+- `-f, --features`: Features to include in the template. Available options are `manual`, `automated`, and `traffic`.
+
+**Example**
+
+To generate a canary traffic template and save the output to a file:
+
+`armory template kubernetes canary -f traffic > deploy-canary-traffic.yaml`
+
+## Get the CLI version
+
+**Usage**
+
+`armory version`
+
+</br>
+</br>

--- a/content/en/borealis/Reference/ref-deployment-file.md
+++ b/content/en/borealis/Reference/ref-deployment-file.md
@@ -11,7 +11,7 @@ exclude_search: true
 
 The deployment file is what you use to define how and where Borealis deploys your app.
 
-You can see what a blank deployment file looks like in the [Template file](#blank-template) section. To see a filled out example, see [Example file](#example).
+You can see what a blank deployment file looks like in the [Blank templates](#blank-template) section. To see a filled out example, see [Complete examples](#complete-examples).
 
 ## Blank templates
 
@@ -71,7 +71,7 @@ armory template kubernetes bluegreen > bluegreen-deployment-template.yaml
 
 </details>
 
-## Example
+## Complete examples
 
 <details><summary>Show me a completed basic deployment file</summary>
 
@@ -91,12 +91,13 @@ armory template kubernetes bluegreen > bluegreen-deployment-template.yaml
 
 </details><br>
 
+## Sections
 
-## `application`
+### `application`
 
 Provide a descriptive name for your application so that you can identify it when viewing the status of your deployment in the Status UI and other locations.
 
-## `targets.`
+### `targets.`
 
 This config block is where you define where and how you want to deploy an app. You can specify multiple targets. Provide unique descriptive names for each environment to which you are deploying.
 
@@ -111,7 +112,7 @@ targets:
 
 
 
-### `targets.<targetName>`
+#### `targets.<targetName>`
 
 A descriptive name for this deployment, such as the name of the environment you want to deploy to.
 
@@ -123,7 +124,7 @@ targets:
 ...
 ```
 
-### `targets.<targetName>.account`
+#### `targets.<targetName>.account`
 
 The account name that a target Kubernetes cluster got assigned when you installed the Remote Network Agent (RNA) on it. Specifically, it is the value for the `agentIdentifier` parameter. Note that older versions of the RNA used the `agent-k8s.accountName` parameter.
 
@@ -138,7 +139,7 @@ targets:
 ...
 ```
 
-### `targets.<targetName>.namespace`
+#### `targets.<targetName>.namespace`
 
 (Recommended) The namespace on the target Kubernetes cluster that you want to deploy to. This field overrides any namespaces defined in your manifests.
 
@@ -151,7 +152,7 @@ targets:
     namespace: overflow
 ```
 
-### `targets.<targetName>.strategy`
+#### `targets.<targetName>.strategy`
 
 This is the name of the strategy that you want to use to deploy your app. You define the strategy and its behavior in the `strategies` block.
 
@@ -167,7 +168,7 @@ targets:
 
 Read more about how this config is defined and used in the [strategies.<strategyName>](#strategies.<strategyName>) section.
 
-### `targets.<targetName>.constraints`
+#### `targets.<targetName>.constraints`
 
 A map of conditions that must be met before a deployment starts. The constraints can be dependencies on previous deployments, such as requiring deployments to a test environment before staging, or a pause. If you omit the constraints section, the deployment starts immediately when it gets triggered.
 
@@ -189,7 +190,7 @@ targets:
             unit: <seconds|minutes|hours>
 ```
 
-#### `targets.<targetName>.constraints.dependsOn`
+##### `targets.<targetName>.constraints.dependsOn`
 
 A comma-separated list of deployments that must finish before this deployment can start. You can use this option to sequence deployments. Deployments with the same `dependsOn` criteria execute in parallel. For example, you can make it so that a deployment to prod cannot happen until a staging deployment finishes successfully.
 
@@ -205,7 +206,7 @@ targets:
       dependsOn: ["dev-west"]
 ```
 
-#### `targets.<targetName>.constraints.beforeDeployment`
+##### `targets.<targetName>.constraints.beforeDeployment`
 
 Conditions that must be met before the deployment can start. These are in addition to the deployments you define in `dependsOn` that must finish.
 
@@ -249,7 +250,7 @@ targets:
             unit: seconds
 ```
 
-## `manifests.`
+### `manifests.`
 
 ```yaml
 manifests:
@@ -261,15 +262,15 @@ manifests:
     targets: ["<targetName3>", "<targetName4>"]
 ```  
 
-### `manifests.path`
+#### `manifests.path`
 
 The path to a manifest file that you want to deploy or the directory where your manifests are stored. If you specify a directory, such as `/deployments/manifests/configmaps`, Borealis reads all the YAML files in the directory and deploys the manifests to the target you specified in `targets`.
 
-### `manifests.path.targets`
+#### `manifests.path.targets`
 
 (Optional). If you omit this option, the manifests are deployed to all targets listed in the deployment file. A comma-separated list of deployment targets that you want to deploy the manifests to. Make sure to enclose each target in quotes. Use the name you defined in `targets.<targetName>` to refer to a deployment target.
 
-## `strategies.`
+### `strategies.`
 
 This config block is where you define behavior and the actual steps to a deployment strategy.
 
@@ -314,7 +315,7 @@ strategies:
             untilApproved: true
 ```
 
-### `strategies.<strategyName>`
+#### `strategies.<strategyName>`
 
 The name you assign to the strategy. Use this name for `targets.<targetName>.strategy`. You can define multiple strategies, so make sure to use a unique descriptive name for each.
 
@@ -336,7 +337,7 @@ targets:
 ...
 ```
 
-### `strategies.<strategyName>.<strategy>`
+#### `strategies.<strategyName>.<strategy>`
 
 The kind of deployment strategy this strategy uses. Borealis supports `canary` and `blueGreen`.
 
@@ -346,9 +347,9 @@ strategies:
     canary:
 ```
 
-### Canary fields
+#### Canary fields
 
-#### `strategies.<strategyName>.canary.steps`
+##### `strategies.<strategyName>.canary.steps`
 
 Borealis progresses through all the steps you define as part of the deployment process. The process is sequential and steps can be of the types, `analysis`, `setWeight` or `pause`.
 
@@ -361,7 +362,7 @@ Some scenarios where this pairing sequence might not be used would be the follow
 
 You can add as many steps as you need but do not need to add a final step that deploys the app to 100% of the cluster. Borealis automatically does that after completing the final step you define.
 
-#### `strategies.<strategyName>.canary.steps.setWeight.weight`
+##### `strategies.<strategyName>.canary.steps.setWeight.weight`
 
 This is an integer value and determines how much of the cluster the app gets deployed to. The value must be between 0 and 100 and the the `weight` for each `setWeight` step should increase as the deployment progresses. After hitting this threshold, Borealis pauses the deployment based on the behavior you set for  the `strategies.<strategyName>.<strategy>.steps.pause` that follows.
 
@@ -375,7 +376,7 @@ steps:
       weight: 33
 ```
 
-#### `strategies.<strategyName>.canary.steps.pause`
+##### `strategies.<strategyName>.canary.steps.pause`
 
 There are two base behaviors you can set for `pause`, either a set amount of time or until a manual judgment is made.
 
@@ -424,7 +425,7 @@ steps:
       untilApproved: true
 ```
 
-#### `strategies.<strategyName>.canary.steps.analysis`
+##### `strategies.<strategyName>.canary.steps.analysis`
 
 The `analysis` step is used to run a set of queries against your deployment. Based on the results of the queries, the deployment can (automatically or manually) roll forward or roll back.
 
@@ -446,11 +447,11 @@ steps:
               - <queryName>
 ```
 
-##### `strategies.<strategyName>.canary.steps.analysis.metricProviderName`
+###### `strategies.<strategyName>.canary.steps.analysis.metricProviderName`
 
 Optional. The name of a configured metric provider. If you do not provide a metric provider name, Borealis uses the default metric provider defined in the `analysis.defaultMetricProviderName`. Use the **Configuration UI** to add a metric provider.
 
-##### `strategies.<strategyName>.canary.steps.analysis.context`
+###### `strategies.<strategyName>.canary.steps.analysis.context`
 
 Custom key/value pairs that are passed as substitutions for variables to the queries.
 
@@ -474,7 +475,7 @@ You can supply your own variables by adding them to this section. When you use t
 
 For information about writing queries, see the [Query Reference Guide]({{< ref "ref-queries.md" >}}).
 
-##### `strategies.<strategyName>.canary.steps.analysis.interval`
+###### `strategies.<strategyName>.canary.steps.analysis.interval`
 
 ```yaml
 steps:
@@ -497,11 +498,11 @@ steps:
 
 ```
 
-##### `strategies.<strategyName>.canary.steps.analysis.unit`
+###### `strategies.<strategyName>.canary.steps.analysis.unit`
 
 The unit of time for the interval. Use `seconds`, `minutes` or `hours`. See `strategies.<strategyName>.<strategy>.steps.analysis.interval` for more information.
 
-##### `strategies.<strategyName>.canary.steps.analysis.numberOfJudgmentRuns`
+###### `strategies.<strategyName>.canary.steps.analysis.numberOfJudgmentRuns`
 
 ```yaml
 steps:
@@ -514,7 +515,7 @@ steps:
 
 The number of times that each query runs as part of the analysis. Borealis takes the average of all the results of the judgment runs to determine whether the deployment falls within the acceptable range.
 
-##### `strategies.<strategyName>.canary.steps.analysis.rollBackMode`
+###### `strategies.<strategyName>.canary.steps.analysis.rollBackMode`
 
 ```yaml
 steps:
@@ -529,7 +530,7 @@ Optional. Can either be `manual` or `automatic`. Defaults to `automatic` if omit
 
 How a rollback is approved if the analysis step determines that the deployment should be rolled back. The thresholds for a rollback are set in `lowerLimit` and `upperLimit` in the `analysis` block of the deployment file. This block is separate from the `analysis` step that this parameter is part of.
 
-##### `strategies.<strategyName>.canary.steps.analysis.rollForwardMode`
+###### `strategies.<strategyName>.canary.steps.analysis.rollForwardMode`
 
 ```yaml
 steps:
@@ -544,7 +545,7 @@ Optional. Can either be `manual` or `automatic`. Defaults to `automatic` if omit
 
 How a rollback is approved if the analysis step determines that the deployment should proceed (or roll forward). The thresholds for a roll forward are any values that fall within the range you create when you set the `lowerLimit` and `upperLimit`values in the `analysis` block of the deployment file. This block is separate from the `analysis` step that this parameter is part of.
 
-##### `strategies.<strategyName>.canary.steps.analysis.queries`
+###### `strategies.<strategyName>.canary.steps.analysis.queries`
 
 ```yaml
 steps:
@@ -560,9 +561,9 @@ A list of queries that you want to use as part of this `analysis` step. Provide 
 
 All the queries must pass for the step as a whole to be considered a success.
 
-### Blue/green fields
+#### Blue/green fields
 
-#### `strategies.<strategyName>.blueGreen.activeService`
+##### `strategies.<strategyName>.blueGreen.activeService`
 
 The name of a [Kubernetes Service object](https://kubernetes.io/docs/concepts/services-networking/service/) that you created to route traffic to your application.
 
@@ -573,7 +574,7 @@ strategies:
       activeService: <active-service>
 ```
 
-#### `strategies.<strategyName>.blueGreen.previewService`
+##### `strategies.<strategyName>.blueGreen.previewService`
 
 (Optional) The name of a [Kubernetes Service object](https://kubernetes.io/docs/concepts/services-networking/service/) you created to route traffic to the new version of your application so you can preview your updates.
 
@@ -584,11 +585,11 @@ strategies:
       previewService: <preview-service>
 ```
 
-#### `strategies.<strategyName>.blueGreen.redirectTrafficAfter`
+##### `strategies.<strategyName>.blueGreen.redirectTrafficAfter`
 
 The `redirectTrafficAfter` steps are conditions for exposing the new version to the `activeService`. The steps are executed in parallel.After each step completes, Borealis exposes the new version to the `activeService`.
 
-##### `strategies.<strategyName>.blueGreen.redirectTrafficAfter.pause`
+###### `strategies.<strategyName>.blueGreen.redirectTrafficAfter.pause`
 
 There are two base behaviors you can set for `pause`, either a set amount of time or until a manual judgment is made.
 
@@ -637,7 +638,7 @@ redirectTrafficAfter:
       untilApproved: true
 ```
 
-##### `strategies.<strategyName>.blueGreen.redirectTrafficAfter.analysis`
+###### `strategies.<strategyName>.blueGreen.redirectTrafficAfter.analysis`
 
 The `analysis` step is used to run a set of queries against your deployment. Based on the results of the queries, the deployment can (automatically or manually) roll forward or roll back.
 
@@ -658,7 +659,7 @@ redirectTrafficAfter:
         - <queryName>
 ```
 
-#### `strategies.<strategyName>.blueGreen.shutdownOldVersionAfter`
+##### `strategies.<strategyName>.blueGreen.shutdownOldVersionAfter`
 
 This step is a condition for deleting the old version of your software. Borealis executes the `shutDownOldVersion` steps in parallel. After each step completes, Borealis deletes the old version.
 
@@ -668,7 +669,7 @@ shutdownOldVersionAfter:
       untilApproved: true
 ```
 
-##### `strategies.<strategyName>.blueGreen.shutdownOldVersionAfter.analysis`
+###### `strategies.<strategyName>.blueGreen.shutdownOldVersionAfter.analysis`
 
 The `analysis` step is used to run a set of queries against your deployment. Based on the results of the queries, the deployment can (automatically or manually) roll forward or roll back.
 
@@ -689,7 +690,7 @@ shutdownOldVersionAfter:
         - <queryName>
 ```
 
-## `analysis`
+### `analysis.`
 
 This block defines the queries used to analyze a deployment for any `analysis` steps. In addition, you set upper and lower limits for the queries that define what is considered a failed deployment step or a successful deployment step.
 
@@ -726,33 +727,33 @@ You can insert variables into your queries. Variables are inserted using the for
 
 For more information, see the [`analysis.context` section](#strategiesstrategynamestrategystepsanalysiscontext).
 
-### `analysis.defaultMetricProviderName`
+#### `analysis.defaultMetricProviderName`
 
 The name that you assigned to a metrics provider in the **Configuration UI**. If the analysis step does not specify a metrics provider, the default metrics provider is used.
 
-### `analysis.queries`
+#### `analysis.queries`
 
 This block is how you define the queries that you want to run.
 
-#### `analysis.queries.name`
+##### `analysis.queries.name`
 
 Used in `analysis` steps to specify the query that you want to use for the step. Specifically it's used for the list in `steps.analysis.queries`.
 
 Provide a unique and descriptive name for the query, such as `containerCPUSeconds` or `avgMemoryUsage`.
 
-#### `analysis.queries.upperLimit`
+##### `analysis.queries.upperLimit`
 
 The upper limit for the query. If the analysis returns a value that is above this range, the deployment is considered a failure, and a rollback is triggered. The rollback can happen either manually or automatically depending on how you configured `strategies.<strategyName>.<strategy>.steps.analysis.rollBackMode`.
 
 If the query returns a value that falls within the range between the `upperLimit` and `lowerLimit` after all the runs of the query complete, the query is considered a success.
 
-#### `analysis.queries.lowerLimit`
+##### `analysis.queries.lowerLimit`
 
 The lower limit for the query. If the analysis returns a value that is below this range, the deployment is considered a failure, and a rollback is triggered. The rollback can happen either manually or automatically depending on how you configured `strategies.<strategyName>.<strategy>.steps.analysis.rollBackMode`.
 
 If the query returns a value that falls within the range between the `upperLimit` and `lowerLimit` after all the runs of the query, the query is considered a success.
 
-#### `analysis.queries.queryTemplate`
+##### `analysis.queries.queryTemplate`
 
 ```yaml
 analysis: # Define queries and thresholds used for automated analysis

--- a/content/en/borealis/quick-start/borealis-cli-get-started.md
+++ b/content/en/borealis/quick-start/borealis-cli-get-started.md
@@ -110,7 +110,7 @@ If you choose to install the CLI binary manually, you must download a specific r
 
    The command returns basic information about the  Borealis CLI, including available commands.
 
-For the AVM or the CLI, you can use the `--help` option for more information about specific commands.
+For the AVM or the CLI, you can use the `-h` flag for more information about specific commands.
 
 {{% /tabbody %}}
 

--- a/content/en/borealis/quick-start/borealis-cli-get-started.md
+++ b/content/en/borealis/quick-start/borealis-cli-get-started.md
@@ -19,7 +19,12 @@ Note that you need a device that can support OTP two-factor authentication, such
 
 ## Install the Borealis CLI
 
-The automated install involves installing an Armory Version Manager (AVM) that handles downloading, installing, and updating the Borealis CLI. Using this install method gives you  to way to keep the Borealis CLI updated as well as the ability to switch versions from the command line. The manual installation method involves downloading a specific release from GitHub and installing that release. Armory recommends using the automated install method.
+The CLI binary is called `armory`. You can install the CLI using the Armory Version Manager (AVM) or you can install the `armory` binary manually.
+
+Armory recommends installing the AVM because you can use it to quickly and easily download, install, and update the CLI. The AVM provides additional features such as the ability to list installed CLI versions and to declare which version of the CLI to use.
+
+If you choose to install the CLI binary manually, you must download a specific release binary from GitHub and install that release. You have to repeat the installation process each time you upgrade the CLI version.
+
 
 {{< tabs name="borealis-cli-install" >}}
 
@@ -88,7 +93,7 @@ The automated install involves installing an Armory Version Manager (AVM) that h
       ```
 
     1. In the file, find the line for the `PATH` that your resource file exports. They follow the format `export PATH=$HOME/bin:/usr/local/bin:$PATH`.
-    2. Insert the path provided by AVM (such as `/Users/brianle/.avm/bin`)before the ending `$PATH`. The line should look similar to this:
+    2. Insert the path provided by AVM (such as `/Users/brianle/.avm/bin`) before the ending `$PATH`. The line should look similar to this:
 
        ```bash
        export PATH=$HOME/bin:/usr/local/bin::/Users/milton/.avm/bin:$PATH
@@ -133,6 +138,9 @@ For AVM or the Borealis CLI, you can use the `--help` option for more informatio
 {{% /tabbody %}}
 
 {{< /tabs >}}
+
+
+
 
 ## Manually deploy apps using the CLI
 

--- a/content/en/borealis/quick-start/borealis-cli-get-started.md
+++ b/content/en/borealis/quick-start/borealis-cli-get-started.md
@@ -29,7 +29,7 @@ If you choose to install the CLI binary manually, you must download a specific r
 
 {{% tabbody name="Automated (Recommended)" %}}
 
-1. Download the AVM for your operating system and CPU architecture. You can manually download it from the [repo]((https://github.com/armory/avm/releases/) or use the following command:
+1. Download the AVM for your operating system and CPU architecture. You can manually download it from the [repo](https://github.com/armory/avm/releases/) or use the following command:
 
    ```bash
    wget https://github.com/armory/avm/releases/latest/download/avm-<os>-<architecture>

--- a/content/en/borealis/quick-start/borealis-cli-get-started.md
+++ b/content/en/borealis/quick-start/borealis-cli-get-started.md
@@ -55,10 +55,9 @@ If you choose to install the CLI binary manually, you must download a specific r
    ```
    The command returns your `PATH`, which should now include `/usr/local/bin/`.
 
-5. Move AVM to `/usr/local/bin`, which is on your `PATH`. For example (on macOS):
+5. Rename the AVM binary to `avm` and move it to `/usr/local/bin`, which is on your `PATH`. For example (on macOS):
 
    ```bash
-   # Moves AVM to /usr/local/bin, which is on your PATH
    mv avm-darwin-amd64 /usr/local/bin/avm
    ```
 

--- a/content/en/borealis/quick-start/borealis-cli-get-started.md
+++ b/content/en/borealis/quick-start/borealis-cli-get-started.md
@@ -2,7 +2,7 @@
 title: Get Started with the CLI to Deploy Apps
 linktitle: CLI
 description: >
-  The Borealis CLI is a CLI for interacting with Project Borealis. With the CLI, you can integrate Borealis into your existing CI/CD tooling. Start by familiarizing yourself with the Borealis CLI and its workflow.
+  Use the Borealis CLI to interact with Project Borealis. You can integrate Borealis into your existing CI/CD tooling. Start by familiarizing yourself with the Borealis CLI and its workflow.
 exclude_search: true
 weight: 5
 ---
@@ -24,7 +24,6 @@ The CLI binary is called `armory`. You can install the CLI using the Armory Vers
 Armory recommends installing the AVM because you can use it to quickly and easily download, install, and update the CLI. The AVM provides additional features such as the ability to list installed CLI versions and to declare which version of the CLI to use.
 
 If you choose to install the CLI binary manually, you must download a specific release binary from GitHub and install that release. You have to repeat the installation process each time you upgrade the CLI version.
-
 
 {{< tabs name="borealis-cli-install" >}}
 
@@ -112,7 +111,7 @@ If you choose to install the CLI binary manually, you must download a specific r
 
    The command returns basic information about the  Borealis CLI, including available commands.
 
-For AVM or the Borealis CLI, you can use the `--help` option for more information about specific commands.
+For the AVM or the CLI, you can use the `--help` option for more information about specific commands.
 
 {{% /tabbody %}}
 
@@ -140,17 +139,18 @@ For AVM or the Borealis CLI, you can use the `--help` option for more informatio
 {{< /tabs >}}
 
 
+See the {{< linkWithTitle "avm-cheat.md" >}} and {{< linkWithTitle "cli-cheat.md" >}} pages for more information on AVM and CLI commands.
 
 
 ## Manually deploy apps using the CLI
 
 >Project Borealis manages your Kubernetes deployments using ReplicaSet resources. During the initial deployment of your application using Project Borealis, the underlying Kubernetes deployment object is deleted in a way that it leaves behind the ReplicaSet and pods so that there is no actual downtime for your application. These are later deleted when the deployment succeeds.
 
-Before you can deploy, make sure that you have the client ID and secret for your deployment target available. These are used to authenticate Armory's hosted deployment services with the target cluster. The credentials were created and tied to your deployment target as part of the [Get Started with Project Borealis]({{< ref "borealis-org-get-started" >}}) guide.
+Before you can deploy, make sure that you have the Client ID and Client Secret for your deployment target available. These are used to authenticate Armory's hosted deployment services with the target cluster. The credentials were created and tied to your deployment target as part of the [Get Started with Project Borealis]({{< ref "borealis-org-get-started" >}}) guide.
 
-Since you are using the Borealis CLI, you do not need to have service account credentials for authenticating your CLI to the deployment services. Instead, you will log in manually with your user account.
+Since you are using the Borealis CLI, you do not need to have service account credentials for authenticating your CLI to the deployment services. Instead, you log in manually with your user account.
 
-If this is the first deployment of your app, Borealis automatically deploys the app to 100% of the cluster since there is no previous version. Subsequent deployments of this app follow the steps defined in your deployment file.
+**If this is the first deployment of your app, Borealis automatically deploys the app to 100% of the cluster since there is no previous version.** Subsequent deployments of this app follow the steps defined in your deployment file.
 
 1. Log in to Armory's hosted deployment services from the CLI:
 


### PR DESCRIPTION
Resolves Jira: [DOC-570]

Add that the CLI is `armory`.  https://deploy-preview-1359--armory-docs.netlify.app/borealis/quick-start/borealis-cli-get-started/#install-the-borealis-cli
Install the Borealis CLI, Step 4: Clarify that the AVM gets renamed as part of moving it to usr/local/bin. 
Created cheat sheets loosely modeled after the kubectl cheatsheet that's been open in my browser for the past week. 

AVM cheatsheet: https://deploy-preview-1359--armory-docs.netlify.app/borealis/reference/avm-cheat/
CLI cheatsheet: https://deploy-preview-1359--armory-docs.netlify.app/borealis/reference/cli-cheat/

[DOC-570]: https://armory.atlassian.net/browse/DOC-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ