### PR TITLE
docs(fix): Correct namespace for AE install

### DIFF
--- a/content/en/armory-enterprise/installation/armory-operator/op-quickstart.md
+++ b/content/en/armory-enterprise/installation/armory-operator/op-quickstart.md
@@ -89,7 +89,8 @@ See [Custom Halyard Configuration]({{< ref "op-advanced-config.md" >}}) if you n
 Deploy using `kubectl`:
 
 ```bash
-kubectl -n spinnaker-operator apply -f deploy/spinnaker/basic/SpinnakerService.yml
+kubectl create ns spinnaker
+kubectl -n spinnaker apply -f deploy/spinnaker/basic/SpinnakerService.yml
 ```
 
 {{% /tabbody %}}
@@ -125,7 +126,8 @@ spec:
 Deploy using `kubectl`:
 
 ```bash
-kubectl -n spinnaker-operator apply -f deploy/spinnaker/basic/spinnakerservice.yml
+kubectl create ns spinnaker
+kubectl -n spinnaker apply -f deploy/spinnaker/basic/spinnakerservice.yml
 ```
 
 {{% /tabbody %}}
@@ -134,13 +136,13 @@ kubectl -n spinnaker-operator apply -f deploy/spinnaker/basic/spinnakerservice.y
 You can watch the installation progress by executing:
 
 ```bash
-kubectl -n spinnaker-operator get spinsvc spinnaker -w
+kubectl -n spinnaker get spinsvc spinnaker -w
 ```
 
 You can verify pod status by executing:
 
 ```bash
- kubectl -n spinnaker-operator get pods
+ kubectl -n spinnaker get pods
  ```
 
 The included manifest file is only for a very basic installation.
@@ -226,19 +228,20 @@ spec:
 1. Deploy from the `/spinnaker-operator/deploy/spinnaker/kustomize/` directory:
 
    ```bash
-   kubectl -n spinnaker-operator apply -k .
+   kubectl create ns spinnaker
+   kubectl -n spinnaker apply -k .
    ```
 
 1. You can watch the installation progress by executing:
 
    ```bash
-   kubectl -n spinnaker-operator get spinsvc spinnaker -w
+   kubectl -n spinnaker get spinsvc spinnaker -w
    ```
 
 1. You can verify pod status by executing:
 
    ```bash
-   kubectl -n spinnaker-operator get pods
+   kubectl -n spinnaker get pods
    ```
 
 ## Help resources


### PR DESCRIPTION
Changed the namespace from `spinnaker-operator` to `spinnaker` in the _Deploy an Armory Enterprise instance_ section. Add command to create `spinnaker` namespace.


Resolves Jira: [DOC-678]

Deploy preview https://deploy-preview-1647--armory-docs.netlify.app/armory-enterprise/installation/armory-operator/op-quickstart/#deploy-an-armory-enterprise-instance


[DOC-678]: https://armory.atlassian.net/browse/DOC-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ