### PR TITLE
docs(cdaas): quickstart - add alternate instructions for armory create

### DIFF
--- a/content/en/cd-as-a-service/setup/quickstart.md
+++ b/content/en/cd-as-a-service/setup/quickstart.md
@@ -32,6 +32,7 @@ aliases:
 ## Sign up for CD-as-a-Service
 
 {{< include "cdaas/register.md" >}}
+<!-- after creating an account, the user sees the Let's Get Started wizard. https://next.console.cloud.armory.io/getting-started -->
 
 ## Install the CD-as-as-Service CLI
 
@@ -47,7 +48,7 @@ Confirm the device code in your browser when prompted. Then return to this guide
 
 ## Connect your cluster
 
-CD-as-a-Service uses an agent to execute deployments in your Kubernetes cluster. The installation process uses credentials from your `~/.kube/config` file to install the CD-as-a-Service agent.
+CD-as-a-Service uses an agent to execute deployments in your Kubernetes cluster. The installation process uses credentials from your `~/.kube/config` file to install the CD-as-a-Service agent into a new `armory-rna` namespace.
 
 Run the following command to install an agent in your Kubernetes cluster:
 
@@ -57,12 +58,15 @@ armory agent create
 
 You name your agent during the installation process. This guide references that name as `<my-agent-identifier>`.
 
-<details><summary>Having connection issues? Expand to see alternate instructions</summary>
+<details><summary>Having connection issues? Expand to see alternate instructions.</summary>
 
-1. [Open a ticket](https://github.com/armory/docs//issues/new?title=Armory%20CD-as-a-Service%20Quickstart) so Armory knows what issues you are having.
-1. Use the [CD-as-a-Service Console](https://console.cloud.armory.io/) to generate an install script that you can run locally using kubectl.
+Use the **CD-as-a-Service Console** to generate kubectl commands that you can run locally.
 
-   {{< include "cdaas/rna-ui-add-agent.md" >}}
+<!-- If the user is already logged in, clicking https://console.cloud.armory.io/configuration/agents goes directly to that page. If the user has an account but is not logged into the web UI,  the user is also redirected to the Agent page (even after all the Auth0 authenticator stuff) -->
+
+{{< include "cdaas/rna-ui-add-agent.md" >}}
+
+You can also [open a ticket](https://github.com/armory/docs//issues/new?title=Armory%20CD-as-a-Service%20Quickstart) so Armory knows what issues you had.
 
 </details>
 
@@ -87,7 +91,7 @@ armory deploy start -f https://go.armory.io/hello-armory-first-deployment --acco
 
 Congratulations, you've just started your first deployment with CD-as-a-Service! 
 
-You can use the link provided by the CLI to observe your deployment's progression in the [CD-as-a-Service Console](https://console.cloud.armory.io/deployments). CD-as-a-Service deploys your resources to `staging`. Once those resources have deployed successfully, CD-as-a-Service deploys to `prod`.
+You can use the link provided by the CLI to observe your deployment's progression in the [CD-as-a-Service Deployments Console](https://console.cloud.armory.io/deployments). CD-as-a-Service deploys your resources to `staging`. Once those resources have deployed successfully, CD-as-a-Service deploys to `prod`.
 
 ### Second deployment
 

--- a/content/en/cd-as-a-service/setup/quickstart.md
+++ b/content/en/cd-as-a-service/setup/quickstart.md
@@ -57,6 +57,15 @@ armory agent create
 
 You name your agent during the installation process. This guide references that name as `<my-agent-identifier>`.
 
+<details><summary>Having connection issues? Expand to see alternate instructions</summary>
+
+1. [Open a ticket](https://github.com/armory/docs//issues/new?title=Armory%20CD-as-a-Service%20Quickstart) so Armory knows what issues you are having.
+1. Use the [CD-as-a-Service Console](https://console.cloud.armory.io/) to generate an install script that you can run locally using kubectl.
+
+   {{< include "cdaas/rna-ui-add-agent.md" >}}
+
+</details>
+
 ## Deploy the sample app
 
 Armory's [`potato-facts` sample app](https://github.com/armory-io/potato-facts-go) is a simple web app. The UI polls the API backend for facts about potatoes and renders them for users.
@@ -208,11 +217,19 @@ CD-as-a-Service also supports a [blue/green]({{< ref "cd-as-a-service/setup/blue
 
 ## Clean up
 
-You can clean kubectl to clean up the resources you created:
+You can clean kubectl to clean up the app resources you created:
 
 ```shell
 kubectl delete ns potato-facts-staging potato-facts-prod
 ```
+
+To remove the Remote Network Agent, run:
+
+```shell
+kubectl delete ns armory-rna
+```
+
+>Don't delete your Remote Network Agent if you plan to use the same cluster to deploy your own app.
 
 ## {{%  heading "nextSteps" %}}
 

--- a/content/en/cd-as-a-service/setup/quickstart.md
+++ b/content/en/cd-as-a-service/setup/quickstart.md
@@ -2,7 +2,7 @@
 title: Armory CD-as-a-Service Quickstart
 linktitle: Quickstart
 description: >
-  Install the Armory Continuous Deployment-as-a-Service CLI, connect your Kubernetes cluster with a single command, and deploy an sample app using a traffic split. Learn deployment file syntax.
+  Install the Armory Continuous Deployment-as-a-Service CLI, connect your Kubernetes cluster with a single CLI command, and deploy an sample app using a traffic split. Learn deployment file syntax.
 weight: 1
 categories: ["Get Started"]
 tags: ["Deployment", "Quickstart"]

--- a/content/en/cd-as-a-service/tasks/networking/install-agent.md
+++ b/content/en/cd-as-a-service/tasks/networking/install-agent.md
@@ -55,12 +55,7 @@ _Do not close the pop-up window in the UI until you have completed RNA installat
 
 ### Option 2
 
-1. In the CD-as-a-Service Console, navigate to the [Configuration page](https://console.cloud.armory.io/configuration).
-1. Access the **Networking** > **Agents** screen.
-1. Click **Add an Agent**.
-1. In the **Name New Remote Network Agent** window, enter a name for your Remote Network Agent (RNA) in **Agent Identifier**. You install this RNA in the cluster where you want to deploy your app, so create a meaningful name.
-1. Choose **I want to use my own cluster.** in the **Choose Cluster Type** window.
-1. Copy the script in the **Install a Remote Network Agent** window and run it locally using kubectl.
+{{< include "cdaas/rna-ui-add-agent.md" >}}
 
 ## Install manually using the CLI
 

--- a/content/en/includes/cdaas/rna-ui-add-agent.md
+++ b/content/en/includes/cdaas/rna-ui-add-agent.md
@@ -1,0 +1,6 @@
+1. In the CD-as-a-Service Console, navigate to the [Configuration page](https://console.cloud.armory.io/configuration).
+1. Access the **Networking** > **Agents** screen.
+1. Click **Add an Agent**.
+1. In the **Name New Remote Network Agent** window, enter a name for your Remote Network Agent (RNA) in **Agent Identifier**. You install this RNA in the cluster where you want to deploy your app, so create a meaningful name.
+1. Choose **I want to use my own cluster** in the **Choose Cluster Type** window.
+1. Copy the script in the **Install a Remote Network Agent** window and run it locally using kubectl.

--- a/content/en/includes/cdaas/rna-ui-add-agent.md
+++ b/content/en/includes/cdaas/rna-ui-add-agent.md
@@ -1,6 +1,6 @@
-1. In the CD-as-a-Service Console, navigate to the [Configuration page](https://console.cloud.armory.io/configuration).
-1. Access the **Networking** > **Agents** screen.
+1. Access the [Agents page](https://console.cloud.armory.io/configuration/agents).
 1. Click **Add an Agent**.
 1. In the **Name New Remote Network Agent** window, enter a name for your Remote Network Agent (RNA) in **Agent Identifier**. You install this RNA in the cluster where you want to deploy your app, so create a meaningful name.
 1. Choose **I want to use my own cluster** in the **Choose Cluster Type** window.
-1. Copy the script in the **Install a Remote Network Agent** window and run it locally using kubectl.
+1. Copy the **Option 1** content in the **Install a Remote Network Agent** window.
+1. In your local terminal, ensure you are connected to your cluster and then execute the commands. 


### PR DESCRIPTION
Add UI-based RNA install instructions as an alternate if user has issues with the `armory create` command.

The instructions are in an expandable section. Direct link to Agents page.
If the user is already logged in, clicking https://console.cloud.armory.io/configuration/agents goes directly to that page. If the user is not logged into the web UI,  the user is also redirected to the Agent page (even after all the Auth0 authenticator stuff) 


Resolves Jira: [CDAAS-2523]

Deploy preview https://deploy-preview-2047--armory-docs.netlify.app/cd-as-a-service/setup/quickstart/#connect-your-cluster

[CDAAS-2523]: https://armory.atlassian.net/browse/CDAAS-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ