### PR TITLE
docs(infra): switch to GA4 measurement ID

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,11 @@ pygmentsUseClassic = false
 # See https://help.farbox.com/pygments.html
 pygmentsStyle = "tango"
 
+# Google Analytics configuration
+# https://gohugo.io/templates/internal/#configure-google-analytics
+# https://www.docsy.dev/docs/adding-content/feedback/#adding-analytics
+googleAnalytics = 'G-W14B82N2D2'
+
 # Docsy is now a Go module; need to map theme dirs to local dirs
 [module]
 proxy = "direct"
@@ -93,11 +98,8 @@ resampleFilter = "CatmullRom"
 quality = 75
 anchor = "smart"
 
-# Google Analytics configuration
-[services]
-[services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-79996712-5"
+
+
 
 # Language configuration
 


### PR DESCRIPTION
Google Universal end of life on 1 July 2023
Resolves Jira: [DOC-639]



[DOC-639]: https://armory.atlassian.net/browse/DOC-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ