### PR TITLE
fix(releaseNotes): workaround neeeded by peter-evans GHA

### DIFF
--- a/.github/workflows/create-spinnaker-release-notes.yml
+++ b/.github/workflows/create-spinnaker-release-notes.yml
@@ -17,7 +17,10 @@ jobs:
         run: apk --no-cache add git
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Workaround pull-request-creation-peter-evans
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: build output file path
         id: build_output


### PR DESCRIPTION
This is a workaround needed by the GHA that creates Release Notes. More info is here: https://github.com/peter-evans/create-pull-request/issues/1170