### PR TITLE
docs(cdaas): DOC-618 RNA K8s permissions

### DIFF
--- a/content/en/cd-as-a-service/setup/get-started.md
+++ b/content/en/cd-as-a-service/setup/get-started.md
@@ -37,8 +37,8 @@ The **Welcome to Continuous Deployment-as-a-Service** [Configuration page](https
 1. Click **Continue**.
 1. The pop-up window displays options for installing the RNA.
 
-   - The quickest option is to copy the provided script and run it in your terminal after you have set your `kubectl` context.
-   - You can also manually install the RNA in your cluster. Copy the **Client ID**, **Client Secret**, and the name you gave you RNA (the value of the **Agent Identifier** field). Then follow the instructions in the {{< linkWithTitle "cd-as-a-service/tasks/networking/install-agent.md" >}} guide.
+   - **Quick**: The quickest option is to copy the provided script and run it in your terminal after you have set your `kubectl` context. _By default, the RNA is installed with `*` (all) permissions in the cluster. You need to do a manual install if you want to modify the default permissions._
+   - **Manual**: Copy the **Client ID**, **Client Secret**, and the name you gave you RNA (the value of the **Agent Identifier** field). Then follow the instructions in the {{< linkWithTitle "cd-as-a-service/tasks/networking/install-agent.md" >}} guide.
 
 ## {{%  heading "nextSteps" %}}
 

--- a/content/en/includes/cdaas/rna-install.md
+++ b/content/en/includes/cdaas/rna-install.md
@@ -1,6 +1,6 @@
 ### Kubernetes permissions for the Remote Network Agent
 
-By default, the RNA is installed with full access to the cluster. At a minimum, the RNA needs permissions to create, edit, and delete all KINDs that you plan to deploy with CD-as-a-Service, in all namespaces to which you plan to deploy. The RNA also requires network access to any monitoring solutions or webhook APIs that you plan to forward through it.
+By default, the RNA is installed with full access to the cluster. At a minimum, the RNA needs permissions to create, edit, and delete all `kind` objects that you plan to deploy with CD-as-a-Service, in all namespaces to which you plan to deploy. The RNA also requires network access to any monitoring solutions or webhook APIs that you plan to forward through it.
 
 For advanced use cases such as restricting permissions, proxy configurations, custom annotations, labels, or environment variables, download and modify the [`values.yaml` for the RNA](https://github.com/armory-io/remote-network-agent-helm-chart/blob/main/values.yaml) or override existing values on the command line using `--set`. For information about using a `values file`, see the [Helm Values Files guide](https://helm.sh/docs/chart_template_guide/values_files/) and the [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) section of the _Using Helm_ guide.
 

--- a/content/en/includes/cdaas/rna-install.md
+++ b/content/en/includes/cdaas/rna-install.md
@@ -1,3 +1,11 @@
+### Kubernetes permissions for the Remote Network Agent
+
+By default, the RNA is installed with full access to the cluster. At a minimum, the RNA needs permissions to create, edit, and delete all KINDs that you plan to deploy with CD-as-a-Service, in all namespaces to which you plan to deploy. The RNA also requires network access to any monitoring solutions or webhook APIs that you plan to forward through it.
+
+For advanced use cases such as restricting permissions, proxy configurations, custom annotations, labels, or environment variables, download and modify the [`values.yaml` for the RNA](https://github.com/armory-io/remote-network-agent-helm-chart/blob/main/values.yaml) or override existing values on the command line using `--set`. For information about using a `values file`, see the [Helm Values Files guide](https://helm.sh/docs/chart_template_guide/values_files/) and the [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) section of the _Using Helm_ guide.
+
+### Installation
+
 1. In your terminal, configure your `kubectl` [context](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-set-context-em-) to connect to the cluster where you want to deploy your app:
 
    ```bash
@@ -18,20 +26,24 @@
 
    The examples use Kubernetes secrets to encrypt the value. You supply the encrypted values in the Helm command to install the RNA.
 
-1. Install the RNA using the Helm chart.
+1. You can install the RNA with default permissions and values or you can customize using a `values.yaml` file.
 
-    For most scenarios, you install one RNA per cluster. Use the `agentIdentifier` parameter to give each RNA a unique name. When you deploy your app, you specify which RNA to use, so Armory recommends creating a meaningful name that identifies the cluster.
+   For most scenarios, you install one RNA per cluster. Use the `agentIdentifier` parameter to give each RNA a unique name. When you deploy your app, you specify which RNA to use, so Armory recommends creating a meaningful name that identifies the cluster.
 
-    ```bash
-    helm upgrade --install armory-rna armory/remote-network-agent \
+   **Default values**
+
+   The encrypted values for `clientId` and `clientSecret` reference the Kubernetes secrets you generated in an earlier step.
+
+   ```bash
+   helm upgrade --install armory-rna armory/remote-network-agent \
         --set agentIdentifier=<rna-name> \
         --set 'clientId=encrypted:k8s!n:rna-client-credentials!k:client-id' \
         --set 'clientSecret=encrypted:k8s!n:rna-client-credentials!k:client-secret' \
         --namespace armory-rna
-    ```
+   ```
 
-    The encrypted values for `clientId` and `clientSecret` reference the Kubernetes secrets you generated in an earlier step.
+   **Customized values**
 
-    For advanced use cases such as proxy configurations, custom annotations, labels, or environment variables, see the [`values.yaml` for the RNA](https://github.com/armory-io/remote-network-agent-helm-chart/blob/master/values.yaml?rgh-link-date=2022-02-02T22%3A38%3A35Z). For information about using a `values file`, see the [Helm documentation](https://helm.sh/docs/chart_template_guide/values_files/).
+   You can specify the path to your customized values file using `-f <your-path>values.yaml` or you can override values using the command line `--set <key:value>`. Refer to the [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) section in the Helm docs.
 
 1. You can go to the [Agents page](https://console.cloud.armory.io/configuration/agents) in the CD-as-a-Service Console to verify that your RNA has been installed and is communicating with CD-as-a-Service. If you do not see the RNA, check the cluster logs to see if the RNA is running.


### PR DESCRIPTION
Add default K8s permissions for RNA.
Add links to Helm docs for values.yaml and customizing the chart

Note that the rna-install.md file is included in multiple files.

Resolves Jira: [DOC-618]

https://deploy-preview-1472--armory-docs.netlify.app/cd-as-a-service/setup/get-started/
https://deploy-preview-1472--armory-docs.netlify.app/cd-as-a-service/tasks/networking/install-agent/

[DOC-618]: https://armory.atlassian.net/browse/DOC-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ