### PR TITLE
docs(fix): fix typo in linktitle

### DIFF
--- a/content/en/cd-as-a-service/tasks/networking/monitor-agents.md
+++ b/content/en/cd-as-a-service/tasks/networking/monitor-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Monitor Installed Remote Network Agents
-linktitle: Montor Agents
+linktitle: Monitor Agents
 
 description: >
   Monitor Remote Network Agents using the Armory CD-as-a-Service console.


### PR DESCRIPTION
"Montor" to "Monitor"

Report by Parth in Slack
