### PR TITLE
docs(cdaas): Fix how context variables are used in the deployment file

### DIFF
--- a/content/en/includes/cdaas/dep-file/webhooks-config.md
+++ b/content/en/includes/cdaas/dep-file/webhooks-config.md
@@ -77,7 +77,7 @@ strategies:
             name: <webhookName>
             ...
             context:
-              - <variableName>: <variableValue>
+              <variableName>: <variableValue>
 ```
 
 You need to configure your custom variables for each webhook step that references them.


### PR DESCRIPTION
Fix Context variable declaration in docs from list to KV Pair.