### PR TITLE
docs(fix): Fix broken links to Spinnaker's Plugin User Guide

### DIFF
--- a/content/en/armory-enterprise/armory-admin/evaluate-artifacts-stage-enable.md
+++ b/content/en/armory-enterprise/armory-admin/evaluate-artifacts-stage-enable.md
@@ -16,7 +16,7 @@ For information about how to use the stage, see {{< linkWithTitle "evaluate-arti
 
 ## {{% heading "prereq" %}}
 
-* If you are new to enabling plugins, read the [Plugin Users Guide](https://spinnaker.io/guides/user/plugins/) to familiarize yourself with how plugins to Armory Enterprise work.
+* If you are new to enabling plugins, read Spinnaker's [Plugin Users Guide](https://spinnaker.io/docs/guides/user/plugins-users/) to familiarize yourself with how plugins to Armory Enterprise work.
 * The Evaluate Artifacts Stage requires Armory Enterprise 2.24.x or later (Spinnaker 1.24.x or later)
 
 

--- a/content/en/armory-enterprise/installation/armory-operator/op-manifest-reference/plugins.md
+++ b/content/en/armory-enterprise/installation/armory-operator/op-manifest-reference/plugins.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 {{% alert title="Warning" color="warning" %}}
-Please see the [Plugins User Guide](https://spinnaker.io/guides/user/plugins) for a detailed explanation of plugins.
+Please see Spinnaker's [Plugins User Guide](https://spinnaker.io/docs/guides/user/plugins-users/) for a detailed explanation of plugins.
 {{% /alert %}}
 
 ## Parameters
@@ -50,7 +50,7 @@ spec:
     - `id`: same as <repository-name>
     - `url`: URL to `repositories.json` or `plugins.json`
 
-See the Plugin Users Guide _Add a plugin repository_ [section](https://spinnaker.io/guides/user/plugins/#add-a-plugin-repository-using-halyard) for when you can use `plugins.json` instead of `repositories.json`.
+See the Plugin Users Guide _Add a plugin repository_ [section](https://spinnaker.io/docs/guides/user/plugins-users/#add-a-plugin-repository-using-halyard) for when you can use `plugins.json` instead of `repositories.json`.
 
 ### Deck proxy
 
@@ -125,4 +125,4 @@ spec:
 
 ## Kustomize patch examples
 
-You can see examples in the `spinnaker-kustomize-patches` repo's [`plugins` folder](https://github.com/armory/spinnaker-kustomize-patches/tree/master/plugins). 
+You can see examples in the `spinnaker-kustomize-patches` repo's [`plugins` folder](https://github.com/armory/spinnaker-kustomize-patches/tree/master/plugins).

--- a/content/en/armory-enterprise/plugin-guide/pf4j-deploy-example.md
+++ b/content/en/armory-enterprise/plugin-guide/pf4j-deploy-example.md
@@ -17,7 +17,7 @@ By implementing Orca's SimpleStage PF4J extension point, the `pf4jStagePlugin` c
 - You understand the concept of [managing Kubernetes resources using manifests](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/)
 - You have a basic understanding of how the [Armory Operator]({{< ref "armory-operator" >}}) deploys Armory to [Kubernetes](https://kubernetes.io/)
 - You have `kubectl` access to an instance of Armory installed using the Armory Operator in `basic` and have permissions to modify and apply the manifest that deploys Armory
-- You have read the [Plugin Users Guide](https://spinnaker.io/guides/user/plugins); you are familiar with plugin concepts and the files used when deploying plugins (`repositories.json`, `plugins.json`)
+- You have read Spinnaker's [Plugin Users Guide](https://spinnaker.io/docs/guides/user/plugins-users/); you are familiar with plugin concepts and the files used when deploying plugins (`repositories.json`, `plugins.json`)
 
 ### Armory environment
 

--- a/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-6.md
+++ b/content/en/armory-enterprise/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-19-6.md
@@ -55,7 +55,7 @@ Addressed a number of CVEs found within the Spinnaker services.
 
 **Plugins**
 
-This release supports Plugin deployment using Armory-extended Halyard or the [Spinnaker Operator]({{< ref "armory-operator" >}}). Consult the open source [Plugin](https://spinnaker.io/guides/user/plugins/) docs for Halyard usage or the [Plugins Operator Reference]({{< ref "plugins" >}}) for a manifest example.
+This release supports Plugin deployment using Armory-extended Halyard or the [Spinnaker Operator]({{< ref "armory-operator" >}}). Consult the open source [Plugin](https://spinnaker.io/docs/guides/user/plugins-users/) docs for Halyard usage or the [Plugins Operator Reference]({{< ref "plugins" >}}) for a manifest example.
 
 Additionally, this version of Spinnaker includes updates to how Deck is built. Previously, Deck's builds were non-deterministic, causing issues with loading plugins into the UI. Deck's builds are now deterministic and support UI plugins.
 

--- a/content/en/includes/breaking-changes/bc-metrics-name.md
+++ b/content/en/includes/breaking-changes/bc-metrics-name.md
@@ -5,14 +5,14 @@ Metrics data, specifically the metric names, for Spinnaker changed. These change
 **Workarounds**:
 
 * **Observability Plugin**: Armory is working on updates to the [Observability Plugin](https://github.com/armory-plugins/armory-observability-plugin) to remedy this issue. The plugin currently supports New Relic & Prometheus. Note that this resolution requires you to make updates to use the new metric names.
-   
+
    For information about how to configure the Observability Plugin, see [Monitoring Spinnaker with Prometheus]({{< ref "prometheus-monitoring" >}}).
 
-   For information about how to install a plugin, see [Plugin Users Guide](https://spinnaker.io/guides/user/plugins/).
+   For information about how to install a plugin, see Spinnaker's [Plugin Users Guide](https://spinnaker.io/docs/guides/user/plugins-users/).
 
 * **Update existing dashboards**: Change your dashboards and alerts to use the new metric names.
 
-Although both workarounds involve updating your dashboards to use the new metric names, Armory recommends switching to the Observability plugin. Due to changes the Spinnaker project is making, the Observability plugin provides a long-term solution. 
+Although both workarounds involve updating your dashboards to use the new metric names, Armory recommends switching to the Observability plugin. Due to changes the Spinnaker project is making, the Observability plugin provides a long-term solution.
 
 **Affected versions**: Armory 2.20.x or later (OSS 1.20.x)
 

--- a/content/en/includes/breaking-changes/bc-spinnaker-metrics.md
+++ b/content/en/includes/breaking-changes/bc-spinnaker-metrics.md
@@ -6,11 +6,11 @@ Metrics data, specifically the metric names, for Spinnaker changed in 2.20. Thes
 
 * **Observability plugin**: Armory is working on updates to the [Observability plugin](https://github.com/armory-plugins/armory-observability-plugin) to remedy this issue. The plugin currently supports New Relic & Prometheus. Note that this resolution requires you to make updates to use the new metric names.
 
-   For information about how to install a plugin, see [Plugin Users Guide](https://spinnaker.io/guides/user/plugins/).
+   For information about how to install a plugin, see Spinnaker's [Plugin Users Guide](https://spinnaker.io/docs/guides/user/plugins-users/).
 
 * **Update existing dashboards**: Change your dashboards and alerts to use the new metric names.
 
-Although both workarounds involve updating your dashboards to use the new metric names, Armory recommends switching to the Observability plugin. Due to changes the Spinnaker project is making, the Observability plugin provides a long-term solution. 
+Although both workarounds involve updating your dashboards to use the new metric names, Armory recommends switching to the Observability plugin. Due to changes the Spinnaker project is making, the Observability plugin provides a long-term solution.
 
 This release note will be updated once the updated plugin is available.
 


### PR DESCRIPTION
Fix broken links to Spinnaker's Plugin User Guide.

Resolves GitHub issue: https://github.com/armory/docs/issues/1676
Resolves Jira: [DOC-683]




[DOC-683]: https://armory.atlassian.net/browse/DOC-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ