### PR TITLE
docs(infra): add error handling to linkWithTitle shortcode

### DIFF
--- a/content/en/armory-cdaas/setup/cli.md
+++ b/content/en/armory-cdaas/setup/cli.md
@@ -282,7 +282,7 @@ Make sure you are running the lastest version of the CLI.
 
 ## {{% heading "nextSteps" %}}
 
-* {{< linkWithTitle "get-started-gh-action.md" >}}
+* {{< linkWithTitle "gh-action.md" >}}
 * {{< linkWithTitle "deploy-demo-app.md" >}}
 
 

--- a/content/en/armory-cdaas/setup/get-started.md
+++ b/content/en/armory-cdaas/setup/get-started.md
@@ -77,5 +77,5 @@ Now that Borealis is configured for your deployment target, you can either try o
 
 ### Deploy an app
 
-Use the {{< linkWithTitle "get-started-cli.md" >}} guide to learn how to manually deploy an app using the Borealis CLI.
+Use the {{< linkWithTitle "armory-cdaas/setup/cli.md" >}} guide to learn how to manually deploy an app using the Borealis CLI.
 

--- a/content/en/armory-cdaas/tasks/borealis-automate/_index.md
+++ b/content/en/armory-cdaas/tasks/borealis-automate/_index.md
@@ -15,7 +15,7 @@ Project Borealis and the CLI can be integrated with any of your tools and script
 
 ## {{% heading "prereq" %}}
 
-Before you get started, ensure that the requirements listed on [Requirements]({{< ref "cdaas-requirements" >}}) are met and that you can log in to the [Armory Cloud Console](https://console.cloud.armory.io/).
+Before you get started, ensure that the requirements listed on [Requirements]({{< ref "requirements" >}}) are met and that you can log in to the [Armory Cloud Console](https://console.cloud.armory.io/).
 
 ## Create service account credentials
 
@@ -29,7 +29,7 @@ Armory recommends that you store these credentials in a secret engine that is su
 
 ## GitHub Actions
 
-You can use Armory's Project Borealis Deployment Action to integrate Project Borealis with your GitHub repo. For more information, see the [Project Borealis Deployment Action repo](https://github.com/armory/cli-deploy-action) or the {{< linkWithTitle "get-started-gh-action.md" >}} page.
+You can use Armory's Project Borealis Deployment Action to integrate Project Borealis with your GitHub repo. For more information, see the [Project Borealis Deployment Action repo](https://github.com/armory/cli-deploy-action) or the {{< linkWithTitle "gh-action.md" >}} page.
 
 ## Jenkins
 

--- a/content/en/armory-cdaas/tutorials/external-automation/webhook-jenkins.md
+++ b/content/en/armory-cdaas/tutorials/external-automation/webhook-jenkins.md
@@ -13,7 +13,7 @@ description: >
 
 ## {{% heading "prereq" %}}
 
-- You have read the webhook approval [introductory page]({{< ref "cdaas-webhooks" >}}).
+- You have read the webhook approval [introductory page]({{< ref "webhook-approval" >}}).
 
 
 

--- a/content/en/armory-enterprise/armory-admin/cf/add-cf-account.md
+++ b/content/en/armory-enterprise/armory-admin/cf/add-cf-account.md
@@ -8,7 +8,7 @@ description: Add a Cloud Foundry account as a cloud provider deployment target i
 
 This document assumes the following:
 
-* You are familiar with how Spinnaker uses Cloud Foundry as a deployment target. See the {{< linkWithTitle "cloud-foundry-concepts.md" >}} guide for details.
+* You are familiar with how Spinnaker uses Cloud Foundry as a deployment target. See the {{< linkWithTitle "cloud-foundry-concept.md" >}} guide for details.
 * You have access to a running Spinnaker instance.
 * You use the Armory Operator or the Spinnaker Operator for Kubernetes to configure your Spinnaker instance.
 * You have a valid Cloud Foundry account with at least `Space Developer` access to one or more spaces.

--- a/content/en/armory-enterprise/armory-agent/agent-vault.md
+++ b/content/en/armory-enterprise/armory-agent/agent-vault.md
@@ -51,7 +51,7 @@ vault kv put secret/kubernetes account01=@kubeconfig.yaml
 
 ### Configuration template
 
-Replace the configuration files and `kubeconfig` files from the {{< linkWithTitle "armory-agent-quick.md" >}} guide and instead use [Vault injector annotations](https://www.vaultproject.io/docs/platform/k8s/injector/annotations) to provide a template.
+Replace the configuration files and `kubeconfig` files with [Vault injector annotations](https://www.vaultproject.io/docs/platform/k8s/injector/annotations) to provide a template.
 
 {{< prism lang="yaml" line="13-23" >}}
 apiVersion: apps/v1

--- a/content/en/armory-enterprise/installation/guide/install-redhat-marketplace.md
+++ b/content/en/armory-enterprise/installation/guide/install-redhat-marketplace.md
@@ -11,7 +11,7 @@ draft: true
 
 ## Overview of the Armory Operator Red Hat Marketplace offering
 
-The {{< linkWithTitle "operator.md" >}} is a Kubernetes Operator that makes it easier to install, deploy, and upgrade Armory. You can get the Armory Operator from the [Red Hat Marketplace](https://marketplace.redhat.com/), which is available directly from your OpenShift web console. See the Red Hat Marketplace [docs](https://marketplace.redhat.com/en-us/documentation/) for how to use marketplace.
+The {{< linkWithTitle "armory-enterprise/installation/armory-operator/_index.md" >}} is a Kubernetes Operator that makes it easier to install, deploy, and upgrade Armory. You can get the Armory Operator from the [Red Hat Marketplace](https://marketplace.redhat.com/), which is available directly from your OpenShift web console. See the Red Hat Marketplace [docs](https://marketplace.redhat.com/en-us/documentation/) for how to use marketplace.
 
 Installing Armory consists of the following:
 

--- a/content/en/armory-enterprise/zz-contribute/markdown-elements.md
+++ b/content/en/armory-enterprise/zz-contribute/markdown-elements.md
@@ -228,10 +228,3 @@ _The photo above of the Spruce Picea abies shoot with foliage buds: Bjørn Erik 
 ## Another Heading
 
 
-
-
-
-<<<<<<< HEAD:content/en/docs/smoke-test/index.md
-See the {{< linkWithTitle pacrd-crd-docs.md >}} for an example.
-=======
->>>>>>> origin:content/en/docs/zz-contribute/smoke-test.md

--- a/content/en/armory-enterprise/zz-contribute/shortcodes/_index.md
+++ b/content/en/armory-enterprise/zz-contribute/shortcodes/_index.md
@@ -22,7 +22,8 @@ alert, swaggerui, imgproc
 
 location:  `docs/layouts/shortcodes`
 
-## Heading
+
+### Heading
 This shortcode works in conjunction with the `i118n/en.toml` file, which contains key/value pairs for common headings.
 
 Usage:
@@ -68,6 +69,15 @@ Renders as:
 See the {{< linkWithTitle best-practices.md >}} page...
 
 See this page: {{< linkWithTitle agent-troubleshooting.md >}}.
+
+This shortcode throws an error if the file is not found.
+
+
+```markdown
+See the {{</* linkWithTitle bubba.md */>}} page...
+```
+
+See the {{< linkWithTitle bubba.md >}} page...
 
 ### Google suite shortcode
 

--- a/content/en/armory-enterprise/zz-contribute/tabs/index.md
+++ b/content/en/armory-enterprise/zz-contribute/tabs/index.md
@@ -127,7 +127,6 @@ Usage:
   </p>
 {{< /rawhtml >}}  
 
-See the {{< linkWithTitle pacrd-crd-docs.md >}} for an example.
 
 ## Includes with tabs
 

--- a/layouts/shortcodes/linkWithTitle.html
+++ b/layouts/shortcodes/linkWithTitle.html
@@ -1,3 +1,8 @@
-{{- $fileName := .Get 0 -}}
-{{ with .Site.GetPage $fileName }}
-<a href="{{.Permalink}}"}>{{.Title}}</a>{{ end }}
+{{ $fileName := .Get 0 }}
+{{ $myPage := .Site.GetPage $fileName }}
+{{ if $myPage }}
+  {{ with $myPage }}
+    <a href="{{.Permalink}}"}>{{.Title}}</a>{{ end }}
+{{ else }}
+{{ errorf "linkWithTitle file not found: %s" $fileName }}
+{{ end }}


### PR DESCRIPTION
Throw error if file can't be found. This is vital to identify issues when renaming files.

Resolves Jira: [DOC-585]




[DOC-585]: https://armory.atlassian.net/browse/DOC-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ