### PR TITLE
docs(redirects): add redirect for very old URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,42 @@
   GO_VERSION = "1.18"
 
 # section redirects
+[[redirects]]
+  from = "/docs/release-notes/rn-armory-agent/*"
+  to = "/plugins/scale-agent/release-notes/:splat"
+
+[[redirects]]
+  from = "/armory-enterprise/release-notes/rn-armory-agent/*"
+  to = "/plugins/scale-agent/release-notes/:splat"
+
+[[redirects]]
+  from = "/continuous-deployment/release-notes/rn-armory-agent/*"
+  to = "/scale-agent/release-notes/:splat"
+
+[[redirects]]
+  from = "/armory-enterprise/armory-agent/*"
+  to = "/plugins/scale-agent/:splat"
+
+[[redirects]]
+  from = "/continuous-deployment/armory-agent/*"
+  to = "/plugins/scale-agent/:splat"
+
+[[redirects]]
+  from = "/scale-agent/*"
+  to = "/plugins/scale-agent/:splat"
+
+[[redirects]]
+  from = "/cd-as-a-service/plugin-spinnaker/"
+  to = "/plugins/cdaas-spinnaker/"
+  force = true # ensure this always redirects because cdaas-spinnaker does exist (for users clicking web search result link)
+
+[[redirects]]
+  from = "/continuous-deployment/armory-admin/policy-engine/policy-engine-use/*"
+  to = "/plugins/policy-engine/use/:splat"
+  
+[[redirects]]
+  from = "/continuous-deployment/plugin-guide/*"
+  to = "/plugins/:splat"
 
 [[redirects]]
   from = "/docs/*"
@@ -24,31 +60,6 @@
 [[redirects]]
   from = "/armory-cdaas/*"
   to = "/cd-as-a-service/"
-
-[[redirects]]
-  from = "/armory-enterprise/release-notes/rn-armory-agent/*"
-  to = "/scale-agent/release-notes/:splat"
-
-[[redirects]]
-  from = "/cd-as-a-service/plugin-spinnaker/"
-  to = "/plugins/cdaas-spinnaker/"
-  force = true # ensure this always redirects because cdaas-spinnaker does exist (for users clicking web search result link)
-
-[[redirects]]
-  from = "/continuous-deployment/armory-admin/policy-engine/policy-engine-use/*"
-  to = "/plugins/policy-engine/use/:splat"
-
-[[redirects]]
-  from = "/armory-enterprise/armory-agent/*"
-  to = "/plugins/scale-agent/"
-
-[[redirects]]
-  from = "/scale-agent/*"
-  to = "/plugins/scale-agent/:splat"
-  
-[[redirects]]
-  from = "/continuous-deployment/plugin-guide/*"
-  to = "/plugins/:splat"
 
 # https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,14 @@
   to = "/plugins/scale-agent/release-notes/:splat"
 
 [[redirects]]
+  from = "/docs/release-notes/rn-armory-agent/agent-plugin/*"
+  to = "/plugins/scale-agent/release-notes/agent-plugin/:splat"
+
+[[redirects]]
+  from = "/docs/release-notes/rn-armory-agent/agent-service/*"
+  to = "/plugins/scale-agent/release-notes/agent-service/:splat"
+
+[[redirects]]
   from = "/armory-enterprise/release-notes/rn-armory-agent/*"
   to = "/plugins/scale-agent/release-notes/:splat"
 


### PR DESCRIPTION
/docs/release-notes/rn-armory-agent/*

test:

- [x] /docs/release-notes/rn-armory-agent/agent-service/ -> /plugins/scale-agent/release-notes/agent-service/
- [x]  /docs/release-notes/rn-armory-agent/agent-plugin/ -> /plugins/scale-agent/release-notes/agent-plugin/
- [x] /docs/release-notes/rn-armory-agent/agent-service/agent-service-v-1-0-38/ -> /plugins/scale-agent/release-notes/agent-service/agent-service-v-1-0-38/