### PR TITLE
revert(agent): Automated agent plugin release notes (v0.11.0) (#1467)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -166,8 +166,8 @@ agent_plug_latest-2="0.8.63"
 agent_plug_latest_spin-2="2.25.x (1.25.x)"
 agent_plug_latest-1="0.9.55"
 agent_plug_latest_spin-1="2.26.x (1.26.x)"
-agent_plug_latest="0.11.0"
-agent_plug_latest_spin="2.28.x (1.28.x)"
+agent_plug_latest="0.10.39"
+agent_plug_latest_spin="2.27.x (1.27.x)"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
This reverts commit fccccdc4ef198a53c185104621f74ff480acd1a4.
Armory Spinnaker 2.28.x has not been released yet
