### PR TITLE
Update(knownissues): 403 error removed and AuthZ

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-0.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-0.md
@@ -54,8 +54,6 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 
 {{< include "known-issues/ki-app-eng-acct-auth.md" >}}
 
-{{< include "known-issues/ki-403-permission-err.md" >}}
-
 {{< include "known-issues/ki-spel-expr-art-binding.md" >}}
 
 {{< include "known-issues/ki-pipelines-as-code-gh-comments.md" >}}

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-1.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-1.md
@@ -52,8 +52,6 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 
 {{< include "known-issues/ki-app-eng-acct-auth.md" >}}
 
-{{< include "known-issues/ki-403-permission-err.md" >}}
-
 {{< include "known-issues/ki-spel-expr-art-binding.md" >}}
 
 {{< include "known-issues/ki-pipelines-as-code-gh-comments.md" >}}

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-2.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-2.md
@@ -52,8 +52,6 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 
 {{< include "known-issues/ki-app-eng-acct-auth.md" >}}
 
-{{< include "known-issues/ki-403-permission-err.md" >}}
-
 {{< include "known-issues/ki-spel-expr-art-binding.md" >}}
 
 {{< include "known-issues/ki-pipelines-as-code-gh-comments.md" >}}
@@ -74,7 +72,7 @@ Trigger Spinnaker pipelines natively when pull requests are opened in BitBucket 
 
 ### Terraform template fix
 
-Armory fixed an issue with SpEL expression failures appearing while using Terraformer to serialize data from a Terraform Plan execution. With this feature flag fix enabled, you will be able to use the Terraform template file provider. Please open a support ticket if you need this fix. 
+Armory fixed an issue with SpEL expression failures appearing while using Terraformer to serialize data from a Terraform Plan execution. With this feature flag fix enabled, you will be able to use the Terraform template file provider. Please open a support ticket if you need this fix.
 
 
 ## Highlighted updates

--- a/content/en/includes/known-issues/ki-403-permission-err.md
+++ b/content/en/includes/known-issues/ki-403-permission-err.md
@@ -1,3 +1,0 @@
-### 403 and permission errors when upgrading to 2.28.x+
-
-Some users are reporting 403 and permission errors when upgrading to 2.28.x. Please reference this support article - [403 and permission errors when Upgrading to 2.28.x+ ](https://support.armory.io/support?id=kb_article_view&sysparm_article=KB0010662&sys_kb_id=794f06ae1bda5550ec88b8c2cc4bcb67&spa=1) for more information.

--- a/content/en/includes/known-issues/ki-empty-roles.md
+++ b/content/en/includes/known-issues/ki-empty-roles.md
@@ -1,9 +1,10 @@
-### When Auth Z is enabled, Access Denied on deployments using accounts that have empty permissions
+#### When Auth Z is enabled, Access Denied on deployments using accounts that have empty permissions
 
 Users report that when attempting to use FIAT-defined User Accounts/Service Accounts/Service Principals that have empty permissions or roles, they receive an `Exception: Access denied to account ***` message. For example, `Exception: Access denied to account aws`. This is contrary to expected behavior in Spinnaker/Armory Continuous Deployment.
 
 **Workaround**:
 
 Users can add roles to the accounts in FIAT that are affected, even "dummy" roles. 
+Customers can use the following KB article to locate the user accounts, service accounts, or service principals, affected  https://support.armory.io/support?id=kb_article_view&sysparm_article=KB0010748
 
 **Affected versions**: Armory CD 2.28.x

--- a/content/en/includes/known-issues/ki-empty-roles.md
+++ b/content/en/includes/known-issues/ki-empty-roles.md
@@ -4,7 +4,8 @@ Users report that when attempting to use FIAT-defined User Accounts/Service Acco
 
 **Workaround**:
 
-Users can add roles to the accounts in FIAT that are affected, even "dummy" roles. 
-Customers can use the following KB article to locate the user accounts, service accounts, or service principals, affected  https://support.armory.io/support?id=kb_article_view&sysparm_article=KB0010748
+Users can add roles to the accounts in FIAT that are affected, even "dummy" roles.
+
+See the [How to Audit for Empty Roles in FIAT using Redis/MySQL](https://support.armory.io/support?id=kb_article_view&sysparm_article=KB0010748) KB article for how to locate affected user accounts, service accounts, or service principals.
 
 **Affected versions**: Armory CD 2.28.x


### PR DESCRIPTION
Added remediation steps that customers can use to discover Empty roles.

403 permissions were removed as the root cause was that the customer made changes that they did not account for.

FYi @aimeeu , I removed that known issue but didn't make changes to the release notes that may have referred to it yet.  Not sure if that will break things.  

Resolves Jira: [BOB-30836]

[BOB-30836]: https://armory.atlassian.net/browse/BOB-30836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ