### PR TITLE
fix(pe): update version to 0.3.0 for spinnaker >= 2.28

### DIFF
--- a/content/en/includes/breaking-changes/bc-plugin-compatibility-2-28-0.md
+++ b/content/en/includes/breaking-changes/bc-plugin-compatibility-2-28-0.md
@@ -4,12 +4,12 @@ Due to changes in the underlying services, older versions of some plugins may no
 
 The following table lists the plugins and their required minimum version:
 
-| Plugin                                                                                             | Version |
-| -------------------------------------------------------------------------------------------------- | ------- |
-| [Scale Agent for Spinnaker and Kubernetes Clouddriver Plugin]({{< ref "plugins/scale-agent/_index.md" >}})                     | 0.11.0  |
-| App Name                                                                                           | 0.2.0   |
-| [AWS Lambda](https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/releases) | 1.0.10  |
-| [Evaluate Artifacts](https://github.com/armory-plugins/evaluate-artifacts-releases/releases)       | 0.1.1   |
-| [External Accounts](https://github.com/armory-plugins/external-accounts/releases)                  | 0.3.0   |
-| [Observability Plugin](https://github.com/armory-plugins/armory-observability-plugin/releases)     | 1.3.1   |
-| [Policy Engine](https://github.com/armory-plugins/policy-engine-releases/releases)                 | 0.2.2   |
+| Plugin                                                                                                                        | Version |
+|-------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Scale Agent for Spinnaker and Kubernetes Clouddriver Plugin]({{< ref "plugins/scale-agent/_index.md" >}})                    | 0.11.0  |
+| App Name                                                                                                                      | 0.2.0   |
+| [AWS Lambda](https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/releases)                            | 1.0.10  |
+| [Evaluate Artifacts](https://github.com/armory-plugins/evaluate-artifacts-releases/releases)                                  | 0.1.1   |
+| [External Accounts](https://github.com/armory-plugins/external-accounts/releases)                                             | 0.3.0   |
+| [Observability Plugin](https://github.com/armory-plugins/armory-observability-plugin/releases)                                | 1.3.1   |
+| [Policy Engine](https://github.com/armory-plugins/policy-engine-releases/releases)                                            | 0.3.0   |


### PR DESCRIPTION
According to https://docs.armory.io/plugins/policy-engine/ we need to use version 0.3.0 for spinnaker >= 2.28