### PR TITLE
chore(release): add release notes for 2.27.8

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-8.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-8.md
@@ -1,0 +1,216 @@
+---
+title: v2.27.8 Armory Release (OSS Spinnaker™ v1.27.0)
+toc_hide: true
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+date: 2023-04-18
+description: >
+  Release notes for Armory Continuous Deployment v2.27.8
+---
+
+## 2023/04/18 Release Notes
+
+> Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a previous working version and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory 2.27.8, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker Community Contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.27.0](https://www.spinnaker.io/changelogs/1.27.0-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+Here's the BOM for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: a3347ca5e207273abe60ca48e98bf494e6d8d359
+    version: 2.27.8
+  deck:
+    commit: 57f5d89f15f6f9ddc5c3f4554e4b0a3bb6f03e2b
+    version: 2.27.8
+  dinghy:
+    commit: d9146416b57d6c7008cfe6323ba3b0e6527181d0
+    version: 2.27.8
+  echo:
+    commit: b220bcaa01be72ca2c4489203bc5ceb53d83e8af
+    version: 2.27.8
+  fiat:
+    commit: e23c8b8a65463100c7075b1aacc140a0e0dc5216
+    version: 2.27.8
+  front50:
+    commit: 5e1fe36c4b8df29cc9cb4d7af581a44b0ca44e59
+    version: 2.27.8
+  gate:
+    commit: 9cd1a1174ee0bd19577ffdbd6aa11ad432a67082
+    version: 2.27.8
+  igor:
+    commit: ebfdd8b8068fe1ff1ba3e7c25cd2b0c0fa803bd9
+    version: 2.27.8
+  kayenta:
+    commit: 822b3339a4dbbccb9a135c102d8ba1ff199d49ec
+    version: 2.27.8
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 2aa5a723767a5972a3b31278a1dcf5af32e66b99
+    version: 2.27.8
+  rosco:
+    commit: 8b94ccff09fe762d896df9052e4199af6dd9b666
+    version: 2.27.8
+  terraformer:
+    commit: 736ece67b4a52a612262cbe844d1edd3ad176d19
+    version: 2.27.8
+timestamp: "2023-03-22 15:19:48"
+version: 2.27.8
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Fiat - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to fiat:2023.02.28.17.42.01.release-1.27.x (#439)
+  - chore(cd): update base service version to fiat:2023.03.16.17.57.42.release-1.27.x (#447)
+
+#### Armory Igor - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to igor:2023.02.28.17.45.14.release-1.27.x (#417)
+  - chore(cd): update base service version to igor:2023.02.28.19.16.26.release-1.27.x (#418)
+
+#### Armory Gate - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to gate:2023.02.28.17.43.36.release-1.27.x (#520)
+  - chore(cd): update base service version to gate:2023.02.28.19.18.24.release-1.27.x (#521)
+
+#### Armory Orca - 2.27.7...2.27.8
+
+  - chore(cd): update base orca version to 2023.02.28.17.51.52.release-1.27.x (#594)
+  - chore(cd): update base orca version to 2023.02.28.19.23.37.release-1.27.x (#595)
+
+#### Armory Kayenta - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to kayenta:2023.02.28.21.15.17.release-1.27.x (#392)
+
+#### Terraformer™ - 2.27.7...2.27.8
+
+  - chore(alpine): Update alpine version (backport #497) (#498)
+
+#### Armory Rosco - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to rosco:2023.02.28.17.41.47.release-1.27.x (#498)
+
+#### Armory Deck - 2.27.7...2.27.8
+
+  - chore(alpine): Upgrade alpine version (backport #1302) (#1304)
+
+#### Armory Clouddriver - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to clouddriver:2023.02.22.23.00.31.release-1.27.x (#805)
+  - chore(cd): update base service version to clouddriver:2023.02.28.18.06.11.release-1.27.x (#809)
+  - chore(cd): update base service version to clouddriver:2023.02.28.19.32.28.release-1.27.x (#811)
+  - chore(cd): update base service version to clouddriver:2023.03.21.20.22.35.release-1.27.x (#822)
+
+#### Armory Echo - 2.27.7...2.27.8
+
+  - chore(cd): update base service version to echo:2023.02.28.17.42.44.release-1.27.x (#540)
+  - chore(cd): update base service version to echo:2023.02.28.19.16.55.release-1.27.x (#541)
+
+#### Dinghy™ - 2.27.7...2.27.8
+
+  - chore(dependencies): bumped oss dinghy version to 20230201103309-a73a68c80965 (#479)
+  - chore(alpine): Upgrade alpine version (backport #481) (#483)
+
+#### Armory Front50 - 2.27.7...2.27.8
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Fiat - 1.27.0
+
+  - chore(dependencies): Autobump korkVersion (#1024)
+  - fix(logs): Redacted secret data in logs. (#1029) (#1032)
+
+#### Spinnaker Igor - 1.27.0
+
+  - chore(dependencies): Autobump korkVersion (#1091)
+  - chore(dependencies): Autobump fiatVersion (#1092)
+
+#### Spinnaker Gate - 1.27.0
+
+  - chore(dependencies): Autobump korkVersion (#1621)
+  - chore(dependencies): Autobump fiatVersion (#1622)
+
+#### Spinnaker Orca - 1.27.0
+
+  - chore(dependencies): Autobump korkVersion (#4401)
+  - chore(dependencies): Autobump fiatVersion (#4402)
+
+#### Spinnaker Kayenta - 1.27.0
+
+  - chore(dependencies): Autobump orcaVersion (#934)
+
+#### Spinnaker Rosco - 1.27.0
+
+  - chore(dependencies): Autobump korkVersion (#957)
+
+#### Spinnaker Deck - 1.27.0
+
+
+#### Spinnaker Clouddriver - 1.27.0
+
+  - fix(ecr): Two credentials with same accountId confuses EcrImageProvider with different regions (#5885) (#5886)
+  - chore(dependencies): Autobump korkVersion (#5894)
+  - chore(dependencies): Autobump fiatVersion (#5895)
+  - fix(core): Renamed a query parameter for template tags (#5906) (#5907)
+
+#### Spinnaker Echo - 1.27.0
+
+  - chore(dependencies): Autobump korkVersion (#1259)
+  - chore(dependencies): Autobump fiatVersion (#1260)
+
+#### Spinnaker Front50 - 1.27.0
+
+

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-8.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-27-8.md
@@ -1,7 +1,7 @@
 ---
 title: v2.27.8 Armory Release (OSS Spinnaker™ v1.27.0)
 toc_hide: true
-version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+version: 02.27.08
 date: 2023-04-18
 description: >
   Release notes for Armory Continuous Deployment v2.27.8
@@ -22,12 +22,70 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 ## Breaking changes
 <!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
 
+{{< include "breaking-changes/bc-k8s-version-pre1-16.md" >}}
+{{< include "breaking-changes/bc-k8s-infra-buttons.md" >}}
+{{< include "breaking-changes/bc-hal-deprecation.md" >}}
+{{< include "breaking-changes/bc-plug-version-lts-227.md" >}}
+
 > Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
 
 ## Known issues
 <!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
 
-## Highlighted updates
+### Dinghy fails to start with SQL enabled
+Known bug with the java version
+
+```
+enabledTLSProtocols=TLSv1.2
+  
+```
+needs to be added as an argument on newer JVMs.
+
+{{< include "known-issues/ki-artifact-binding-spel.md" >}}
+{{< include "known-issues/ki-dinghy-gh-notifications.md" >}}
+{{< include "known-issues/ki-secrets-and-spring-cloud.md" >}}
+{{< include "known-issues/ki-pipelines-as-code-gh-comments.md" >}}
+
+## Early Access Features
+
+### Dynamic Rollback Timeout
+
+To make the dynamic timeout available, you need to enable the feature flag in Orca and Deck.
+
+On the Orca side, the feature flag overrides the default value rollback timeout - 5min - with a UI input from the user.
+
+```
+{
+  "yaml,"
+   "orca.yml,"
+  "rollback:"
+  "timeout:"
+    "enabled: true"
+}
+```
+
+On the Deck side, the feature flag enhances the Rollback Cluster stage UI with timeout input.
+
+`window.spinnakerSettings.feature.dynamicRollbackTimeout = true;`
+
+The default is used if there is no value set in the UI.
+
+### Pipelines as Code multi-branch enhancement
+
+Now you can configure Pipelines as Code to pull Dinghy files from multiple branches in the same repo. Cut out the tedious task of managing multiple repos; have a single repo for Spinnaker application pipelines. See [Multiple branches]({{< ref "continuous-deployment/armory-admin/dinghy-enable#multiple-branches" >}}) for how to enable and configure this feature.
+
+### Automatically Cancel Jenkins Jobs
+
+You now have the ability to cancel triggered Jenkins jobs when a Spinnaker pipeline is canceled, giving you more control over your full Jenkins workflow. Learn more about Jenkins + Spinnaker in this [documentation](https://spinnaker.io/changelogs/1.29.0-changelog/#orca).
+
+
+## Fixes
+
+* Clouddriver: Two credentials with same accountId confuses EcrImageProvider with different regions
+* Clouddriver: Renamed a query parameter for template tags
+* Alpine updates for Deck, Dinghy, and Terraformer
+
+
 
 <!--
 Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:

--- a/payload.json
+++ b/payload.json
@@ -2,206 +2,197 @@
   "armoryServices": [
     {
       "commitMessages": [
-        "chore(cd): update base service version to echo:2023.03.02.19.38.24.release-1.28.x (#542)",
-        "chore(cd): update base service version to echo:2023.03.02.21.17.15.release-1.28.x (#543)",
-        "chore(cd): update base service version to echo:2023.03.27.19.10.41.release-1.28.x (#550)"
+        "chore(cd): update base service version to fiat:2023.02.28.17.42.01.release-1.27.x (#439)",
+        "chore(cd): update base service version to fiat:2023.03.16.17.57.42.release-1.27.x (#447)"
       ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Echo",
-      "previousVersion": "2.28.5"
+      "currentVersion": "2.27.8",
+      "name": "Armory Fiat",
+      "previousVersion": "2.27.7"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to kayenta:2023.03.03.04.50.48.release-1.28.x (#393)"
+        "chore(cd): update base service version to igor:2023.02.28.17.45.14.release-1.27.x (#417)",
+        "chore(cd): update base service version to igor:2023.02.28.19.16.26.release-1.27.x (#418)"
       ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to igor:2023.03.02.19.40.25.release-1.28.x (#419)",
-        "chore(cd): update base service version to igor:2023.03.02.21.16.28.release-1.28.x (#420)"
-      ],
-      "currentVersion": "2.28.6-rc1",
+      "currentVersion": "2.27.8",
       "name": "Armory Igor",
-      "previousVersion": "2.28.5"
+      "previousVersion": "2.27.7"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to rosco:2023.03.02.19.37.08.release-1.28.x (#500)"
+        "chore(cd): update base service version to gate:2023.02.28.17.43.36.release-1.27.x (#520)",
+        "chore(cd): update base service version to gate:2023.02.28.19.18.24.release-1.27.x (#521)"
       ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Rosco",
-      "previousVersion": "2.28.5"
+      "currentVersion": "2.27.8",
+      "name": "Armory Gate",
+      "previousVersion": "2.27.7"
     },
     {
       "commitMessages": [
-        "chore(alpine): Update alpine version (backport #497) (#499)"
+        "chore(cd): update base orca version to 2023.02.28.17.51.52.release-1.27.x (#594)",
+        "chore(cd): update base orca version to 2023.02.28.19.23.37.release-1.27.x (#595)"
       ],
-      "currentVersion": "2.28.6-rc1",
+      "currentVersion": "2.27.8",
+      "name": "Armory Orca",
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to kayenta:2023.02.28.21.15.17.release-1.27.x (#392)"
+      ],
+      "currentVersion": "2.27.8",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(alpine): Update alpine version (backport #497) (#498)"
+      ],
+      "currentVersion": "2.27.8",
       "name": "Terraformer™",
-      "previousVersion": "2.28.5"
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to rosco:2023.02.28.17.41.47.release-1.27.x (#498)"
+      ],
+      "currentVersion": "2.27.8",
+      "name": "Armory Rosco",
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(alpine): Upgrade alpine version (backport #1302) (#1304)"
+      ],
+      "currentVersion": "2.27.8",
+      "name": "Armory Deck",
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to clouddriver:2023.02.22.23.00.31.release-1.27.x (#805)",
+        "chore(cd): update base service version to clouddriver:2023.02.28.18.06.11.release-1.27.x (#809)",
+        "chore(cd): update base service version to clouddriver:2023.02.28.19.32.28.release-1.27.x (#811)",
+        "chore(cd): update base service version to clouddriver:2023.03.21.20.22.35.release-1.27.x (#822)"
+      ],
+      "currentVersion": "2.27.8",
+      "name": "Armory Clouddriver",
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to echo:2023.02.28.17.42.44.release-1.27.x (#540)",
+        "chore(cd): update base service version to echo:2023.02.28.19.16.55.release-1.27.x (#541)"
+      ],
+      "currentVersion": "2.27.8",
+      "name": "Armory Echo",
+      "previousVersion": "2.27.7"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): bumped oss dinghy version to 20230201103309-a73a68c80965 (#479)",
+        "chore(alpine): Upgrade alpine version (backport #481) (#483)"
+      ],
+      "currentVersion": "2.27.8",
+      "name": "Dinghy™",
+      "previousVersion": "2.27.7"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.28.6-rc1",
+      "currentVersion": "2.27.8",
       "name": "Armory Front50",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to clouddriver:2023.03.02.19.57.01.release-1.28.x (#812)",
-        "chore(cd): update base service version to clouddriver:2023.03.03.02.32.42.release-1.28.x (#813)",
-        "chore(cd): update base service version to clouddriver:2023.03.21.20.21.00.release-1.28.x (#821)",
-        "chore(cd): update base service version to clouddriver:2023.03.23.14.57.28.release-1.28.x (#826)",
-        "chore(cd): update base service version to clouddriver:2023.03.27.19.24.21.release-1.28.x (#829)"
-      ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Clouddriver",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): bumped oss dinghy version to 20230201103309-a73a68c80965 (#480)",
-        "chore(alpine): Upgrade alpine version (backport #481) (#482)"
-      ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Dinghy™",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to gate:2023.03.02.19.38.56.release-1.28.x (#523)",
-        "chore(cd): update base service version to gate:2023.03.02.21.17.09.release-1.28.x (#524)",
-        "chore(cd): update base service version to gate:2023.03.27.19.10.16.release-1.28.x (#530)"
-      ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Gate",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(alpine): Upgrade alpine version (backport #1302) (#1303)"
-      ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Deck",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base orca version to 2023.03.02.19.46.59.release-1.28.x (#597)",
-        "chore(cd): update base orca version to 2023.03.02.21.24.49.release-1.28.x (#598)",
-        "chore(cd): update base orca version to 2023.03.28.15.32.53.release-1.28.x (#608)"
-      ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Orca",
-      "previousVersion": "2.28.5"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to fiat:2023.03.02.19.37.20.release-1.28.x (#441)",
-        "chore(cd): update base service version to fiat:2023.03.16.17.55.44.release-1.28.x (#446)"
-      ],
-      "currentVersion": "2.28.6-rc1",
-      "name": "Armory Fiat",
-      "previousVersion": "2.28.5"
+      "previousVersion": "2.27.7"
     }
   ],
-  "armoryVersion": "2.28.6-rc1",
+  "armoryVersion": "2.27.8",
   "ossServices": [
     {
       "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1261)",
-        "chore(dependencies): Autobump fiatVersion (#1262)",
-        "chore(dependencies): Autobump fiatVersion (#1270)"
+        "chore(dependencies): Autobump korkVersion (#1024)",
+        "fix(logs): Redacted secret data in logs. (#1029) (#1032)"
       ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump orcaVersion (#936)"
-      ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1093)",
-        "chore(dependencies): Autobump fiatVersion (#1094)"
-      ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Igor",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#959)"
-      ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#5897)",
-        "chore(dependencies): Autobump fiatVersion (#5898)",
-        "fix(core): Renamed a query parameter for template tags (#5906) (#5908)",
-        "chore(aws): Update AWS IAM Authenticator version (#5910)",
-        "chore(dependencies): Autobump fiatVersion (#5916)"
-      ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1624)",
-        "chore(dependencies): Autobump fiatVersion (#1625)",
-        "chore(dependencies): Autobump fiatVersion (#1632)"
-      ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Gate",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#4405)",
-        "chore(dependencies): Autobump fiatVersion (#4406)",
-        "chore(dependencies): Autobump fiatVersion (#4425)",
-        "Fix/blue green deploy (backport #4414) (#4419)"
-      ],
-      "currentVersion": "1.28.6",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1026)",
-        "fix(logs): Redacted secret data in logs. (#1029) (#1030)"
-      ],
-      "currentVersion": "1.28.6",
+      "currentVersion": "1.27.0",
       "name": "Spinnaker Fiat",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump korkVersion (#1091)",
+        "chore(dependencies): Autobump fiatVersion (#1092)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Igor",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump korkVersion (#1621)",
+        "chore(dependencies): Autobump fiatVersion (#1622)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Gate",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump korkVersion (#4401)",
+        "chore(dependencies): Autobump fiatVersion (#4402)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump orcaVersion (#934)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump korkVersion (#957)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "fix(ecr): Two credentials with same accountId confuses EcrImageProvider with different regions (#5885) (#5886)",
+        "chore(dependencies): Autobump korkVersion (#5894)",
+        "chore(dependencies): Autobump fiatVersion (#5895)",
+        "fix(core): Renamed a query parameter for template tags (#5906) (#5907)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Clouddriver",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump korkVersion (#1259)",
+        "chore(dependencies): Autobump fiatVersion (#1260)"
+      ],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.27.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.27.0",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.27.0"
     }
   ],
-  "ossVersion": "1.28.6",
-  "prerelease": true,
+  "ossVersion": "1.27.0",
+  "prerelease": false,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -214,40 +205,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "e3b237b6188e587b6de17922aa09841ae77f35bf",
-        "version": "2.28.6-rc1"
+        "commit": "a3347ca5e207273abe60ca48e98bf494e6d8d359",
+        "version": "2.27.8"
       },
       "deck": {
-        "commit": "c9062f5626855846a1354d274bf1bc7083a86880",
-        "version": "2.28.6-rc1"
+        "commit": "57f5d89f15f6f9ddc5c3f4554e4b0a3bb6f03e2b",
+        "version": "2.27.8"
       },
       "dinghy": {
-        "commit": "912007004f7720b418cd133301c7fb20207e1f2f",
-        "version": "2.28.6-rc1"
+        "commit": "d9146416b57d6c7008cfe6323ba3b0e6527181d0",
+        "version": "2.27.8"
       },
       "echo": {
-        "commit": "8b763d646f1a52db3a9de33acf4e7e420220c3e0",
-        "version": "2.28.6-rc1"
+        "commit": "b220bcaa01be72ca2c4489203bc5ceb53d83e8af",
+        "version": "2.27.8"
       },
       "fiat": {
-        "commit": "45039aa7952cc409329faa30b8443667566459c1",
-        "version": "2.28.6-rc1"
+        "commit": "e23c8b8a65463100c7075b1aacc140a0e0dc5216",
+        "version": "2.27.8"
       },
       "front50": {
-        "commit": "fab8841982330e7537629c9f24f41205cd5863fd",
-        "version": "2.28.6-rc1"
+        "commit": "5e1fe36c4b8df29cc9cb4d7af581a44b0ca44e59",
+        "version": "2.27.8"
       },
       "gate": {
-        "commit": "43c004af54657dba4a8a429f450de0dad240ed7e",
-        "version": "2.28.6-rc1"
+        "commit": "9cd1a1174ee0bd19577ffdbd6aa11ad432a67082",
+        "version": "2.27.8"
       },
       "igor": {
-        "commit": "60964526194a1273a03a7ade1f8939751e337735",
-        "version": "2.28.6-rc1"
+        "commit": "ebfdd8b8068fe1ff1ba3e7c25cd2b0c0fa803bd9",
+        "version": "2.27.8"
       },
       "kayenta": {
-        "commit": "705629b88f6532d4f81dcd8063a31ad55a0ee29b",
-        "version": "2.28.6-rc1"
+        "commit": "822b3339a4dbbccb9a135c102d8ba1ff199d49ec",
+        "version": "2.27.8"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -258,19 +249,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "6bec7e613ce3cbb8b3ea9223311579e433efc7b1",
-        "version": "2.28.6-rc1"
+        "commit": "2aa5a723767a5972a3b31278a1dcf5af32e66b99",
+        "version": "2.27.8"
       },
       "rosco": {
-        "commit": "12b901a2270bba8971c4b44b47e9256db95cd9b4",
-        "version": "2.28.6-rc1"
+        "commit": "8b94ccff09fe762d896df9052e4199af6dd9b666",
+        "version": "2.27.8"
       },
       "terraformer": {
-        "commit": "ea9b0255b7d446bcbf0f0d4e03fc8699b7508431",
-        "version": "2.28.6-rc1"
+        "commit": "736ece67b4a52a612262cbe844d1edd3ad176d19",
+        "version": "2.27.8"
       }
     },
-    "timestamp": "2023-03-28 16:41:18",
-    "version": "2.28.6-rc1"
+    "timestamp": "2023-03-22 15:19:48",
+    "version": "2.27.8"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [
        "chore(cd): update base service version to fiat:2023.02.28.17.42.01.release-1.27.x (#439)",
        "chore(cd): update base service version to fiat:2023.03.16.17.57.42.release-1.27.x (#447)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Fiat",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to igor:2023.02.28.17.45.14.release-1.27.x (#417)",
        "chore(cd): update base service version to igor:2023.02.28.19.16.26.release-1.27.x (#418)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Igor",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to gate:2023.02.28.17.43.36.release-1.27.x (#520)",
        "chore(cd): update base service version to gate:2023.02.28.19.18.24.release-1.27.x (#521)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Gate",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base orca version to 2023.02.28.17.51.52.release-1.27.x (#594)",
        "chore(cd): update base orca version to 2023.02.28.19.23.37.release-1.27.x (#595)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Orca",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to kayenta:2023.02.28.21.15.17.release-1.27.x (#392)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Kayenta",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(alpine): Update alpine version (backport #497) (#498)"
      ],
      "currentVersion": "2.27.8",
      "name": "Terraformer™",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to rosco:2023.02.28.17.41.47.release-1.27.x (#498)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Rosco",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(alpine): Upgrade alpine version (backport #1302) (#1304)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Deck",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2023.02.22.23.00.31.release-1.27.x (#805)",
        "chore(cd): update base service version to clouddriver:2023.02.28.18.06.11.release-1.27.x (#809)",
        "chore(cd): update base service version to clouddriver:2023.02.28.19.32.28.release-1.27.x (#811)",
        "chore(cd): update base service version to clouddriver:2023.03.21.20.22.35.release-1.27.x (#822)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Clouddriver",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to echo:2023.02.28.17.42.44.release-1.27.x (#540)",
        "chore(cd): update base service version to echo:2023.02.28.19.16.55.release-1.27.x (#541)"
      ],
      "currentVersion": "2.27.8",
      "name": "Armory Echo",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [
        "chore(dependencies): bumped oss dinghy version to 20230201103309-a73a68c80965 (#479)",
        "chore(alpine): Upgrade alpine version (backport #481) (#483)"
      ],
      "currentVersion": "2.27.8",
      "name": "Dinghy™",
      "previousVersion": "2.27.7"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.27.8",
      "name": "Armory Front50",
      "previousVersion": "2.27.7"
    }
  ],
  "armoryVersion": "2.27.8",
  "ossServices": [
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1024)",
        "fix(logs): Redacted secret data in logs. (#1029) (#1032)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1091)",
        "chore(dependencies): Autobump fiatVersion (#1092)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Igor",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1621)",
        "chore(dependencies): Autobump fiatVersion (#1622)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Gate",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#4401)",
        "chore(dependencies): Autobump fiatVersion (#4402)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Orca",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump orcaVersion (#934)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#957)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Deck",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "fix(ecr): Two credentials with same accountId confuses EcrImageProvider with different regions (#5885) (#5886)",
        "chore(dependencies): Autobump korkVersion (#5894)",
        "chore(dependencies): Autobump fiatVersion (#5895)",
        "fix(core): Renamed a query parameter for template tags (#5906) (#5907)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1259)",
        "chore(dependencies): Autobump fiatVersion (#1260)"
      ],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Echo",
      "previousVersion": "1.27.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.27.0",
      "name": "Spinnaker Front50",
      "previousVersion": "1.27.0"
    }
  ],
  "ossVersion": "1.27.0",
  "prerelease": false,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "a3347ca5e207273abe60ca48e98bf494e6d8d359",
        "version": "2.27.8"
      },
      "deck": {
        "commit": "57f5d89f15f6f9ddc5c3f4554e4b0a3bb6f03e2b",
        "version": "2.27.8"
      },
      "dinghy": {
        "commit": "d9146416b57d6c7008cfe6323ba3b0e6527181d0",
        "version": "2.27.8"
      },
      "echo": {
        "commit": "b220bcaa01be72ca2c4489203bc5ceb53d83e8af",
        "version": "2.27.8"
      },
      "fiat": {
        "commit": "e23c8b8a65463100c7075b1aacc140a0e0dc5216",
        "version": "2.27.8"
      },
      "front50": {
        "commit": "5e1fe36c4b8df29cc9cb4d7af581a44b0ca44e59",
        "version": "2.27.8"
      },
      "gate": {
        "commit": "9cd1a1174ee0bd19577ffdbd6aa11ad432a67082",
        "version": "2.27.8"
      },
      "igor": {
        "commit": "ebfdd8b8068fe1ff1ba3e7c25cd2b0c0fa803bd9",
        "version": "2.27.8"
      },
      "kayenta": {
        "commit": "822b3339a4dbbccb9a135c102d8ba1ff199d49ec",
        "version": "2.27.8"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "2aa5a723767a5972a3b31278a1dcf5af32e66b99",
        "version": "2.27.8"
      },
      "rosco": {
        "commit": "8b94ccff09fe762d896df9052e4199af6dd9b666",
        "version": "2.27.8"
      },
      "terraformer": {
        "commit": "736ece67b4a52a612262cbe844d1edd3ad176d19",
        "version": "2.27.8"
      }
    },
    "timestamp": "2023-03-22 15:19:48",
    "version": "2.27.8"
  }
}
```