### PR TITLE
docs(fix): change sql.connectionPool to sql.connectionPools in configs

### DIFF
--- a/content/en/armory-enterprise/armory-admin/orca-sql-configure.md
+++ b/content/en/armory-enterprise/armory-admin/orca-sql-configure.md
@@ -23,7 +23,7 @@ You can configure your SQL database by adding the following snippet to `Spinnake
 ```yaml
 sql:
   enabled: true
-  connectionPool:
+  connectionPools:
     jdbcUrl: jdbc:mysql://<DB CONNECTION HOSTNAME>:<DB CONNECTION PORT>/<DATABASE NAME>
     user: orca_service
     password: <orca_service password>
@@ -133,7 +133,7 @@ To try a different database you can switch the JDBC URL and set the `dialect` in
 ```yaml
 sql:
   enabled: true
-  connectionPool:
+  connectionPools:
     jdbcUrl: jdbc:<DRIVER>://<DB CONNECTION HOSTNAME>:<DB CONNECTION PORT>/<DATABASE NAME>
     dialect: <DIALECT VALUE>
     ...

--- a/content/en/armory-enterprise/plugin-guide/plugin-iam-authentication.md
+++ b/content/en/armory-enterprise/plugin-guide/plugin-iam-authentication.md
@@ -191,7 +191,7 @@ spec:
 
         sql:
           enabled: true
-          connectionPool:
+          connectionPools:
             jdbcUrl: jdbc:mysql:aws://<RDSHOST>:<PORT>/orca?enabledTLSProtocols=TLSv1.2&acceptAwsProtocolOnly=true&useAwsIam=true
             user: orca_service
             connectionTimeout: 5000


### PR DESCRIPTION

sql.connectionPool is deprecated

Resolves Jira: [DOC-687]




[DOC-687]: https://armory.atlassian.net/browse/DOC-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ