### PR TITLE
chore(release): add release notes for 2.28.3

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-3.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-3.md
@@ -1,0 +1,194 @@
+---
+title: v2.28.3 Armory Release (OSS Spinnaker™ v1.28.4)
+toc_hide: true
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+date: 2023-01-26
+description: >
+  Release notes for Armory Enterprise v2.28.3
+---
+
+## 2023/01/26 Release Notes
+
+> Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a previous working version and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory 2.28.3, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker Community Contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.28.4](https://www.spinnaker.io/changelogs/1.28.4-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+Here's the BOM for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 66e1a26166ed649ebfb0ad6b0ac830924d2d6df2
+    version: 2.28.3
+  deck:
+    commit: dd17c153eaf117ab7990c11182a6bdc887d020f9
+    version: 2.28.3
+  dinghy:
+    commit: c4ed5b19dbcfefe8dea14cdff7df9a8ab540eba3
+    version: 2.28.3
+  echo:
+    commit: 53bebfd6900b3de124dde043a00d164aa2e50773
+    version: 2.28.3
+  fiat:
+    commit: 48c8759b0878fd1b86b91dae9ee288afcf03dd39
+    version: 2.28.3
+  front50:
+    commit: fab8841982330e7537629c9f24f41205cd5863fd
+    version: 2.28.3
+  gate:
+    commit: 65bdd30238312bbca2dce613825eda7ae88f1dfa
+    version: 2.28.3
+  igor:
+    commit: 61ce26babfcd0bdf62872c24e707ca5b5371a381
+    version: 2.28.3
+  kayenta:
+    commit: 0333b9ed6153acfc090edcfa38e3514439e2863c
+    version: 2.28.3
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 76fe72a46566bb404eb4db4c842ecb0775c546bf
+    version: 2.28.3
+  rosco:
+    commit: 945f21dec252da7dd2e00c8d23a1687aa3b9841a
+    version: 2.28.3
+  terraformer:
+    commit: 3764e523e17dfdd4cf309dc2bd7c13d9b804f309
+    version: 2.28.3
+timestamp: "2023-01-20 19:07:29"
+version: 2.28.3
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Kayenta - 2.28.2...2.28.3
+
+  - fix(kayenta-integration-tests): update dynatrace tenant to qso00828 (backport #376) (#377)
+  - chore(cd): update base service version to kayenta:2022.12.05.19.06.46.release-1.28.x (#374)
+
+#### Armory Gate - 2.28.2...2.28.3
+
+
+#### Armory Rosco - 2.28.2...2.28.3
+
+
+#### Armory Igor - 2.28.2...2.28.3
+
+
+#### Armory Orca - 2.28.2...2.28.3
+
+
+#### Terraformer™ - 2.28.2...2.28.3
+
+  - Fixes builds with golint being dead until were on a newer golang (#491) (#495)
+  - feat(gcloud): Bump to latest gcloud sdk & adds the GKE Auth plugin (#490) (#493)
+
+#### Armory Deck - 2.28.2...2.28.3
+
+
+#### Armory Clouddriver - 2.28.2...2.28.3
+
+  - feat(google): Updated google cloud SDK to support GKE >1.26 (#769) (#772)
+  - chore(cd): update base service version to clouddriver:2023.01.20.18.13.55.release-1.28.x (#779)
+
+#### Dinghy™ - 2.28.2...2.28.3
+
+
+#### Armory Echo - 2.28.2...2.28.3
+
+  - chore(cd): update base service version to echo:2022.12.14.15.47.22.release-1.28.x (#516)
+  - chore(cd): update base service version to echo:2023.01.20.14.47.47.release-1.28.x (#527)
+
+#### Armory Fiat - 2.28.2...2.28.3
+
+
+#### Armory Front50 - 2.28.2...2.28.3
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Kayenta - 1.28.4
+
+  - fix(security): Bump commons-text for CVE-2022-42889 (#911) (#914)
+  - chore(dependencies): Autobump spinnakerGradleVersion (#917) (#921)
+  - chore(dependencies): Autobump orcaVersion (#923)
+
+#### Spinnaker Gate - 1.28.4
+
+
+#### Spinnaker Rosco - 1.28.4
+
+
+#### Spinnaker Igor - 1.28.4
+
+
+#### Spinnaker Orca - 1.28.4
+
+
+#### Spinnaker Deck - 1.28.4
+
+
+#### Spinnaker Clouddriver - 1.28.4
+
+  - chore(dependencies): pin version of com.github.tomakehurst:wiremock (#5845) (#5858)
+
+#### Spinnaker Echo - 1.28.4
+
+  - feat(event): Add circuit breaker for events sending. (#1233) (#1237)
+  - fix: The circuit breaker feature for sending events to telemetry endpoint is hidden under a required feature flag property (#1241) (#1245)
+
+#### Spinnaker Fiat - 1.28.4
+
+
+#### Spinnaker Front50 - 1.28.4
+
+

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-3.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-3.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.3 Armory Release (OSS Spinnaker™ v1.28.4)
 toc_hide: true
-version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+version: 02.28.3
 date: 2023-01-26
 description: >
   Release notes for Armory Enterprise v2.28.3
@@ -22,12 +22,66 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 ## Breaking changes
 <!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
 
+{{< include "breaking-changes/bc-orca-rdbms-configured-utf8.md" >}}
+
+{{< include "breaking-changes/bc-kubectl-120.md" >}}
+
+{{< include "breaking-changes/bc-dinghy-slack.md" >}}
+
+{{< include "breaking-changes/bc-java-tls-mysql.md" >}}
+
+{{< include "breaking-changes/bc-k8s-version-pre1-16.md" >}}
+
+{{< include "breaking-changes/bc-k8s-infra-buttons.md" >}}
+
+{{< include "breaking-changes/bc-git-artifact-constraint.md" >}}
+
+{{< include "breaking-changes/bc-hal-deprecation.md" >}}
+
+{{< include "breaking-changes/bc-plugin-compatibility-2-28-0.md" >}}
+
+
 > Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
 
 ## Known issues
 <!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
 
-## Highlighted updates
+{{< include "known-issues/ki-empty-roles.md" >}}
+
+{{< include "known-issues/ki-app-attr-not-configured.md" >}}
+
+{{< include "known-issues/ki-app-eng-acct-auth.md" >}}
+
+{{< include "known-issues/ki-spel-expr-art-binding.md" >}}
+
+{{< include "known-issues/ki-pipelines-as-code-gh-comments.md" >}}
+
+{{< include "known-issues/ki-secrets-and-spring-cloud.md" >}}
+
+## Early access
+
+### Pipelines as Code multi-branch enhancement
+
+Now you can configure Pipelines as Code to pull Dinghy files from multiple branches on the same repo. Cut out the tedious task of managing multiple repos; have a single repo for Spinnaker application pipelines. See [Multiple branches]({{< ref "continuous-deployment/armory-admin/dinghy-enable#multiple-branches" >}}) for how to enable and configure this feature.
+
+### Enhanced BitBucket Server pull request handling
+
+Trigger Spinnaker pipelines natively when pull requests are opened in BitBucket with newly added events including PR opened, deleted, and declined. See [Triggering pipelines with Bitbucket Server](https://spinnaker.io/docs/guides/user/pipeline/triggers/bitbucket-events/) in the Spinnaker docs for details.
+
+<!-- Spinnaker docs PR https://github.com/spinnaker/spinnaker.io/pull/285 -->
+
+### Terraform template fix
+
+Armory fixed an issue with SpEL expression failures appearing while using Terraformer to serialize data from a Terraform Plan execution. With this feature flag fix enabled, you will be able to use the Terraform template file provider. Please open a support ticket if you need this fix.
+
+### Automatically Cancel Jenkins Jobs
+
+You now have the ability to cancel triggered Jenkins jobs when a Spinnaker pipeline is canceled, giving you more control over your full Jenkins workflow. Learn more about Jenkins + Spinnaker in this [documentation](https://spinnaker.io/changelogs/1.29.0-changelog/#orca) .
+
+## Fixed Issues
+
+* Updated google cloud SDK to support GKE >1.26
+* Bumped commons-text to address CVE-2022-42889
 
 <!--
 Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:

--- a/payload.json
+++ b/payload.json
@@ -1,153 +1,164 @@
 {
   "armoryServices": [
     {
-      "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Armory Fiat",
-      "previousVersion": "2.27.6-rc1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Armory Orca",
-      "previousVersion": "2.27.6-rc1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Armory Front50",
-      "previousVersion": "2.27.6-rc1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
+      "commitMessages": [
+        "fix(kayenta-integration-tests): update dynatrace tenant to qso00828 (backport #376) (#377)",
+        "chore(cd): update base service version to kayenta:2022.12.05.19.06.46.release-1.28.x (#374)"
+      ],
+      "currentVersion": "2.28.3",
       "name": "Armory Kayenta",
-      "previousVersion": "2.27.6-rc1"
+      "previousVersion": "2.28.2"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Armory Rosco",
-      "previousVersion": "2.27.6-rc1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
+      "currentVersion": "2.28.3",
       "name": "Armory Gate",
-      "previousVersion": "2.27.6-rc1"
+      "previousVersion": "2.28.2"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
+      "currentVersion": "2.28.3",
+      "name": "Armory Rosco",
+      "previousVersion": "2.28.2"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.3",
       "name": "Armory Igor",
-      "previousVersion": "2.27.6-rc1"
+      "previousVersion": "2.28.2"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Dinghy™",
-      "previousVersion": "2.27.6-rc1"
+      "currentVersion": "2.28.3",
+      "name": "Armory Orca",
+      "previousVersion": "2.28.2"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to echo:2022.12.14.15.47.16.release-1.27.x (#515)",
-        "chore(cd): update base service version to echo:2023.01.20.14.47.33.release-1.27.x (#525)"
+        "Fixes builds with golint being dead until were on a newer golang (#491) (#495)",
+        "feat(gcloud): Bump to latest gcloud sdk & adds the GKE Auth plugin (#490) (#493)"
       ],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Armory Echo",
-      "previousVersion": "2.27.6-rc1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
+      "currentVersion": "2.28.3",
       "name": "Terraformer™",
-      "previousVersion": "2.27.6-rc1"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to clouddriver:2023.01.20.18.19.32.release-1.27.x (#781)"
-      ],
-      "currentVersion": "2.27.6-rc2",
-      "name": "Armory Clouddriver",
-      "previousVersion": "2.27.6-rc1"
+      "previousVersion": "2.28.2"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.27.6-rc2",
+      "currentVersion": "2.28.3",
       "name": "Armory Deck",
-      "previousVersion": "2.27.6-rc1"
+      "previousVersion": "2.28.2"
+    },
+    {
+      "commitMessages": [
+        "feat(google): Updated google cloud SDK to support GKE >1.26 (#769) (#772)",
+        "chore(cd): update base service version to clouddriver:2023.01.20.18.13.55.release-1.28.x (#779)"
+      ],
+      "currentVersion": "2.28.3",
+      "name": "Armory Clouddriver",
+      "previousVersion": "2.28.2"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.3",
+      "name": "Dinghy™",
+      "previousVersion": "2.28.2"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to echo:2022.12.14.15.47.22.release-1.28.x (#516)",
+        "chore(cd): update base service version to echo:2023.01.20.14.47.47.release-1.28.x (#527)"
+      ],
+      "currentVersion": "2.28.3",
+      "name": "Armory Echo",
+      "previousVersion": "2.28.2"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.3",
+      "name": "Armory Fiat",
+      "previousVersion": "2.28.2"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.3",
+      "name": "Armory Front50",
+      "previousVersion": "2.28.2"
     }
   ],
-  "armoryVersion": "2.27.6-rc2",
+  "armoryVersion": "2.28.3",
   "ossServices": [
     {
-      "commitMessages": [],
-      "currentVersion": "1.27.3",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.27.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.27.3",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.27.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.27.3",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.27.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.27.3",
+      "commitMessages": [
+        "fix(security): Bump commons-text for CVE-2022-42889 (#911) (#914)",
+        "chore(dependencies): Autobump spinnakerGradleVersion (#917) (#921)",
+        "chore(dependencies): Autobump orcaVersion (#923)"
+      ],
+      "currentVersion": "1.28.4",
       "name": "Spinnaker Kayenta",
-      "previousVersion": "1.27.0"
+      "previousVersion": "1.28.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.27.3",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.27.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.27.3",
+      "currentVersion": "1.28.4",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.27.0"
+      "previousVersion": "1.28.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.27.3",
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.4",
       "name": "Spinnaker Igor",
-      "previousVersion": "1.27.0"
-    },
-    {
-      "commitMessages": [
-        "feat(event): Add circuit breaker for events sending. (#1233) (#1238)",
-        "fix: The circuit breaker feature for sending events to telemetry endpoint is hidden under a required feature flag property (#1241) (#1244)"
-      ],
-      "currentVersion": "1.27.3",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.27.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): pin version of com.github.tomakehurst:wiremock (#5845) (#5857)"
-      ],
-      "currentVersion": "1.27.3",
-      "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.27.0"
+      "previousVersion": "1.28.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.27.3",
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.4",
       "name": "Spinnaker Deck",
-      "previousVersion": "1.27.0"
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): pin version of com.github.tomakehurst:wiremock (#5845) (#5858)"
+      ],
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Clouddriver",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [
+        "feat(event): Add circuit breaker for events sending. (#1233) (#1237)",
+        "fix: The circuit breaker feature for sending events to telemetry endpoint is hidden under a required feature flag property (#1241) (#1245)"
+      ],
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.28.0"
     }
   ],
-  "ossVersion": "1.27.3",
-  "prerelease": true,
+  "ossVersion": "1.28.4",
+  "prerelease": false,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -160,40 +171,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "60eafebf9875071709e3d8ec53d2729a197574f1",
-        "version": "2.27.6-rc2"
+        "commit": "66e1a26166ed649ebfb0ad6b0ac830924d2d6df2",
+        "version": "2.28.3"
       },
       "deck": {
-        "commit": "0802cbb92aa32eb6b387b5a6e54db14843fc6f31",
-        "version": "2.27.6-rc2"
+        "commit": "dd17c153eaf117ab7990c11182a6bdc887d020f9",
+        "version": "2.28.3"
       },
       "dinghy": {
-        "commit": "ca161395d61ae5e93d1f9ecfbb503b68c2b54bc5",
-        "version": "2.27.6-rc2"
+        "commit": "c4ed5b19dbcfefe8dea14cdff7df9a8ab540eba3",
+        "version": "2.28.3"
       },
       "echo": {
-        "commit": "3204f90e951562245c62430d863617c34b3a0826",
-        "version": "2.27.6-rc2"
+        "commit": "53bebfd6900b3de124dde043a00d164aa2e50773",
+        "version": "2.28.3"
       },
       "fiat": {
-        "commit": "b3ca6748d2377454949420613e7912748ea00b52",
-        "version": "2.27.6-rc2"
+        "commit": "48c8759b0878fd1b86b91dae9ee288afcf03dd39",
+        "version": "2.28.3"
       },
       "front50": {
-        "commit": "5e1fe36c4b8df29cc9cb4d7af581a44b0ca44e59",
-        "version": "2.27.6-rc2"
+        "commit": "fab8841982330e7537629c9f24f41205cd5863fd",
+        "version": "2.28.3"
       },
       "gate": {
-        "commit": "adf9732bc7b3c8df48b21b86ef9783efcadec78b",
-        "version": "2.27.6-rc2"
+        "commit": "65bdd30238312bbca2dce613825eda7ae88f1dfa",
+        "version": "2.28.3"
       },
       "igor": {
-        "commit": "9e2d7946da19c803eb0bd12e888c5119528a364c",
-        "version": "2.27.6-rc2"
+        "commit": "61ce26babfcd0bdf62872c24e707ca5b5371a381",
+        "version": "2.28.3"
       },
       "kayenta": {
-        "commit": "5a1efcefddfe78f37550f5bee723570e3737ce04",
-        "version": "2.27.6-rc2"
+        "commit": "0333b9ed6153acfc090edcfa38e3514439e2863c",
+        "version": "2.28.3"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -204,19 +215,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "fa3449f0202512534382d2d2a0431f25f4f408c5",
-        "version": "2.27.6-rc2"
+        "commit": "76fe72a46566bb404eb4db4c842ecb0775c546bf",
+        "version": "2.28.3"
       },
       "rosco": {
-        "commit": "f4164fdcfa275b62e0c0fefbe26b5cbd845c543d",
-        "version": "2.27.6-rc2"
+        "commit": "945f21dec252da7dd2e00c8d23a1687aa3b9841a",
+        "version": "2.28.3"
       },
       "terraformer": {
-        "commit": "f845ba2fc760c46b98794a10c32cc2b713c7c9e0",
-        "version": "2.27.6-rc2"
+        "commit": "3764e523e17dfdd4cf309dc2bd7c13d9b804f309",
+        "version": "2.28.3"
       }
     },
-    "timestamp": "2023-01-20 20:04:33",
-    "version": "2.27.6-rc2"
+    "timestamp": "2023-01-20 19:07:29",
+    "version": "2.28.3"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [
        "fix(kayenta-integration-tests): update dynatrace tenant to qso00828 (backport #376) (#377)",
        "chore(cd): update base service version to kayenta:2022.12.05.19.06.46.release-1.28.x (#374)"
      ],
      "currentVersion": "2.28.3",
      "name": "Armory Kayenta",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Gate",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Rosco",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Igor",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Orca",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [
        "Fixes builds with golint being dead until were on a newer golang (#491) (#495)",
        "feat(gcloud): Bump to latest gcloud sdk & adds the GKE Auth plugin (#490) (#493)"
      ],
      "currentVersion": "2.28.3",
      "name": "Terraformer™",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Deck",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [
        "feat(google): Updated google cloud SDK to support GKE >1.26 (#769) (#772)",
        "chore(cd): update base service version to clouddriver:2023.01.20.18.13.55.release-1.28.x (#779)"
      ],
      "currentVersion": "2.28.3",
      "name": "Armory Clouddriver",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Dinghy™",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to echo:2022.12.14.15.47.22.release-1.28.x (#516)",
        "chore(cd): update base service version to echo:2023.01.20.14.47.47.release-1.28.x (#527)"
      ],
      "currentVersion": "2.28.3",
      "name": "Armory Echo",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Fiat",
      "previousVersion": "2.28.2"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.3",
      "name": "Armory Front50",
      "previousVersion": "2.28.2"
    }
  ],
  "armoryVersion": "2.28.3",
  "ossServices": [
    {
      "commitMessages": [
        "fix(security): Bump commons-text for CVE-2022-42889 (#911) (#914)",
        "chore(dependencies): Autobump spinnakerGradleVersion (#917) (#921)",
        "chore(dependencies): Autobump orcaVersion (#923)"
      ],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Gate",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Igor",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Orca",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Deck",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): pin version of com.github.tomakehurst:wiremock (#5845) (#5858)"
      ],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "feat(event): Add circuit breaker for events sending. (#1233) (#1237)",
        "fix: The circuit breaker feature for sending events to telemetry endpoint is hidden under a required feature flag property (#1241) (#1245)"
      ],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Echo",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Front50",
      "previousVersion": "1.28.0"
    }
  ],
  "ossVersion": "1.28.4",
  "prerelease": false,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "66e1a26166ed649ebfb0ad6b0ac830924d2d6df2",
        "version": "2.28.3"
      },
      "deck": {
        "commit": "dd17c153eaf117ab7990c11182a6bdc887d020f9",
        "version": "2.28.3"
      },
      "dinghy": {
        "commit": "c4ed5b19dbcfefe8dea14cdff7df9a8ab540eba3",
        "version": "2.28.3"
      },
      "echo": {
        "commit": "53bebfd6900b3de124dde043a00d164aa2e50773",
        "version": "2.28.3"
      },
      "fiat": {
        "commit": "48c8759b0878fd1b86b91dae9ee288afcf03dd39",
        "version": "2.28.3"
      },
      "front50": {
        "commit": "fab8841982330e7537629c9f24f41205cd5863fd",
        "version": "2.28.3"
      },
      "gate": {
        "commit": "65bdd30238312bbca2dce613825eda7ae88f1dfa",
        "version": "2.28.3"
      },
      "igor": {
        "commit": "61ce26babfcd0bdf62872c24e707ca5b5371a381",
        "version": "2.28.3"
      },
      "kayenta": {
        "commit": "0333b9ed6153acfc090edcfa38e3514439e2863c",
        "version": "2.28.3"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "76fe72a46566bb404eb4db4c842ecb0775c546bf",
        "version": "2.28.3"
      },
      "rosco": {
        "commit": "945f21dec252da7dd2e00c8d23a1687aa3b9841a",
        "version": "2.28.3"
      },
      "terraformer": {
        "commit": "3764e523e17dfdd4cf309dc2bd7c13d9b804f309",
        "version": "2.28.3"
      }
    },
    "timestamp": "2023-01-20 19:07:29",
    "version": "2.28.3"
  }
}
```