### PR TITLE
docs(fix): Exclude /armory-enterprise/plugin-guide/cdaas-spinnaker from sitemap

### DIFF
--- a/content/en/armory-enterprise/plugin-guide/cdaas-spinnaker.md
+++ b/content/en/armory-enterprise/plugin-guide/cdaas-spinnaker.md
@@ -2,6 +2,7 @@
 title: Armory Continuous Deployment-as-a-Service Plugin for Armory Enterprise and Spinnaker
 linkTitle: Armory CD-as-a-Service Plugin
 manualLinkRelRef: "cd-as-a-service/plugin-spinnaker.md"
+exclude_search: true
 description: >
   Use this guide to install the Armory CD-as-a-Service plugin for Spinnaker and Armory Enterprise. This enables performing canary and blue/green deployments in a single stage.
 ---

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -4,6 +4,7 @@ User-agent: *
 Disallow: /armory-enterprise/plugin-guide/plugin-appname/
 Disallow: /armory-enterprise/plugin-guide/plugin-external-account/
 Disallow: /armory-enterprise/plugin-guide/plugin-iam-authentication/
+Disallow: /armory-enterprise/plugin-guide/cdaas-spinnaker/
 Disallow: /armory-enterprise/feature-status/deprecations/pacrd-deprecation/
 Disallow: /armory-enterprise/installation/deployment-reg/
 Disallow: /managed-spin/

--- a/netlify.toml
+++ b/netlify.toml
@@ -128,6 +128,7 @@ package = "@netlify/plugin-sitemap"
     './public/armory-enterprise/plugin-guide/plugin-appname/',
     './public/armory-enterprise/plugin-guide/plugin-external-account/',
     './public/armory-enterprise/plugin-guide/plugin-iam-authentication/',
+    './public/armory-enterprise/plugin-guide/cdaas-spinnaker/',
     './public/armory-enterprise/feature-status/deprecations/pacrd-deprecation/',
     './public/armory-enterprise/installation/deployment-reg/',
     './public/managed-spin',

--- a/netlify.toml
+++ b/netlify.toml
@@ -117,6 +117,10 @@
   from = "/armory-enterprise/armory-agent/*"
   to = "/scale-agent/"
 
+[[redirects]]
+  from = "/armory-enterprise/plugin-guide/cdaas-spinnaker/"
+  to = "/cd-as-a-service/plugin-spinnaker/"
+
 # https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]
 package = "@netlify/plugin-sitemap"

--- a/netlify.toml
+++ b/netlify.toml
@@ -120,6 +120,7 @@
 [[redirects]]
   from = "/armory-enterprise/plugin-guide/cdaas-spinnaker/"
   to = "/cd-as-a-service/plugin-spinnaker/"
+  force = true # ensure this always redirects because cdaas-spinnaker does exist
 
 # https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]


### PR DESCRIPTION
The page automatically redirects to the cd-as-a-service location but is still showing up in Google search. Only the main /cd-as-a-service/plugin-spinnaker page should be indexed.

- Add to sitemap exclusion section in netlify.toml
- Add to robots.txt
- Exclude from docs.armory.io internal site search
- Add force redirect to netlify.toml to external link click redirects to correct internal page

Resolves Jira: [DOC-685]



[DOC-685]: https://armory.atlassian.net/browse/DOC-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ