### PR TITLE
docs(dinghy): Fixed inaccurate information about multiple branches support in Dinghy

### DIFF
--- a/content/en/plugins/pipelines-as-code/install/configure.md
+++ b/content/en/plugins/pipelines-as-code/install/configure.md
@@ -95,7 +95,7 @@ spec:
 
 {{< tabpane text=true right=true >}}
 {{% tab header="Spinnaker"  %}}
-Each branch in a repository must be explicitly configured in a separate  `repoConfig` item. In the example below, Dinghy will properly handle changes from two branches, `branch_a` and `branch_b` in `repository-GitHub-repository`. Add the following to your `dinghy.yml` config:
+Each branch in a repository must be explicitly configured in a separate  `repoConfig` item. In the example below, Dinghy properly handles changes from two branches, `branch_a` and `branch_b` in `repository-GitHub-repository`. Add the following to your `dinghy.yml` profile config:
 
 ```yaml
 multipleBranchesEnabled: true

--- a/content/en/plugins/pipelines-as-code/install/configure.md
+++ b/content/en/plugins/pipelines-as-code/install/configure.md
@@ -93,21 +93,22 @@ spec:
 
 {{< include "early-access-feature.html" >}}
 
-This feature enables you to select multiple branches in the UI. You must enable the feature and configure your branches.
-
 {{< tabpane text=true right=true >}}
 {{% tab header="Spinnaker"  %}}
-Add the following to your `dinghy.yml` config:
+Each branch in a repository must be explicitly configured in a separate  `repoConfig` item. In the example below, Dinghy will properly handle changes from two branches, `branch_a` and `branch_b` in `repository-GitHub-repository`. Add the following to your `dinghy.yml` config:
 
 ```yaml
 multipleBranchesEnabled: true
 repoConfig:
+- branch: branch_a
+  provider: github
+  repo: my-github-repository
+- branch: branch_b
+  provider: github
+  repo: my-github-repository
 - branch: some_branch
   provider: bitbucket-server
   repo: my-bitbucket-repository
-- branch: some_branch
-  provider: github
-  repo: my-github-repository
 ```
 {{% /tab %}}
 {{% tab header="Armory CD"  %}}


### PR DESCRIPTION
Removed incorrect information about selecting the branches from the UI. This is inaccurate. 
Enhanced the example yaml with one more item in the list to clarify how to configure multiple branches per single repository.

Resolves Jira: [CDSH-193](https://armory.atlassian.net/browse/CDSH-193)


[CDSH-193]: https://armory.atlassian.net/browse/CDSH-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ