### PR TITLE
feat(pe): update PE docs based on user validation testing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -231,6 +231,15 @@ agent_plug_latest_spin-1="2.27.x (1.27.x)"
 agent_plug_latest="0.11.31"
 agent_plug_latest_spin="2.28.x (1.28.x)"
 
+# Policy Engine plugin versions
+[params.policy-engine-plugin]
+pe_plug_latest="0.3.0"
+pe_plug_latest_spin="2.28.x (1.28.x)"
+pe_plug_latest-1="0.2.2"
+pe_plug_latest_spin-1="2.27.x (1.27.x)"
+pe_plug_latest-2="0.1.6"
+pe_plug_latest_spin-2="2.26.x (1.26.x)"
+
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -184,47 +184,70 @@ spec:
 
 You have three options for enabling the Policy Engine plugin:
 
-1. [Armory Operator or Spinnaker Operator](#armory-operator-or-spinnaker-operator)
-1. [Spinnaker services local files](#spinnaker-services-local-files) (Spinnaker only)
-1. [Halyard](#halyard) (Spinnaker only)
+1. Armory Operator or Spinnaker Operator
+1. Spinnaker services local files
+1. Halyard
 
-### Armory Operator or Spinnaker Operator              
+{{< tabs name="Install Instructions" >}}
 
-You can enable the Policy Engine plugin using the Armory Operator or the Spinnaker Operator and the sample manifest, which uses Kustomize and is in the [spinnaker-kustomize-patches repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml).
+{{% tabbody name="Spinnaker Operator" %}}
 
-* The sample manifest is for the Armory Operator and Armory CD. If you are using the Spinnaker Operator and Spinnaker, you must replace the `apiVersion` value "spinnaker.armory.io/" with "spinnaker.io/". For example:
+You can enable the Policy Engine plugin using the the Spinnaker Operator and
+the sample manifest, which uses Kustomize and is in the
+[spinnaker-kustomize-patches
+repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml):
+
+<details><summary>Show the manifest</summary>
+{{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
+</details>
+
+{{% alert title="Warning" color="warning" %}}
+The sample manifest is for the Armory Operator and Armory CD. When using the
+Spinnaker Operator and Spinnaker, you must replace the `apiVersion` value
+"spinnaker.armory.io/" with "spinnaker.io/". For example:
 
   * Armory Operator: `apiVersion: spinnaker.armory.io/v1alpha2`
   * Spinnaker Operator: `apiVersion: spinnaker.io/v1alpha2`
+{{% /alert%}}
 
-* In the `gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version` entry, make sure to replace the version number listed after `&version` with the version of the plugin you want to use. For example, if you are using Armory CD 2.27.x (Spinnaker 1.27.x), you would use version 0.2.1:
+This patch uses [YAML
+anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values)
+to ensure that plugin versions are set correctly throughout Spinnaker's config.
+In the
+`gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version`
+entry, make sure to replace the version number listed after `&version` with the
+version of the plugin you want to use. Refer to the [supported
+versions](#supported-versions) section to determine the correct plugin version
+for your installation.
 
-   {{< prism lang="yaml" line="12" >}}
-   gate:
-     spinnaker:
-        extensibility:
-         plugins:
-           Armory.PolicyEngine:
-              enabled: true
-         deck-proxy:
-           enabled: true
-          plugins:
-             Armory.PolicyEngine:
-                enabled: true
-                version: &version 0.2.1
-   {{< /prism>}}
+{{% /tabbody %}}
 
-If you don't use Kustomize, you should manually patch your `SpinSvc` config with the entries in the sample manifest.
+{{% tabbody name="Armory Operator" %}}
+
+You can enable the Policy Engine plugin using the the Spinnaker Operator and
+the sample manifest, which uses Kustomize and is in the
+[spinnaker-kustomize-patches
+repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml):
 
 <details><summary>Show the manifest</summary>
-{{< github repo="armory/spinnaker-kustomize-patches" file="/armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
-</details>
+{{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
+</details><br />
 
-#### Timeout settings
+This patch uses [YAML
+anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values)
+to ensure that plugin versions are set correctly throughout Spinnaker's config.
+In the
+`gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version`
+entry, make sure to replace the version number listed after `&version` with the
+version of the plugin you want to use. Refer to the [supported
+versions](#supported-versions) section to determine the correct plugin version
+for your installation.
 
-You can configure the amount of time that the Policy Engine waits for a response from your OPA server. If you have network or latency issues, increasing the timeout can make Policy Engine more resilient. Use `spec.spinnakerConfig.profiles.spinnaker.armory.policyEngine.opa.timeoutSeconds` to set the timeout in seconds. The default timeout is 10 seconds if you omit the config.
 
-### Spinnaker services local files
+{{% /tabbody %}}
+
+
+{{% tabbody name="Local Config" %}}
 
 {{% alert title="Warning" color="warning" %}}
 The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in the service’s local profile.
@@ -253,8 +276,9 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You
     {{< /prism >}}
 
 1. Save your files and apply your changes by running `hal deploy apply`.
+{{% /tabbody %}}
 
-### Halyard
+{{% tabbody name="Halyard" %}}
 
 {{% alert title="Warning" color="warning" %}}
 The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to each service. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.
@@ -295,7 +319,17 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. Whe
    {{< /prism >}}
 
 1. Apply the changes by executing `hal deploy apply`. 
+{{% /tabbody %}}
 
+{{< /tabs >}}
+
+#### Timeout settings
+
+You can configure the amount of time that the Policy Engine waits for a response from your OPA server. If you have network or latency issues, increasing the timeout can make Policy Engine more resilient. Use `spec.spinnakerConfig.profiles.spinnaker.armory.policyEngine.opa.timeoutSeconds` to set the timeout in seconds. The default timeout is 10 seconds if you omit the config.
+
+## {{% heading "nextSteps" %}}
+
+* {{< linkWithTitle "continuous-deployment/plugin-guide/policy-engine/use/_index.md" >}}
 
 ## Release notes
 
@@ -317,8 +351,4 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. Whe
 * 0.0.19 - Adds forced authentication feature and fixes NPE bug
 * 0.0.17 - Initial plugin release
 
-</details>
-
-## {{% heading "nextSteps" %}}
-
-* {{< linkWithTitle "continuous-deployment/plugin-guide/policy-engine/use/_index.md" >}}
+</details><br />

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -1,8 +1,8 @@
 ---
-title: Enable the Policy Engine in Armory Continuous Deployment or Spinnaker
+title: Install and Use the Armory Policy Engine in Spinnaker or Armory Continuous Deployment
 linkTitle: Policy Engine
 description: >
-   The Policy Engine enforces save time, runtime, and user interaction policies that you create for Armory Continuous Deployment or Spinnaker. This section includes instructions on how to configure and deploy an Open Policy Agent server and the Policy Engine as well as release notes, usage, and example policies.
+   The Policy Engine enforces save time, runtime, and user interaction policies that you create for Spinnaker or Armory Continuous Deployment. This section includes instructions for configuring and deploying an Open Policy Agent server and the Policy Engine as well as release notes, usage, and example policies.
 no_list: true
 aliases:
    - /continuous-deployment/armory-admin/policy-engine/
@@ -21,7 +21,7 @@ The Armory Policy Engine is a proprietary feature for Armory Continuous Deployme
 * **Runtime validation** - Validate deployments as a pipeline is executing. Tasks with no policies are not validated.
 * **Entitlements using API Authorization** - Enforce restrictions on who can perform certain actions. Note that if you enable policies for API authorization, you must configure who can make API calls or else the API service (Gate) rejects all API calls.
 
-> If no policies are configured for these policy checks, all actions are allowed.
+>If no policies are configured for these policy checks, all actions are allowed.
 
 At a high level, adding policies for the Policy Engine to use is a two-step process:
 
@@ -180,13 +180,12 @@ spec:
 </pre></code>
 </details>
 
-## Enable the Policy Engine plugin
+## Install the Policy Engine plugin
 
-You have three options for enabling the Policy Engine plugin:
+You have the following options for installing the Policy Engine plugin:
 
-1. Armory Operator or Spinnaker Operator
-1. Spinnaker services local files
-1. Halyard
+* **Spinnaker**: Spinnaker Operator, Local Config, or Halyard
+* **Armory CD**: Armory Operator
 
 {{< tabpane text=true right=true >}}
 
@@ -194,10 +193,7 @@ You have three options for enabling the Policy Engine plugin:
 
 {{% tab header="Spinnaker Operator" %}}
 
-You can enable the Policy Engine plugin using the the Spinnaker Operator and
-the sample manifest, which uses Kustomize and is in the
-[spinnaker-kustomize-patches
-repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml):
+You can install the Policy Engine plugin using the the Spinnaker Operator and the sample manifest, which uses Kustomize and is in the [spinnaker-kustomize-patches repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml).
 
 <details><summary><strong>Show the manifest</strong></summary>
 {{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
@@ -207,48 +203,32 @@ repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/ar
   * **Armory Operator: `apiVersion: spinnaker.armory.io/v1alpha2`**
   * **Spinnaker Operator: `apiVersion: spinnaker.io/v1alpha2`**
 
-This patch uses [YAML
-anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values)
-to ensure that plugin versions are set correctly throughout Spinnaker's config.
-In the
-`gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version`
-entry, make sure to replace the version number listed after `&version` with the
-version of the plugin you want to use. Refer to the [supported
-versions](#supported-versions) section to determine the correct plugin version
-for your installation.
+This patch uses [YAML anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values) to ensure that plugin versions are set correctly throughout Spinnaker's config. In the `gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version` entry, make sure to replace the version number listed after `&version` with the version of the plugin you want to use. Refer to the [supported versions](#supported-versions) section to determine the correct plugin version for your installation.
+
+Apply the manifest using `kubectl`.
 
 {{% /tab %}}
 
 {{% tab header="Armory Operator" %}}
 
-You can enable the Policy Engine plugin using the the Spinnaker Operator and
-the sample manifest, which uses Kustomize and is in the
-[spinnaker-kustomize-patches
-repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml):
+You can enable the Policy Engine plugin using the the Armory Operator and the sample manifest, which uses Kustomize and is in the [spinnaker-kustomize-patches repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml).
 
 <details><summary><strong>Show the manifest</strong></summary>
 {{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
 </details><br />
 
-This patch uses [YAML
-anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values)
-to ensure that plugin versions are set correctly throughout Spinnaker's config.
-In the
-`gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version`
-entry, make sure to replace the version number listed after `&version` with the
-version of the plugin you want to use. Refer to the [supported
-versions](#supported-versions) section to determine the correct plugin version
-for your installation.
+This patch uses [YAML anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values) to ensure that plugin versions are set correctly throughout Armory CD's config. In the `gate.spinnaker.extensibility.deck-proxy.plugins.Armory.PolicyEngine.version` entry, make sure to replace the version number listed after `&version` with the version of the plugin you want to use. Refer to the [supported
+versions](#supported-versions) section to determine the correct plugin version for your installation.
 
-
+Apply the manifest using `kubectl`.
 {{% /tab %}}
 
 
 {{% tab header="Local Config" %}}
 
-**Warning: The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in the service’s local profile.**
+**Warning: The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in each impacted service’s local profile.**
 
-The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You must create or update the extended service's local profile in the same directory as the other Halyard configuration files. This is usually `~/.hal/default/profiles` on the machine where Halyard is running.
+The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You should create or update the extended service's local profile in the same directory as the other Halyard configuration files. This is usually `~/.hal/default/profiles` on the machine where Halyard is running.
 
 1. Add the following to `gate-local.yml`, `orca-local.yml`, `front50-local.yml`, and `clouddriver.yml`:
 
@@ -275,7 +255,9 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You
 
 {{% tab header="Halyard" %}}
 
-**Warning: the Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to each service. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.**
+**Warning: When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to all services, not just the ones the plugin is for. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.**
+
+The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. 
 
 1. Add the plugins repository
 

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -335,6 +335,7 @@ You can configure the amount of time that the Policy Engine waits for a response
 
 <details><summary>Show the release notes</summary>
 
+* 0.3.0 - Fixed bug in 1.28 & 2.28 that prevented proper deserialization of Instant values when validating policies
 * 0.2.2 - Fixed bug for createApplication button with Spinnaker 1.28, to be included in 2.28 release
 * 0.2.1 - Fixed bug with the projects tab on deck for Armory Continuous Deployment 2.27.1 and later
 * 0.2.0 - Update plugin to be compatible with Armory Continuous Deployment 2.27.0 and later.

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -184,8 +184,16 @@ spec:
 
 You have the following options for installing the Policy Engine plugin:
 
-* **Spinnaker**: Spinnaker Operator, Local Config, or Halyard
 * **Armory CD**: Armory Operator
+* **Spinnaker**: Spinnaker Operator, Local Config, or Halyard
+
+{{% alert color="warning" title="A note about installing plugins in Spinnaker" %}}
+When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to all services, not just the ones the plugin is for. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.
+
+The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid every Spinnaker service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, follow the **Local Config** installation method, in which you configure the plugin in each extended service’s local profile.
+
+The Spinnaker Operator and Armory Operator add configuration only to extended services.
+{{% /alert %}}
 
 {{< tabpane text=true right=true >}}
 
@@ -226,8 +234,6 @@ Apply the manifest using `kubectl`.
 
 {{% tab header="Local Config" %}}
 
-**Warning: The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in each impacted service’s local profile.**
-
 The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You should create or update the extended service's local profile in the same directory as the other Halyard configuration files. This is usually `~/.hal/default/profiles` on the machine where Halyard is running.
 
 1. Add the following to `gate-local.yml`, `orca-local.yml`, `front50-local.yml`, and `clouddriver.yml`:
@@ -254,10 +260,6 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You
 {{% /tab %}}
 
 {{% tab header="Halyard" %}}
-
-**Warning: When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to all services, not just the ones the plugin is for. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.**
-
-The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. 
 
 1. Add the plugins repository
 

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -60,7 +60,7 @@ If you want to use ConfigMaps for OPA policies, you can use the following manife
 * The manifest deploys the OPA server to a namespace called `opa`.
 * The OPA server uses `"--require-policy-label=true"`. This configures the OPA server to look for a specific label so that it does not check all ConfigMaps for new policies. For information about how to apply the relevant label to your policy ConfigMaps, see [Add the policy to your OPA server]({{< ref "/continuous-deployment/plugin-guide/policy-engine/use#step-2-add-the-policy-to-your-opa-server" >}}).
 
-<details><summary>Show the manifest</summary>
+<details><summary><strong>Show the manifest</strong></summary>
 <code><pre>
 ---
 apiVersion: v1
@@ -188,27 +188,26 @@ You have three options for enabling the Policy Engine plugin:
 1. Spinnaker services local files
 1. Halyard
 
-{{< tabs name="Install Instructions" >}}
+{{< tabpane text=true right=true >}}
 
-{{% tabbody name="Spinnaker Operator" %}}
+{{% tab header="**Install Method**:" disabled=true /%}}
+
+{{% tab header="Spinnaker Operator" %}}
 
 You can enable the Policy Engine plugin using the the Spinnaker Operator and
 the sample manifest, which uses Kustomize and is in the
 [spinnaker-kustomize-patches
 repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml):
 
-<details><summary>Show the manifest</summary>
+<details><summary><strong>Show the manifest</strong></summary>
 {{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
 </details>
 
-{{% alert title="Warning" color="warning" %}}
-The sample manifest is for the Armory Operator and Armory CD. When using the
-Spinnaker Operator and Spinnaker, you must replace the `apiVersion` value
-"spinnaker.armory.io/" with "spinnaker.io/". For example:
-
+{{< alert title="Note" color="primary" >}}
+The sample manifest is for the Armory Operator and Armory CD. When using the Spinnaker Operator and Spinnaker, you must replace the `apiVersion` value "spinnaker.armory.io/" with "spinnaker.io/". For example:
   * Armory Operator: `apiVersion: spinnaker.armory.io/v1alpha2`
   * Spinnaker Operator: `apiVersion: spinnaker.io/v1alpha2`
-{{% /alert%}}
+{{< /alert >}}
 
 This patch uses [YAML
 anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values)
@@ -220,16 +219,16 @@ version of the plugin you want to use. Refer to the [supported
 versions](#supported-versions) section to determine the correct plugin version
 for your installation.
 
-{{% /tabbody %}}
+{{% /tab %}}
 
-{{% tabbody name="Armory Operator" %}}
+{{% tab header="Armory Operator" %}}
 
 You can enable the Policy Engine plugin using the the Spinnaker Operator and
 the sample manifest, which uses Kustomize and is in the
 [spinnaker-kustomize-patches
 repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/armory/patch-policy-engine-plugin.yml):
 
-<details><summary>Show the manifest</summary>
+<details><summary><strong>Show the manifest</strong></summary>
 {{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
 </details><br />
 
@@ -244,10 +243,10 @@ versions](#supported-versions) section to determine the correct plugin version
 for your installation.
 
 
-{{% /tabbody %}}
+{{% /tab %}}
 
 
-{{% tabbody name="Local Config" %}}
+{{% tab header="Local Config" %}}
 
 {{% alert title="Warning" color="warning" %}}
 The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in the service’s local profile.
@@ -276,9 +275,9 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You
     {{< /prism >}}
 
 1. Save your files and apply your changes by running `hal deploy apply`.
-{{% /tabbody %}}
+{{% /tab %}}
 
-{{% tabbody name="Halyard" %}}
+{{% tab header="Halyard" %}}
 
 {{% alert title="Warning" color="warning" %}}
 The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to each service. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.
@@ -319,9 +318,9 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. Whe
    {{< /prism >}}
 
 1. Apply the changes by executing `hal deploy apply`. 
-{{% /tabbody %}}
+{{% /tab %}}
 
-{{< /tabs >}}
+{{< /tabpane >}}
 
 #### Timeout settings
 

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -201,13 +201,11 @@ repository](https://github.com/armory/spinnaker-kustomize-patches/blob/master/ar
 
 <details><summary><strong>Show the manifest</strong></summary>
 {{< github repo="armory/spinnaker-kustomize-patches" file="armory/patch-policy-engine-plugin.yml" lang="yaml" options="" >}}
-</details>
+</details><br />
 
-{{< alert title="Note" color="primary" >}}
-The sample manifest is for the Armory Operator and Armory CD. When using the Spinnaker Operator and Spinnaker, you must replace the `apiVersion` value "spinnaker.armory.io/" with "spinnaker.io/". For example:
-  * Armory Operator: `apiVersion: spinnaker.armory.io/v1alpha2`
-  * Spinnaker Operator: `apiVersion: spinnaker.io/v1alpha2`
-{{< /alert >}}
+**Note: The sample manifest is for the Armory Operator and Armory CD. When using the Spinnaker Operator and Spinnaker, you must replace the `apiVersion` value "spinnaker.armory.io/" with "spinnaker.io/". For example:**
+  * **Armory Operator: `apiVersion: spinnaker.armory.io/v1alpha2`**
+  * **Spinnaker Operator: `apiVersion: spinnaker.io/v1alpha2`**
 
 This patch uses [YAML
 anchors](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#yaml-anchors-and-aliases-sharing-variable-values)
@@ -248,9 +246,7 @@ for your installation.
 
 {{% tab header="Local Config" %}}
 
-{{% alert title="Warning" color="warning" %}}
-The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in the service’s local profile.
-{{% /alert %}}
+**Warning: The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. To avoid each service restarting and downloading the plugin, do not add the plugin using Halyard. Instead, configure the plugin in the service’s local profile.**
 
 The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You must create or update the extended service's local profile in the same directory as the other Halyard configuration files. This is usually `~/.hal/default/profiles` on the machine where Halyard is running.
 
@@ -279,9 +275,7 @@ The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. You
 
 {{% tab header="Halyard" %}}
 
-{{% alert title="Warning" color="warning" %}}
-The Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to each service. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.
-{{% /alert %}}
+**Warning: the Policy Engine plugin extends Orca, Gate, Front50, Clouddriver, and Deck. When Halyard adds a plugin to a Spinnaker installation, it adds the plugin repository information to each service. This means that when you restart Spinnaker, each service restarts, downloads the plugin, and checks if an extension exists for that service. Each service restarting is not ideal for large Spinnaker installations due to service restart times. Clouddriver can take an hour or more to restart if you have many accounts configured.**
 
 1. Add the plugins repository
 

--- a/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
+++ b/content/en/continuous-deployment/plugin-guide/policy-engine/_index.md
@@ -2,7 +2,7 @@
 title: Enable the Policy Engine in Armory Continuous Deployment or Spinnaker
 linkTitle: Policy Engine
 description: >
-   Enable the Policy Engine to enforce policies on your Armory Continuous Deployment or Spinnaker instance. This page includes information about how to deploy and configure an Open Policy Agent server, which the Policy Engine requires. With the Policy Engine enabled, you can write policies that the Policy Engine enforces during save time, runtime validation, or when a user interacts with Armory CD or Spinnaker.
+   The Policy Engine enforces save time, runtime, and user interaction policies that you create for Armory Continuous Deployment or Spinnaker. This section includes instructions on how to configure and deploy an Open Policy Agent server and the Policy Engine as well as release notes, usage, and example policies.
 no_list: true
 aliases:
    - /continuous-deployment/armory-admin/policy-engine/

--- a/content/en/includes/policy-engine/plugin-compat-matrix.md
+++ b/content/en/includes/policy-engine/plugin-compat-matrix.md
@@ -1,5 +1,5 @@
 | Armory CD (Spinnaker) Version | Armory Policy Agent Plugin Version    |
 |:-------------------------- |:------------------------------ |
-| 2.28.x (1.28.x) | 0.2.2 |
-| 2.27.x (1.27.x) | 0.2.1 | 
-| 2.26.x (1.26.x) | 0.1.6 | 
+| {{< param policy-engine-plugin.pe_plug_latest_spin >}} | {{< param policy-engine-plugin.pe_plug_latest >}} |
+| {{< param policy-engine-plugin.pe_plug_latest_spin-1 >}} | {{< param policy-engine-plugin.pe_plug_latest-1 >}} | 
+| {{< param policy-engine-plugin.pe_plug_latest_spin-2 >}} |  {{< param policy-engine-plugin.pe_plug_latest-2 >}} | 


### PR DESCRIPTION
Introduces the following changes:
- Adds parameters for Policy Engine versions that should be updated on release
- Adds tabbed display for install instructions to reduce confusion when choosing an install path
- Introduces manifest earlier in install process
- Adds release note for 0.3.0

Deploy preview:   https://deploy-preview-1865--armory-docs.netlify.app/continuous-deployment/plugin-guide/policy-engine/#install-the-policy-engine-plugin