### PR TITLE
fix(rn): fix front matter in release notes

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-30-0.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-30-0.md
@@ -1,7 +1,7 @@
 ---
 title: v2.30.0 Armory Release (OSS Spinnaker™ v1.30.2)
 toc_hide: true
-version: 02.30.0
+version: 2.30.0
 date: 2023-08-09
 description: >
   Release notes for Armory Continuous Deployment v2.30.0

--- a/layouts/partials/list-recent-release-notes.html
+++ b/layouts/partials/list-recent-release-notes.html
@@ -23,7 +23,7 @@
         {{ $semverSlice := findRE "[0-9]+" .Title }}
         {{ if and (ge (len $semverSlice) 3) (lt (len $displayedTitles) 3) }}
           {{if and (le ( index $semverSlice 0 ) $semverActiveMajor) (lt ( index $semverSlice 1 ) $semverActiveMinor)  }}
-            {{ $semverActiveMajor = index $semverSlice 1 }}
+            {{ $semverActiveMajor = index $semverSlice 0 }}
             {{ $semverActiveMinor = index $semverSlice 1 }}
             {{ $semverActivePatch = index $semverSlice 2 }}
             {{ $displayedTitles = $displayedTitles | append .Title }}


### PR DESCRIPTION
The leading zero likely had the page being interpreted as a hex number instead of an int, so the orderering from the pages got out of whack (2.30 was listed after 2.28). With the logic on the release notes page, it meant that "28" was considered the latest active patch release and therefore kicked the "30" version into the deprecated section. Also fixed a logical bug in the value setting for this page when we release version 28.0.0 of the product xP

<!-- Make sure your PR title matches the following format: <type>(<scope>): <subject> -->
<!-- Include the Jira or GitHub issue associated with this work if there is one -->
Resolves GitHub issue: <link to GH issue>
<!-- If Jira, enclose the ticket in brackets. Jira-GitHub integration requires this format. -->
Resolves Jira: [JIRAPROJECT-123]

<!-- Share artifacts of the changes if they'd help your reviewer, e.g. a screenshot -->
<!-- You can delete these comments when you submit your PR. -->
