### PR TITLE
docs(fix): add /docs/ redirect back to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,10 @@
 # section redirects
 
 [[redirects]]
+  from = "/docs/*"
+  to = "/continuous-deployment/:splat"
+
+[[redirects]]
   from = "/armory-enterprise/*"
   to = "/continuous-deployment/:splat"
 


### PR DESCRIPTION
Support site still uses docs.armory.io/docs/


Partial Jira: [DOC-637] [DOC-690]



[DOC-637]: https://armory.atlassian.net/browse/DOC-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-690]: https://armory.atlassian.net/browse/DOC-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ