### PR TITLE
docs(cdaas): update setup for new install scripts and UI

### DIFF
--- a/content/en/cd-as-a-service/_index.md
+++ b/content/en/cd-as-a-service/_index.md
@@ -20,7 +20,7 @@ For a full list of features and pricing, see the [Armory Continuous Deployment-a
 
 ## Start using Armory CD-as-a-Service
 
-The **Get Started** section contains guides that walk you through the core functionality. The {{< linkWithTitle "cd-as-a-service/setup/get-started.md" >}} guide shows you how to complete registration, create machine credentials, and install the Remote Network Agent in your Kubernetes cluster. You can complete the process in under 10 minutes.
+The **Get Started** section contains guides that walk you through the core functionality. The {{< linkWithTitle "cd-as-a-service/setup/get-started.md" >}} guide shows you how to sign up for an account and then connect to your Kubernetes cluster. You can complete the process in under 5 minutes.
 
 Read the {{< linkWithTitle "cd-as-a-service/setup/cli.md" >}} guide to learn how to install the CLI, create a deployment file, and deploy your app.
 

--- a/content/en/cd-as-a-service/plugin-spinnaker.md
+++ b/content/en/cd-as-a-service/plugin-spinnaker.md
@@ -58,24 +58,20 @@ The Helm chart described in [Enable the Armory CD-as-a-Service Remote Network Ag
 
 Register your Armory Enterprise environment so that it can communicate with Armory services. Each environment needs to get registered if you, for example, have production and development environments.
 
-1. Get your registration link from Armory.
-2. Register your Armory Enterprise [environment]({{< ref "ae-instance-reg" >}}).
+1. [Register](https://go.armory.io/signup/) to use Armory CD-as-a-Service.
+1. Register your Armory Enterprise [environment]({{< ref "ae-instance-reg" >}}).
 
 ## Create client credentials for your Agents
 
-1. Log in to the CD-as-a-Service Console: https://console.cloud.armory.io/.
-2. If you have more than one environment, ensure the proper environment is selected in the user context menu:
-
-   {{< figure src="/images/deploy-engine/cloud-env-context.png" alt="The upper right section of the window shows what environment you are currently in." >}}
-
-3. In the left navigation menu, select **Access Management > Client Credentials**.
-4. In the upper right corner, select **New Credential**.
-5. Create a credential for your RNA. Use a descriptive name for the credential, such as `us-west RNA`
-6. Set the permission scope to `connect:agentHub`.
+1. Log in to the [CD-as-a-Service Console](https://console.cloud.armory.io/).
+1. In the left navigation menu, select **Access Management > Client Credentials**.
+1. In the upper right corner, select **New Credential**.
+1. Create a credential for your RNA. Use a descriptive name for the credential, such as `us-west RNA`
+1. Set the permission scope to `connect:agentHub`.
 
    > Removing a preconfigured scope group does not deselect the permissions that the group assigned. You must remove the permissions manually.
 
-7. Note both the **Client ID** and **Client Secret**. You need these values when configuring the Remote Network Agent or other services that you want to use to interact with Armory CD-as-a-Service. Make sure to store the secret somewhere safe. You are not shown the value again.
+1. Note both the **Client ID** and **Client Secret**. You need these values when configuring the Remote Network Agent or other services that you want to use to interact with Armory CD-as-a-Service. Make sure to store the secret somewhere safe. You are not shown the value again.
 
 ## Enable the Armory CD-as-a-Service Remote Network Agent in target Kubernetes clusters
 

--- a/content/en/cd-as-a-service/setup/cli.md
+++ b/content/en/cd-as-a-service/setup/cli.md
@@ -19,15 +19,32 @@ They do not run on Windows.
 
 ## Install the Armory CD-as-a-Service CLI
 
-The CLI binary is called `armory`. You can install the CLI using the Armory Version Manager (AVM) or you can install the `armory` binary manually.
+You can install the Armory Version Manager (AVM) and CLI using a one-line command or you can download the AVM manually.
 
-Armory recommends installing the AVM because you can use it to quickly and easily download, install, and update the CLI. The AVM provides additional features such as the ability to list installed CLI versions and to declare which version of the CLI to use.
-
-If you choose to install the CLI binary manually, you must download a specific release binary from GitHub and install that release. You have to repeat the installation process each time you upgrade the CLI version. The Armory CLI is only currently supported on Linux and MacOSX.
+The AVM enables you to quickly and easily download, install, and update the CLI. The AVM includes additional features such as the ability to list installed CLI versions and to declare which version of the CLI to use.
 
 {{< tabs name="cdaas-cli-install" >}}
 
-{{% tabbody name="Automated (Recommended)" %}}
+{{% tabbody name="Automated" %}}
+
+You can install the CLI with a one-line script that does the following:
+
+1. Fetches the correct Armory Version Manager binary (`avm`) for your Linux or Mac OSX operating system
+1. Installs the AVM binary
+1. Uses the AVM to install the CLI binary (`armory`)
+1. Adds the AVM and the CLI to the path in your bash or zsh profile
+
+Execute the following script on the machine that has access to your Kubernetes cluster:
+
+```bash
+curl -sL go.armory.io/get-cli | bash
+```
+
+After installation completes, you should start a new terminal session or source your profile.
+
+{{% /tabbody %}}
+
+{{% tabbody name="Manual" %}}
 
 1. Download the AVM for your operating system and CPU architecture. You can manually download it from the [repo](https://github.com/armory/avm/releases/) or use the following command:
 
@@ -114,27 +131,6 @@ For the AVM or the CLI, you can use the `-h` flag for more information about spe
 
 {{% /tabbody %}}
 
-{{% tabbody name="Manual" %}}
-
-1. Download the [latest release](https://github.com/armory/armory-cli/releases) for your operating system.
-1. Save the file in a directory that is on your `PATH`, such as `/usr/local/bin`.
-1. Rename the downloaded file to `armory`.
-1. Give the file execute permission:
-
-   ```bash
-   chmod +x /usr/local/bin/armory
-   ```
-
-1. Verify that you can run the CLI:
-
-   ```bash
-   armory
-   ```
-
-   The command returns basic information about the CLI, including available commands.
-
-{{% /tabbody %}}
-
 {{< /tabs >}}
 
 
@@ -159,9 +155,9 @@ Since you are using the CLI, you do not need to have service account credentials
 
    The CLI returns a `Device Code` and opens your default browser. To complete the log in process, confirm the code in your browser.
 
-   After you successfully authenticate, the CLI returns a list of environments if you have access to more than one, which is rare.
+   After you successfully authenticate, the CLI returns a list of tenants if you have access to more than one, which is rare.
 
-1. Select the environment you want to log in to.   
+1. Select the tenant you want to log in to.   
 1. Generate your deployment template and output it to a file.
 
    This command generates a deployment template for canary deployments and saves it to a file named `canary.yaml`:
@@ -174,7 +170,7 @@ Since you are using the CLI, you do not need to have service account credentials
 
    - `application`: The name of your app.
    - `targets.<deploymentName>`: A descriptive name for your deployment. Armory recommends using the environment name.
-   - `targets.<deploymentName>.account`: This is the value that you assigned to the `agentIdentifier` parameter when you [installed the RNA]({{< ref "cd-as-a-service/setup/get-started#install-the-remote-network-agent" >}}).
+   - `targets.<deploymentName>.account`: This is the name of your RNA. If you installed the RNA manually, it is the value that you assigned to the `agentIdentifier` parameter.
    - `targets.<deploymentName>.strategy`: the name of the deployment strategy you want to use. You define the strategy in `strategies.<strategy-name>`.
    - `manifests`: a map of manifest locations. This can be a directory of `yaml (yml)` files or a specific manifest. Each entry must use the following convention:  `- path: /path/to/directory-or-file`
    - `strategies.<strategy-name>`: the list of your deployment strategies. Use one of these for `targets.<target-cluster>.strategy`. Each strategy in this section consists of a map of steps for your deployment strategy in the following format:
@@ -283,4 +279,4 @@ Make sure you are running the lastest version of the CLI.
 * {{< linkWithTitle "deploy-demo-app.md" >}}
 
 
-<br>
+

--- a/content/en/cd-as-a-service/setup/get-started.md
+++ b/content/en/cd-as-a-service/setup/get-started.md
@@ -18,8 +18,8 @@ The following steps should take less than 10 minutes to complete:
 ## {{% heading "prereq" %}}
 
 * You have reviewed the system requirements for using Armory CD-as-a-Service on the [Requirements]({{< ref "requirements.md" >}}) page.
-* You have access to a Kubernetes cluster and have installed [kubectl]().
-* You have installed [Helm](), which is used to install the Remote Network Agent.
+* You have access to a Kubernetes cluster and have installed [kubectl](https://kubernetes.io/docs/tasks/tools/).
+* You have installed [Helm](https://helm.sh/), which is used to install the Remote Network Agent.
 
 
 ## Register for Armory CD-as-a-Service

--- a/content/en/cd-as-a-service/setup/get-started.md
+++ b/content/en/cd-as-a-service/setup/get-started.md
@@ -9,47 +9,40 @@ weight: 10
 
 ## How to get started using Armory CD-as-a-Service
 
-The following steps should take less than 10 minutes to complete:
+The following steps should take less than 5 minutes to complete:
 
 1. [Register for Armory CD-as-a-Service](#register-for-armory-cd-as-a-service).
-1. [Create client credentials](#create-client-credentials).
-1. [Install the Remote Network Agent](#install-the-rna) in your target deployment cluster.
+1. [Connect your Kubernetes cluster](#connect-your-kubernetes-cluster).
 
 ## {{% heading "prereq" %}}
 
 * You have reviewed the system requirements for using Armory CD-as-a-Service on the [Requirements]({{< ref "requirements.md" >}}) page.
 * You have access to a Kubernetes cluster and have installed [kubectl](https://kubernetes.io/docs/tasks/tools/).
-* You have installed [Helm](https://helm.sh/), which is used to install the Remote Network Agent.
+* You have installed [Helm](https://helm.sh/)(v3), which is used to install the Remote Network Agent.
 
 
 ## Register for Armory CD-as-a-Service
 
-{{< include "cdaas/login-creds" >}}
+Access the [Registration screen](https://go.armory.io/signup/) to create an account. Fill in the required fields. When you're done, click **Create Account**.  
 
-Every user who wants to deploy to your clusters using Armory CD-as-a-Service must have an account. For information about inviting users, see {{< linkWithTitle "cd-as-a-service/tasks/iam/invite-users.md" >}}.
+> You may have to log in after creating your account.
 
-## Prepare your deployment target
+The **Welcome to Continuous Deployment-as-a-Service** [Configuration page](https://console.cloud.armory.io/configuration) lists the steps you need to complete to begin using Armory CD-as-a-Service.
 
-You need to manually install the Remote Network Agent (RNA) to the target deployment cluster. Armory CD-as-a-Service uses the RNA on your deployment target to communicate with Armory's hosted cloud services and to initiate the deployment.
+## Connect your Kubernetes cluster
 
-### Create client credentials
+1. In the CD-as-a-Service Console, navigate to the **Welcome to Continuous Deployment-as-a-Service** [Configuration page](https://console.cloud.armory.io/configuration).
+1. Click the **Connect your Kubernetes clusters** link.
+1. In the **Add a New Remote Network Agent** pop-up window, enter a name for your Remote Network Agent (RNA) in the **Agent Identifier** field. You install this RNA in the cluster where you want to deploy your app, so create a meaningful name.
+1. Click **Continue**.
+1. The pop-up window displays options for installing the RNA.
 
-Create machine to machine client credentials for the various service accounts that you will need. These credentials are machine credentials that are meant for authentication when using Armory CD-as-a-Service programmatically. The credentials consist of a Client ID and a Client Secret. Make sure to keep the secret somewhere safe. You cannot retrieve secrets that you lose access to. You would need to create a new set of credentials and update any services that used the credentials that you are replacing.
-
-> Armory recommends creating separate credentials for each cluster or service.
-
-To get started, you need at least one service account to use for authentication between Armory CD-as-a-Service and your deployment target where a Remote Network Agent (RNA) is installed.
-
-Create the client credentials for the RNA on your deployment target:
-
-{{< include "cdaas/client-creds.md" >}}
-
-</details>
-
-### Install the Remote Network Agent
-
-{{< include "cdaas/rna-install.md" >}}
+   - The quickest option is to copy the provided script and run it in your terminal after you have set your `kubectl` context.
+   - You can also manually install the RNA in your cluster. Copy the **Client ID**, **Client Secret**, and the name you gave you RNA (the value of the **Agent Identifier** field). Then follow the instructions in the {{< linkWithTitle "cd-as-a-service/tasks/networking/install-agent.md" >}} guide.
 
 ## {{%  heading "nextSteps" %}}
 
-Use the {{< linkWithTitle "cd-as-a-service/setup/cli.md" >}} guide to learn how to manually deploy an app using the CLI.
+Learn how to deploy your app using one of these options:
+
+* {{< linkWithTitle "cd-as-a-service/setup/cli.md" >}}
+* {{< linkWithTitle "cd-as-a-service/setup/gh-action.md" >}}

--- a/content/en/cd-as-a-service/setup/get-started.md
+++ b/content/en/cd-as-a-service/setup/get-started.md
@@ -29,10 +29,10 @@ Access the [Registration screen](https://go.armory.io/signup/) to create an acco
 
 The **Welcome to Continuous Deployment-as-a-Service** [Configuration page](https://console.cloud.armory.io/configuration) lists the steps you need to complete to begin using Armory CD-as-a-Service.
 
-## Connect your Kubernetes cluster
+## Connect your Kubernetes Cluster
 
 1. In the CD-as-a-Service Console, navigate to the **Welcome to Continuous Deployment-as-a-Service** [Configuration page](https://console.cloud.armory.io/configuration).
-1. Click the **Connect your Kubernetes clusters** link.
+1. Click the **Connect your Kubernetes Cluster** link.
 1. In the **Add a New Remote Network Agent** pop-up window, enter a name for your Remote Network Agent (RNA) in the **Agent Identifier** field. You install this RNA in the cluster where you want to deploy your app, so create a meaningful name.
 1. Click **Continue**.
 1. The pop-up window displays options for installing the RNA.

--- a/content/en/cd-as-a-service/setup/get-started.md
+++ b/content/en/cd-as-a-service/setup/get-started.md
@@ -17,7 +17,10 @@ The following steps should take less than 10 minutes to complete:
 
 ## {{% heading "prereq" %}}
 
-Review the requirements for using Armory CD-as-a-Service on the [Requirements]({{< ref "requirements.md" >}}) page.
+* You have reviewed the system requirements for using Armory CD-as-a-Service on the [Requirements]({{< ref "requirements.md" >}}) page.
+* You have access to a Kubernetes cluster and have installed [kubectl]().
+* You have installed [Helm](), which is used to install the Remote Network Agent.
+
 
 ## Register for Armory CD-as-a-Service
 
@@ -48,9 +51,5 @@ Create the client credentials for the RNA on your deployment target:
 {{< include "cdaas/rna-install.md" >}}
 
 ## {{%  heading "nextSteps" %}}
-
-Now that Armory CD-as-a-Service is configured for your deployment target, you can either try out deploying a sample app or invite more users.
-
-### Deploy an app
 
 Use the {{< linkWithTitle "cd-as-a-service/setup/cli.md" >}} guide to learn how to manually deploy an app using the CLI.

--- a/content/en/cd-as-a-service/tasks/networking/install-agent.md
+++ b/content/en/cd-as-a-service/tasks/networking/install-agent.md
@@ -5,7 +5,6 @@ exclude_search: true
 description: >
   Install a Remote Network Agent in your Kubernetes cluster.
 aliases:
-   - /cd-as-a-service/setup/get-started/#install-the-remote-network-agent
    - /cd-as-a-service/setup/get-started#install-the-remote-network-agent
 ---
 

--- a/content/en/cd-as-a-service/tasks/networking/install-agent.md
+++ b/content/en/cd-as-a-service/tasks/networking/install-agent.md
@@ -1,6 +1,6 @@
 ---
 title: Install a Remote Network Agent
-linktitle: Install Agent
+linktitle: Install RNA
 exclude_search: true
 description: >
   Install a Remote Network Agent in your Kubernetes cluster.

--- a/content/en/cd-as-a-service/tasks/networking/install-agent.md
+++ b/content/en/cd-as-a-service/tasks/networking/install-agent.md
@@ -4,8 +4,6 @@ linktitle: Install RNA
 exclude_search: true
 description: >
   Install a Remote Network Agent in your Kubernetes cluster.
-aliases:
-   - /cd-as-a-service/setup/get-started#install-the-remote-network-agent
 ---
 
 <!--## Deployment targets

--- a/content/en/cd-as-a-service/tasks/networking/install-agent.md
+++ b/content/en/cd-as-a-service/tasks/networking/install-agent.md
@@ -4,6 +4,9 @@ linktitle: Install Agent
 exclude_search: true
 description: >
   Install a Remote Network Agent in your Kubernetes cluster.
+aliases:
+   - /cd-as-a-service/setup/get-started/#install-the-remote-network-agent
+   - /cd-as-a-service/setup/get-started#install-the-remote-network-agent
 ---
 
 <!--## Deployment targets
@@ -21,7 +24,10 @@ For information about how to add a deployment target, see [Prepare your deployme
 
 ## {{% heading "prereq" %}}
 
-You have created client credentials. See the {{< linkWithTitle "cd-as-a-service/tasks/iam/client-creds.md" >}} guide for instructions.
+* If you are coming to this guide from the **Add a New Remote Network Agent** page in the UI, you have your RNA name (**Agent Identifier**), **Client ID**, and **Client Secret**. _Do not close the pop-up window in the UI until you have completed RNA installation. The credentials in the pop-up window are deleted if you close the window before the RNA has connected._
+* You have created client credentials. See the {{< linkWithTitle "cd-as-a-service/tasks/iam/client-creds.md" >}} guide for instructions.
+* You have access to a Kubernetes cluster and have installed [kubectl](https://kubernetes.io/docs/tasks/tools/).
+* You have installed [Helm](https://helm.sh/)(v3), which is used to install the Remote Network Agent.
 
 ## Install the Remote Network Agent
 

--- a/content/en/includes/cdaas/client-creds.md
+++ b/content/en/includes/cdaas/client-creds.md
@@ -1,9 +1,6 @@
 1. Access the [CD-as-a-Service Console](https://console.cloud.armory.io).
 1. Go to the **Configuration** tab.
-1. If you have more than one environment, ensure the proper environment is selected in the user context menu:
-
-   {{< figure src="/images/deploy-engine/cloud-env-context.png" alt="The upper right section of the window shows what environment you are currently in." >}}
-
+1. If you have more than one tenant, make sure you select the desired tenant in the User context menu.
 1. In the left navigation menu, select **Access Management > Client Credentials**.
 1. In the upper right corner, select **New Credential**.
 1. Create a credential for your RNAs. Use a descriptive name for the credential that matches what it is being used for. For example, name the credentials the same as the account name you assigned the target deployment cluster if creating a credential for an Remote Network Agent (RNA).

--- a/content/en/includes/cdaas/client-creds.md
+++ b/content/en/includes/cdaas/client-creds.md
@@ -1,9 +1,9 @@
 1. Access the [CD-as-a-Service Console](https://console.cloud.armory.io).
 1. Go to the **Configuration** tab.
-1. If you have more than one tenant, make sure you select the desired tenant in the User context menu.
+1. If you have more than one tenant, make sure you select the desired tenant in the User drop down menu.
 1. In the left navigation menu, select **Access Management > Client Credentials**.
 1. In the upper right corner, select **New Credential**.
-1. Create a credential for your RNAs. Use a descriptive name for the credential that matches what it is being used for. For example, name the credentials the same as the account name you assigned the target deployment cluster if creating a credential for an Remote Network Agent (RNA).
+1. Create a credential for your RNA. Use a descriptive name for the credential that matches what it is being used for. For example, name the credentials the same as the account name you assigned the target deployment cluster if creating a credential for an Remote Network Agent (RNA).
 1. Set the permission scope to a preconfigured scope group or manually assign permissions. If the credential is for a RNA, select **Remote Network Agent** from the preconfigured scope group. The group assigns the minimum set of required permissions for a RNA to work:
 
    - `write:infra:data`

--- a/content/en/includes/cdaas/rna-install.md
+++ b/content/en/includes/cdaas/rna-install.md
@@ -1,35 +1,10 @@
-You need to manually install the Remote Network Agent (RNA) to the target deployment cluster. Armory CD-as-a-Service uses the RNA on your deployment target to communicate with Armory's hosted cloud services and to initiate the deployment.
-
-{{< tabs name="install-rna" >}}
-{{% tabbody name="Quick" %}}
-This is **some markdown.**
-
-{{% alert title="Warning" color="warning" %}}
-It can even contain shortcodes.
-{{% /alert %}}
-
-{{% /tabbody %}}
-{{% tabbody name="Manual" %}}
-
-
-
-1. Verify that you are in the correct Kubernetes context. You want to install the RNA in the cluster where you deploy your apps.
-
-1. Add the Armory Helm repo:
+1. In your terminal, configure your `kubectl` [context](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-set-context-em-) to connect to the cluster where you want to deploy your app:
 
    ```bash
-   helm repo add armory https://armory.jfrog.io/artifactory/charts
+   kubectl config set-context <NAME>
    ```
 
-   You only need to do this once.
-
-1. Refresh the repo cache:
-
-   ```bash
-   helm repo update
-   ```
-
-1. Create the namespace where the RNA is installed:
+1. Create the namespace for the RNA:
 
    ```bash
    kubectl create ns armory-rna
@@ -43,9 +18,9 @@ It can even contain shortcodes.
 
    The examples use Kubernetes secrets to encrypt the value. You supply the encrypted values in the Helm command to install the RNA.
 
-1. Install the Helm chart.
+1. Install the RNA using the Helm chart.
 
-    For most scenarios, you install one RNA per cluster. Use the `agentIdentifier` parameter to give each RNA a unique name. When you deploy your app, you specify which RNA to use, so Armory recommends creating a name that identifies the cluster.
+    For most scenarios, you install one RNA per cluster. Use the `agentIdentifier` parameter to give each RNA a unique name. When you deploy your app, you specify which RNA to use, so Armory recommends creating a meaningful name that identifies the cluster.
 
     ```bash
     helm upgrade --install armory-rna armory/remote-network-agent \
@@ -59,9 +34,4 @@ It can even contain shortcodes.
 
     For advanced use cases such as proxy configurations, custom annotations, labels, or environment variables, see the [`values.yaml` for the RNA](https://github.com/armory-io/remote-network-agent-helm-chart/blob/master/values.yaml?rgh-link-date=2022-02-02T22%3A38%3A35Z). For information about using a `values file`, see the [Helm documentation](https://helm.sh/docs/chart_template_guide/values_files/).
 
-
-{{% /tabbody %}}
-{{< /tabs >}}
-
-You can go to the [Agents page](https://console.cloud.armory.io/configuration/agents) in the CD-as-a-Service Console verify that your RNA has been installed and is communicating with CD-as-a-Service. If you do not see the RNA, check the cluster logs to see if the RNA is running.
-
+1. You can go to the [Agents page](https://console.cloud.armory.io/configuration/agents) in the CD-as-a-Service Console to verify that your RNA has been installed and is communicating with CD-as-a-Service. If you do not see the RNA, check the cluster logs to see if the RNA is running.

--- a/content/en/includes/cdaas/rna-install.md
+++ b/content/en/includes/cdaas/rna-install.md
@@ -1,3 +1,18 @@
+You need to manually install the Remote Network Agent (RNA) to the target deployment cluster. Armory CD-as-a-Service uses the RNA on your deployment target to communicate with Armory's hosted cloud services and to initiate the deployment.
+
+{{< tabs name="install-rna" >}}
+{{% tabbody name="Quick" %}}
+This is **some markdown.**
+
+{{% alert title="Warning" color="warning" %}}
+It can even contain shortcodes.
+{{% /alert %}}
+
+{{% /tabbody %}}
+{{% tabbody name="Manual" %}}
+
+
+
 1. Verify that you are in the correct Kubernetes context. You want to install the RNA in the cluster where you deploy your apps.
 
 1. Add the Armory Helm repo:
@@ -42,15 +57,11 @@
 
     The encrypted values for `clientId` and `clientSecret` reference the Kubernetes secrets you generated in an earlier step.
 
-   For advanced use cases such as proxy configurations, custom annotations, labels, or environment variables, see the [`values.yaml` for the RNA](https://github.com/armory-io/remote-network-agent-helm-chart/blob/master/values.yaml?rgh-link-date=2022-02-02T22%3A38%3A35Z). For information about using a `values file`, see the [Helm documentation](https://helm.sh/docs/chart_template_guide/values_files/).
-
-1. Verify the RNA connection. Go to the [Agents page](https://console.cloud.armory.io/configuration/agents) in the Configuration UI, and look for the Agent identifier you assigned to your target deployment cluster. You should see it along with some basic information:
-
-   > Note that you may see a "No Data message" when first loading the Agent page.
-
-   {{< figure src="/images/cdaas/ui-rna-status.jpg" alt="The Connected Remote Network Agents page shows connected agents and the following information: Agent Identifier, Agent Version, Connection Time when the connection was established, Last Heartbeat time, Client ID, and IP Address." >}}
+    For advanced use cases such as proxy configurations, custom annotations, labels, or environment variables, see the [`values.yaml` for the RNA](https://github.com/armory-io/remote-network-agent-helm-chart/blob/master/values.yaml?rgh-link-date=2022-02-02T22%3A38%3A35Z). For information about using a `values file`, see the [Helm documentation](https://helm.sh/docs/chart_template_guide/values_files/).
 
 
+{{% /tabbody %}}
+{{< /tabs >}}
 
-   If you do not see the RNA for your target deployment cluster, check the logs for the target deployment cluster to see if the RNA is up and running.
+You can go to the [Agents page](https://console.cloud.armory.io/configuration/agents) in the CD-as-a-Service Console verify that your RNA has been installed and is communicating with CD-as-a-Service. If you do not see the RNA, check the cluster logs to see if the RNA is running.
 


### PR DESCRIPTION
1. Install CLI -> remove old "manual" content; move "automated" content to manual; new automated content is the one line script https://deploy-preview-1433--armory-docs.netlify.app/cd-as-a-service/setup/cli/
2. Pared down Get Started guide to match new UI https://deploy-preview-1433--armory-docs.netlify.app/cd-as-a-service/setup/get-started/
3. Updated the Install a Remote Network Agent page to account for people coming from Welcome screen https://deploy-preview-1433--armory-docs.netlify.app/cd-as-a-service/tasks/networking/install-agent/
4. Related Customer Portal PRs that update text https://github.com/armory-io/customer-portal/pull/627 and https://github.com/armory-io/customer-portal/pull/628  


Resolves Jira: [DOC-607]




[DOC-607]: https://armory.atlassian.net/browse/DOC-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ