### PR TITLE
fix(docs): correct PipelineAsACode halyard install docs

### DIFF
--- a/content/en/plugins/pipelines-as-code/install/spinnaker-halyard.md
+++ b/content/en/plugins/pipelines-as-code/install/spinnaker-halyard.md
@@ -92,7 +92,9 @@ Replace `<version>` with the plugin version that's compatible with your Spinnake
          Armory.PipelinesAsCode:
            enabled: true
            version: <version>
+       repositories:
          pipelinesAsCode:
+           enabled: true
            url: https://raw.githubusercontent.com/armory-plugins/pluginRepository/master/repositories.json
    ```
 
@@ -110,7 +112,9 @@ Replace `<version>` with the plugin version that's compatible with your Spinnake
          Armory.PipelinesAsCode:
            enabled: true
            version: <version>
+       repositories:
          pipelinesAsCode:
+           enabled: true
            url: https://raw.githubusercontent.com/armory-plugins/pluginRepository/master/repositories.json
    ```
 


### PR DESCRIPTION
Updates docs to correctly configure repository for PipelineAsCode Halyard install 