### PR TITLE
chore(release): add release notes for 2.28.5-rc2

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-28-5-rc2.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-28-5-rc2.md
@@ -1,0 +1,200 @@
+---
+title: v2.28.5-rc2 Armory Release (OSS Spinnaker™ v1.28.4)
+toc_hide: true
+date: 2023-02-21
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+description: >
+  Release notes for Armory Enterprise v2.28.5-rc2. A beta release is not meant for installation in production environments.
+
+---
+
+## 2023/02/21 Release Notes
+
+## Disclaimer
+
+This pre-release software is to allow limited access to test or beta versions of the Armory services (“Services”) and to provide feedback and comments to Armory regarding the use of such Services. By using Services, you agree to be bound by the terms and conditions set forth herein.
+
+Your Feedback is important and we welcome any feedback, analysis, suggestions and comments (including, but not limited to, bug reports and test results) (collectively, “Feedback”) regarding the Services. Any Feedback you provide will become the property of Armory and you agree that Armory may use or otherwise exploit all or part of your feedback or any derivative thereof in any manner without any further remuneration, compensation or credit to you. You represent and warrant that any Feedback which is provided by you hereunder is original work made solely by you and does not infringe any third party intellectual property rights.
+
+Any Feedback provided to Armory shall be considered Armory Confidential Information and shall be covered by any confidentiality agreements between you and Armory.
+
+You acknowledge that you are using the Services on a purely voluntary basis, as a means of assisting, and in consideration of the opportunity to assist Armory to use, implement, and understand various facets of the Services. You acknowledge and agree that nothing herein or in your voluntary submission of Feedback creates any employment relationship between you and Armory.
+
+Armory may, in its sole discretion, at any time, terminate or discontinue all or your access to the Services. You acknowledge and agree that all such decisions by Armory are final and Armory will have no liability with respect to such decisions.
+
+YOUR USE OF THE SERVICES IS AT YOUR OWN RISK. THE SERVICES, THE ARMORY TOOLS AND THE CONTENT ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. ARMORY AND ITS LICENSORS MAKE NO REPRESENTATION, WARRANTY, OR GUARANTY AS TO THE RELIABILITY, TIMELINESS, QUALITY, SUITABILITY, TRUTH, AVAILABILITY, ACCURACY OR COMPLETENESS OF THE SERVICES, THE ARMORY TOOLS OR ANY CONTENT. ARMORY EXPRESSLY DISCLAIMS ON ITS OWN BEHALF AND ON BEHALF OF ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS ANY AND ALL WARRANTIES INCLUDING, WITHOUT LIMITATION (A) THE USE OF THE SERVICES OR THE ARMORY TOOLS WILL BE TIMELY, UNINTERRUPTED OR ERROR-FREE OR OPERATE IN COMBINATION WITH ANY OTHER HARDWARE, SOFTWARE, SYSTEM OR DATA, (B) THE SERVICES AND THE ARMORY TOOLS AND/OR THEIR QUALITY WILL MEET CUSTOMER”S REQUIREMENTS OR EXPECTATIONS, (C) ANY CONTENT WILL BE ACCURATE OR RELIABLE, (D) ERRORS OR DEFECTS WILL BE CORRECTED, OR (E) THE SERVICES, THE ARMORY TOOLS OR THE SERVER(S) THAT MAKE THE SERVICES AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. CUSTOMER AGREES THAT ARMORY SHALL NOT BE RESPONSIBLE FOR THE AVAILABILITY OR ACTS OR OMISSIONS OF ANY THIRD PARTY, INCLUDING ANY THIRD-PARTY APPLICATION OR PRODUCT, AND ARMORY HEREBY DISCLAIMS ANY AND ALL LIABILITY IN CONNECTION WITH SUCH THIRD PARTIES.
+
+IN NO EVENT SHALL ARMORY, ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS BE LIABLE UNDER THIS AGREEMENT FOR ANY CONSEQUENTIAL, SPECIAL, LOST PROFITS, INDIRECT OR OTHER DAMAGES, INCLUDING BUT NOT LIMITED TO LOST PROFITS, LOSS OF BUSINESS, COST OF COVER WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF ARMORY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. IN ANY EVENT, ARMORY, ITS EMPLOYEES’, AGENTS’, ATTORNEYS’, CONSULTANTS’ OR CONTRACTORS’ AGGREGATE LIABILITY UNDER THIS AGREEMENT FOR ANY CLAIM SHALL BE STRICTLY LIMITED TO $100.00. SOME STATES DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+
+You acknowledge that Armory has provided the Services in reliance upon the limitations of liability set forth herein and that the same is an essential basis of the bargain between the parties.
+
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory 2.28.5-rc2, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker Community Contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.28.4](https://www.spinnaker.io/changelogs/1.28.4-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+Here's the BOM for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 35dd10a5a2a262c4456d54e2bffd3db4a434fbf3
+    version: 2.28.5-rc2
+  deck:
+    commit: bd57caffcdc86c9fb7560e958ba89141372d5d3d
+    version: 2.28.5-rc2
+  dinghy:
+    commit: c4ed5b19dbcfefe8dea14cdff7df9a8ab540eba3
+    version: 2.28.5-rc2
+  echo:
+    commit: 53bebfd6900b3de124dde043a00d164aa2e50773
+    version: 2.28.5-rc2
+  fiat:
+    commit: e5eb6837f87b029248e3068119e05acbb85cf22c
+    version: 2.28.5-rc2
+  front50:
+    commit: fab8841982330e7537629c9f24f41205cd5863fd
+    version: 2.28.5-rc2
+  gate:
+    commit: 65bdd30238312bbca2dce613825eda7ae88f1dfa
+    version: 2.28.5-rc2
+  igor:
+    commit: 61ce26babfcd0bdf62872c24e707ca5b5371a381
+    version: 2.28.5-rc2
+  kayenta:
+    commit: 0333b9ed6153acfc090edcfa38e3514439e2863c
+    version: 2.28.5-rc2
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 37f945ea4ca839267ddd95e436912ef8f82d559e
+    version: 2.28.5-rc2
+  rosco:
+    commit: 945f21dec252da7dd2e00c8d23a1687aa3b9841a
+    version: 2.28.5-rc2
+  terraformer:
+    commit: 3764e523e17dfdd4cf309dc2bd7c13d9b804f309
+    version: 2.28.5-rc2
+timestamp: "2023-02-20 19:15:24"
+version: 2.28.5-rc2
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Front50 - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Igor - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Kayenta - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Rosco - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Deck - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Fiat - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Orca - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Dinghy™ - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Echo - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Clouddriver - 2.28.5-rc1...2.28.5-rc2
+
+  - chore(cd): update base service version to clouddriver:2023.02.15.21.39.25.release-1.28.x (#799)
+
+#### Terraformer™ - 2.28.5-rc1...2.28.5-rc2
+
+
+#### Armory Gate - 2.28.5-rc1...2.28.5-rc2
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Front50 - 1.28.4
+
+
+#### Spinnaker Igor - 1.28.4
+
+
+#### Spinnaker Kayenta - 1.28.4
+
+
+#### Spinnaker Rosco - 1.28.4
+
+
+#### Spinnaker Deck - 1.28.4
+
+
+#### Spinnaker Fiat - 1.28.4
+
+
+#### Spinnaker Orca - 1.28.4
+
+
+#### Spinnaker Echo - 1.28.4
+
+
+#### Spinnaker Clouddriver - 1.28.4
+
+  - fix(kubernetes): Revert to using the dockerImage Artifact Replacer for cronjobs (#5876) (#5877)
+
+#### Spinnaker Gate - 1.28.4
+
+

--- a/payload.json
+++ b/payload.json
@@ -2,150 +2,142 @@
   "armoryServices": [
     {
       "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Front50",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.28.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Igor",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
+      "currentVersion": "2.28.5-rc2",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.28.5-rc1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Rosco",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
     },
     {
-      "commitMessages": [
-        "chore(cd): update base deck version to 2023.0.0-20230203161351.release-1.28.x (#1294)"
-      ],
-      "currentVersion": "2.28.5-rc1",
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Deck",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
     },
     {
-      "commitMessages": [
-        "chore(cd): update base service version to fiat:2023.02.07.18.42.05.release-1.28.x (#430)"
-      ],
-      "currentVersion": "2.28.5-rc1",
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Fiat",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
+      "name": "Armory Orca",
+      "previousVersion": "2.28.5-rc1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
+      "name": "Dinghy™",
+      "previousVersion": "2.28.5-rc1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
+      "name": "Armory Echo",
+      "previousVersion": "2.28.5-rc1"
     },
     {
       "commitMessages": [
-        "chore(cd): update base orca version to 2023.02.03.15.05.56.release-1.28.x (#583)"
+        "chore(cd): update base service version to clouddriver:2023.02.15.21.39.25.release-1.28.x (#799)"
       ],
-      "currentVersion": "2.28.5-rc1",
-      "name": "Armory Orca",
-      "previousVersion": "2.28.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
-      "name": "Dinghy™",
-      "previousVersion": "2.28.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
-      "name": "Armory Echo",
-      "previousVersion": "2.28.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
-      "name": "Terraformer™",
-      "previousVersion": "2.28.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Clouddriver",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.28.5-rc1",
+      "currentVersion": "2.28.5-rc2",
+      "name": "Terraformer™",
+      "previousVersion": "2.28.5-rc1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.5-rc2",
       "name": "Armory Gate",
-      "previousVersion": "2.28.4"
+      "previousVersion": "2.28.5-rc1"
     }
   ],
-  "armoryVersion": "2.28.5-rc1",
+  "armoryVersion": "2.28.5-rc2",
   "ossServices": [
     {
       "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Front50",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.28.4",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
       "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Igor",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.4",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.28.4"
     },
     {
       "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Rosco",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
-      "commitMessages": [
-        "fix(timeout): Added feature flag for rollback timeout ui input. (backport #9937) (#9940)"
-      ],
+      "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Deck",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
-      "commitMessages": [
-        "fix: Should fix the deletion of permissions when resource name is uppercase (backport #1012) (#1013)"
-      ],
+      "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Fiat",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
-      "commitMessages": [
-        "fix(timeout): Added feature flag for rollback timeout ui input. (backport #4383) (#4385)"
-      ],
+      "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Orca",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
       "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Echo",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
-      "commitMessages": [],
+      "commitMessages": [
+        "fix(kubernetes): Revert to using the dockerImage Artifact Replacer for cronjobs (#5876) (#5877)"
+      ],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     },
     {
       "commitMessages": [],
       "currentVersion": "1.28.4",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.28.4"
     }
   ],
   "ossVersion": "1.28.4",
@@ -162,40 +154,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "d52c864053d77a05eef806926591427bc866b529",
-        "version": "2.28.5-rc1"
+        "commit": "35dd10a5a2a262c4456d54e2bffd3db4a434fbf3",
+        "version": "2.28.5-rc2"
       },
       "deck": {
         "commit": "bd57caffcdc86c9fb7560e958ba89141372d5d3d",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "dinghy": {
         "commit": "c4ed5b19dbcfefe8dea14cdff7df9a8ab540eba3",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "echo": {
         "commit": "53bebfd6900b3de124dde043a00d164aa2e50773",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "fiat": {
         "commit": "e5eb6837f87b029248e3068119e05acbb85cf22c",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "front50": {
         "commit": "fab8841982330e7537629c9f24f41205cd5863fd",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "gate": {
         "commit": "65bdd30238312bbca2dce613825eda7ae88f1dfa",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "igor": {
         "commit": "61ce26babfcd0bdf62872c24e707ca5b5371a381",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "kayenta": {
         "commit": "0333b9ed6153acfc090edcfa38e3514439e2863c",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -207,18 +199,18 @@
       },
       "orca": {
         "commit": "37f945ea4ca839267ddd95e436912ef8f82d559e",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "rosco": {
         "commit": "945f21dec252da7dd2e00c8d23a1687aa3b9841a",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       },
       "terraformer": {
         "commit": "3764e523e17dfdd4cf309dc2bd7c13d9b804f309",
-        "version": "2.28.5-rc1"
+        "version": "2.28.5-rc2"
       }
     },
-    "timestamp": "2023-02-08 15:59:28",
-    "version": "2.28.5-rc1"
+    "timestamp": "2023-02-20 19:15:24",
+    "version": "2.28.5-rc2"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Front50",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Igor",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Kayenta",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Rosco",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Deck",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Fiat",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Orca",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Dinghy™",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Echo",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2023.02.15.21.39.25.release-1.28.x (#799)"
      ],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Clouddriver",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Terraformer™",
      "previousVersion": "2.28.5-rc1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.5-rc2",
      "name": "Armory Gate",
      "previousVersion": "2.28.5-rc1"
    }
  ],
  "armoryVersion": "2.28.5-rc2",
  "ossServices": [
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Front50",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Igor",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Deck",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Orca",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Echo",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [
        "fix(kubernetes): Revert to using the dockerImage Artifact Replacer for cronjobs (#5876) (#5877)"
      ],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.28.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.4",
      "name": "Spinnaker Gate",
      "previousVersion": "1.28.4"
    }
  ],
  "ossVersion": "1.28.4",
  "prerelease": true,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "35dd10a5a2a262c4456d54e2bffd3db4a434fbf3",
        "version": "2.28.5-rc2"
      },
      "deck": {
        "commit": "bd57caffcdc86c9fb7560e958ba89141372d5d3d",
        "version": "2.28.5-rc2"
      },
      "dinghy": {
        "commit": "c4ed5b19dbcfefe8dea14cdff7df9a8ab540eba3",
        "version": "2.28.5-rc2"
      },
      "echo": {
        "commit": "53bebfd6900b3de124dde043a00d164aa2e50773",
        "version": "2.28.5-rc2"
      },
      "fiat": {
        "commit": "e5eb6837f87b029248e3068119e05acbb85cf22c",
        "version": "2.28.5-rc2"
      },
      "front50": {
        "commit": "fab8841982330e7537629c9f24f41205cd5863fd",
        "version": "2.28.5-rc2"
      },
      "gate": {
        "commit": "65bdd30238312bbca2dce613825eda7ae88f1dfa",
        "version": "2.28.5-rc2"
      },
      "igor": {
        "commit": "61ce26babfcd0bdf62872c24e707ca5b5371a381",
        "version": "2.28.5-rc2"
      },
      "kayenta": {
        "commit": "0333b9ed6153acfc090edcfa38e3514439e2863c",
        "version": "2.28.5-rc2"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "37f945ea4ca839267ddd95e436912ef8f82d559e",
        "version": "2.28.5-rc2"
      },
      "rosco": {
        "commit": "945f21dec252da7dd2e00c8d23a1687aa3b9841a",
        "version": "2.28.5-rc2"
      },
      "terraformer": {
        "commit": "3764e523e17dfdd4cf309dc2bd7c13d9b804f309",
        "version": "2.28.5-rc2"
      }
    },
    "timestamp": "2023-02-20 19:15:24",
    "version": "2.28.5-rc2"
  }
}
```