### PR TITLE
docs(lint): comment out Quote.yaml contents

### DIFF
--- a/.github/styles/Google/Quotes.yml
+++ b/.github/styles/Google/Quotes.yml
@@ -1,7 +1,7 @@
-extends: existence
-message: "Commas and periods go inside quotation marks."
-link: 'https://developers.google.com/style/quotation-marks'
-level: error
-nonword: true
-tokens:
-  - '"[^"]+"[.,?]'
+# extends: existence
+# message: "Commas and periods go inside quotation marks."
+# link: 'https://developers.google.com/style/quotation-marks'
+# level: error
+# nonword: true
+# tokens:
+#   - '"[^"]+"[.,?]'

--- a/.github/styles/Google/Quotes.yml
+++ b/.github/styles/Google/Quotes.yml
@@ -1,7 +1,6 @@
-# extends: existence
-# message: "Commas and periods go inside quotation marks."
-# link: 'https://developers.google.com/style/quotation-marks'
-# level: error
-# nonword: true
-# tokens:
-#   - '"[^"]+"[.,?]'
+extends: existence
+message: "Commas and periods go inside quotation marks."
+link: 'https://developers.google.com/style/quotation-marks'
+level: error
+nonword: true
+tokens:


### PR DESCRIPTION
Armory follows international (British) style of putting punctuation outside of quotes


