### PR TITLE
docs(cdaas): Add Pendo script

### DIFF
--- a/layouts/cd-as-a-service/baseof.html
+++ b/layouts/cd-as-a-service/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
+    {{ partial "cdaas/pendo.html" . }}
   </head>
   <body class="td-{{ .Kind }}">
     <header>

--- a/layouts/partials/cdaas/pendo.html
+++ b/layouts/partials/cdaas/pendo.html
@@ -1,0 +1,38 @@
+<script>
+  (function(apiKey){
+      (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
+      v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
+          o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
+          y=e.createElement(n);y.async=!0;y.src='https://content.guides.cloud.armory.io/agent/static/'+apiKey+'/pendo.js';
+          z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
+  
+          // This function creates anonymous visitor IDs in Pendo unless you change the visitor id field to use your app's values
+          // This function uses the placeholder 'ACCOUNT-UNIQUE-ID' value for account ID unless you change the account id field to use your app's values
+          // Call this function after users are authenticated in your app and your visitor and account id values are available
+          // Please use Strings, Numbers, or Bools for value types.
+          pendo.initialize({
+              visitor: {
+                  id:              'VISITOR-UNIQUE-ID'   // Required if user is logged in, default creates anonymous ID
+                  // email:        // Recommended if using Pendo Feedback, or NPS Email
+                  // full_name:    // Recommended if using Pendo Feedback
+                  // role:         // Optional
+  
+                  // You can add any additional visitor level key-values here,
+                  // as long as it's not one of the above reserved names.
+              },
+  
+              account: {
+                  id:           'ACCOUNT-UNIQUE-ID' // Required if using Pendo Feedback, default uses the value 'ACCOUNT-UNIQUE-ID'
+                  // name:         // Optional
+                  // is_paying:    // Recommended if using Pendo Feedback
+                  // monthly_value:// Recommended if using Pendo Feedback
+                  // planLevel:    // Optional
+                  // planPrice:    // Optional
+                  // creationDate: // Optional
+  
+                  // You can add any additional account level key-values here,
+                  // as long as it's not one of the above reserved names.
+              }
+          });
+  })('dfe1b660-07c8-4f36-798a-997e3fc1e10b');
+  </script>


### PR DESCRIPTION
Add Pendo script using "Multi-Page App" option.
Create a partial for the script.
Add partial only to CDaaS base page.

Tested by doing a View Source on pages in /cd-as-a-service/ vs /continuous-deployment/ and /plugins/