### PR TITLE
docs(cdaas): -analysis s/unit/units

### DIFF
--- a/content/en/cd-as-a-service/reference/CLI/cli-cheat.md
+++ b/content/en/cd-as-a-service/reference/CLI/cli-cheat.md
@@ -120,17 +120,13 @@ Generate a customizable Kubernetes canary deployment template.
 
 **Usage**
 
-`armory template kubernetes canary [flags]`
-
-**Flags**
-
-- `-f, --features`: Features to include in the template. Available options are `manual`, `automated`, and `traffic`.
+`armory template kubernetes canary -f automated`
 
 **Example**
 
-To generate a canary traffic template and save the output to a file:
+To generate a canary template and save the output to a file:
 
-`armory template kubernetes canary -f traffic > deploy-canary-traffic.yaml`
+`armory template kubernetes canary -f automated > deploy-canary-traffic.yaml`
 
 ## Get the CLI version
 

--- a/content/en/cd-as-a-service/reference/deployfile/ref-deployment-file.md
+++ b/content/en/cd-as-a-service/reference/deployfile/ref-deployment-file.md
@@ -250,7 +250,7 @@ strategies:
               keyName: <value>
               keyName: <value>
             interval: <integer>
-            unit: <seconds|minutes|hours>
+            units: <seconds|minutes|hours>
             numberOfJudgmentRuns: <integer>
             rollBackMode: <manual|automatic>
             rollForwardMode: <manual|automatic>
@@ -395,7 +395,7 @@ steps:
               keyName: <value>
               keyName: <value>
             interval: <integer>
-            unit: <seconds|minutes|hours>
+            units: <seconds|minutes|hours>
             numberOfJudgmentRuns: <integer>
             rollBackMode: <manual|automatic>
             rollForwardMode: <manual|automatic>
@@ -439,7 +439,7 @@ steps:
 ...
         - analysis:
             interval: <integer>
-            unit: <seconds|minutes|hours>
+            units: <seconds|minutes|hours>
 ```
 
 How long each sample of the query gets summarized over.
@@ -451,11 +451,11 @@ steps:
 ...
         - analysis:
             interval: 30
-            unit: seconds
+            units: seconds
 
 ```
 
-###### `strategies.<strategyName>.canary.steps.analysis.unit`
+###### `strategies.<strategyName>.canary.steps.analysis.units`
 
 The unit of time for the interval. Use `seconds`, `minutes` or `hours`. See `strategies.<strategyName>.<strategy>.steps.analysis.interval` for more information.
 
@@ -638,7 +638,7 @@ shutdownOldVersionAfter:
         keyName: <value>
         keyName: <value>
       interval: <integer>
-      unit: <seconds|minutes|hours>
+      units: <seconds|minutes|hours>
       numberOfJudgmentRuns: <integer>
       rollBackMode: <manual|automatic>
       rollForwardMode: <manual|automatic>

--- a/content/en/cd-as-a-service/setup/canary.md
+++ b/content/en/cd-as-a-service/setup/canary.md
@@ -137,7 +137,7 @@ Adding canary analysis to your deployment involves updating your deploy file to 
               weight: 50
           - analysis:
               interval: 10
-              unit: seconds
+              units: seconds
               numberOfJudgmentRuns: 3
               rollBackMode: manual
               rollForwardMode: manual
@@ -147,7 +147,7 @@ Adding canary analysis to your deployment involves updating your deploy file to 
               weight: 75
           - analysis:
               interval: 10
-              unit: seconds
+              units: seconds
               numberOfJudgmentRuns: 3
               rollBackMode: manual
               rollForwardMode: manual


### PR DESCRIPTION
From Parth:
I just noticed there is a mismatch in our CLI YAML. for analysis steps we use the term units the docs on our reference page right now say unit . https://docs.armory.io/cd-as-a-service/reference/deployfile/ref-deployment-file/#strategiesstrategynamecanarystepsanalysisinterval 

it is on 2 different pages the reference page and getting started page 

Resolves Jira: [DOC-609]



[DOC-609]: https://armory.atlassian.net/browse/DOC-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ