### PR TITLE
docs(cdaas): add webhook troubleshooting section

### DIFF
--- a/content/en/cd-as-a-service/tasks/webhook-approval.md
+++ b/content/en/cd-as-a-service/tasks/webhook-approval.md
@@ -192,7 +192,5 @@ strategies:
 
 ## {{% heading "nextSteps" %}}
 
-For in-depth examples, see the following tutorials:
-
-* {{< linkWithTitle "webhook-github.md" >}}
-
+* {{< linkWithTitle "cd-as-a-service/tutorials/external-automation/webhook-github.md" >}}
+* {{< linkWithTitle "cd-as-a-service/troubleshooting/webhook.md" >}}

--- a/content/en/cd-as-a-service/troubleshooting/webhook.md
+++ b/content/en/cd-as-a-service/troubleshooting/webhook.md
@@ -1,0 +1,84 @@
+---
+title: Troubleshoot Webhooks
+linktitle: Webhooks
+description: >
+  Solutions for issues you might encounter while using webhooks with Armory Continuous Deployment-as-a-Service.
+---
+
+## GitHub
+
+### 401 status code
+
+In the UI, you see a `Received non-200 status code: 401` error.
+
+**Why this happens**
+
+You pass invalid credentials.
+
+**Fix**
+
+Check that your GitHub access token is valid.
+
+### 404 status code
+
+```
+404 Not Found: [{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}]
+```
+
+**Why this happens**
+
+This is a confusing error that occurs when you do not send authorization credentials in the header.
+
+**Fix**
+
+Make sure you include your GitHub token in the request header.
+
+{{< prism lang="yaml" >}}
+headers:
+- key: Authorization
+  value: token  {{secrets.github_personal_access_token}}
+{{< /prism >}}
+
+### Failed to fetch access token
+
+{{< prism lang="bash" >}}
+level=fatal msg="failed to fetch access token, err: no credentials set or expired. Either run armory login command to interactively login, or add clientId and clientSecret flags to specify service account credentials"
+{{< /prism >}}
+
+You may see this error when you are using Secrets in a reusable workflow.
+
+**Why this happens**
+
+The reusable workflow does not automatically inherit Secrets from the caller worklow.
+
+**Fix**
+
+You need to explicitly configure your reusable workflow to inherit Secrets. See the [GitHub docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) for details.
+
+### Webhook process runs for a long time
+
+**Why this happens**
+
+The call to your action wasn't successful or your workflow didn't trigger the callback.
+
+**Fixes**
+
+Check your repo to see if your action is also still running.
+
+* If the action hasn't started, the call to your action wasn't successful. The UI should display an error message with a non-200 HTTP return code when the webhook process times out. In the meantime, check your deployment file to make sure the following fields have the correct values:
+
+   - `uriTemplate`
+   - `networkMode` and optionally `agentIdentifier`
+   - `event_type` in the inline body template
+
+   If you find an error, cancel your deployment before fixing and redeploying.
+
+* If your GitHub action workflow has completed, your workflow failed to trigger the callback to Armory CD-as-a-Service. Check GitHub's [Monitoring and troubleshooting workflows](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows) for troubleshooting suggestions.
+
+
+
+
+
+
+
+

--- a/content/en/cd-as-a-service/tutorials/external-automation/webhook-github.md
+++ b/content/en/cd-as-a-service/tutorials/external-automation/webhook-github.md
@@ -237,51 +237,9 @@ Deploy by running `armory start deploy -f deploy-webhook.yml`. Then check deploy
 
 {{< figure width="100%" height="100%" src="/images/cdaas/tutorials/webhooks/webhook-failure.jpg"  alt="BeforeDeployment webhook failure"  caption="<center><i>The basicPing webhook failed.</i></center>">}}
 
-## Troubleshooting
+## {{% heading "nextSteps" %}}
 
-### Webhook process runs for a long time
-
-Check your repo to see if the action is also still running.
-
-* If the action hasn't started, the call to your action wasn't successful. The UI should display an error message with a non-200 HTTP return code when the webhook process times out. In the meantime, check your deployment file to make sure the following fields have the correct values:
-
-   - `uriTemplate`
-   - `networkMode` and optionally `agentIdentifier`
-   - `event_type` in the inline body template
-
-   If you find an error, cancel your deployment before fixing and redeploying.
-
-* If your GitHub action workflow has completed, your workflow failed to trigger the callback to Armory CD-as-a-Service. Check GitHub's [Monitoring and troubleshooting workflows](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows) for troubleshooting suggestions.
-
-
-### 401 status code
-
-In the UI, you see a `Received non-200 status code: 401` error when you pass invalid credentials. Check that your GitHub access token is valid.
-
-### 404 status code
-
-```
-404 Not Found: [{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}]
-```
-
-This is a confusing error that occurs when you do not send authorization credentials in the header. Make sure you include your GitHub token in the request header.
-
-{{< prism lang="yaml" >}}
-headers:
-- key: Authorization
-  value: token  {{secrets.github_personal_access_token}}
-{{< /prism >}}
-
-
-
-
-
-
-
-
-
-
-
+{{< linkWithTitle "cd-as-a-service/troubleshooting/webhook.md" >}}
 
 
 <!-- do not delete these. Markdown links used in the content. -->


### PR DESCRIPTION
- Add Webhooks page to Troubleshooting section
- Move troubleshooting from tutorial to new page
- Add Failed to fetch access token error 


Resolves Jira: [DOC-679]




[DOC-679]: https://armory.atlassian.net/browse/DOC-679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ