### PR TITLE
chore(release): add release notes for 2.30.2-rc1

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-30-2-rc1.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-30-2-rc1.md
@@ -1,0 +1,202 @@
+---
+title: v2.30.2-rc1 Armory Release (OSS Spinnaker™ v1.30.3)
+toc_hide: true
+date: 2023-08-29
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+description: >
+  Release notes for Armory Continuous Deployment v2.30.2-rc1. A beta release is not meant for installation in production environments.
+
+---
+
+## 2023/08/29 Release Notes
+
+## Disclaimer
+
+This pre-release software is to allow limited access to test or beta versions of the Armory services (“Services”) and to provide feedback and comments to Armory regarding the use of such Services. By using Services, you agree to be bound by the terms and conditions set forth herein.
+
+Your Feedback is important and we welcome any feedback, analysis, suggestions and comments (including, but not limited to, bug reports and test results) (collectively, “Feedback”) regarding the Services. Any Feedback you provide will become the property of Armory and you agree that Armory may use or otherwise exploit all or part of your feedback or any derivative thereof in any manner without any further remuneration, compensation or credit to you. You represent and warrant that any Feedback which is provided by you hereunder is original work made solely by you and does not infringe any third party intellectual property rights.
+
+Any Feedback provided to Armory shall be considered Armory Confidential Information and shall be covered by any confidentiality agreements between you and Armory.
+
+You acknowledge that you are using the Services on a purely voluntary basis, as a means of assisting, and in consideration of the opportunity to assist Armory to use, implement, and understand various facets of the Services. You acknowledge and agree that nothing herein or in your voluntary submission of Feedback creates any employment relationship between you and Armory.
+
+Armory may, in its sole discretion, at any time, terminate or discontinue all or your access to the Services. You acknowledge and agree that all such decisions by Armory are final and Armory will have no liability with respect to such decisions.
+
+YOUR USE OF THE SERVICES IS AT YOUR OWN RISK. THE SERVICES, THE ARMORY TOOLS AND THE CONTENT ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. ARMORY AND ITS LICENSORS MAKE NO REPRESENTATION, WARRANTY, OR GUARANTY AS TO THE RELIABILITY, TIMELINESS, QUALITY, SUITABILITY, TRUTH, AVAILABILITY, ACCURACY OR COMPLETENESS OF THE SERVICES, THE ARMORY TOOLS OR ANY CONTENT. ARMORY EXPRESSLY DISCLAIMS ON ITS OWN BEHALF AND ON BEHALF OF ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS ANY AND ALL WARRANTIES INCLUDING, WITHOUT LIMITATION (A) THE USE OF THE SERVICES OR THE ARMORY TOOLS WILL BE TIMELY, UNINTERRUPTED OR ERROR-FREE OR OPERATE IN COMBINATION WITH ANY OTHER HARDWARE, SOFTWARE, SYSTEM OR DATA, (B) THE SERVICES AND THE ARMORY TOOLS AND/OR THEIR QUALITY WILL MEET CUSTOMER”S REQUIREMENTS OR EXPECTATIONS, (C) ANY CONTENT WILL BE ACCURATE OR RELIABLE, (D) ERRORS OR DEFECTS WILL BE CORRECTED, OR (E) THE SERVICES, THE ARMORY TOOLS OR THE SERVER(S) THAT MAKE THE SERVICES AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. CUSTOMER AGREES THAT ARMORY SHALL NOT BE RESPONSIBLE FOR THE AVAILABILITY OR ACTS OR OMISSIONS OF ANY THIRD PARTY, INCLUDING ANY THIRD-PARTY APPLICATION OR PRODUCT, AND ARMORY HEREBY DISCLAIMS ANY AND ALL LIABILITY IN CONNECTION WITH SUCH THIRD PARTIES.
+
+IN NO EVENT SHALL ARMORY, ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS BE LIABLE UNDER THIS AGREEMENT FOR ANY CONSEQUENTIAL, SPECIAL, LOST PROFITS, INDIRECT OR OTHER DAMAGES, INCLUDING BUT NOT LIMITED TO LOST PROFITS, LOSS OF BUSINESS, COST OF COVER WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF ARMORY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. IN ANY EVENT, ARMORY, ITS EMPLOYEES’, AGENTS’, ATTORNEYS’, CONSULTANTS’ OR CONTRACTORS’ AGGREGATE LIABILITY UNDER THIS AGREEMENT FOR ANY CLAIM SHALL BE STRICTLY LIMITED TO $100.00. SOME STATES DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+
+You acknowledge that Armory has provided the Services in reliance upon the limitations of liability set forth herein and that the same is an essential basis of the bargain between the parties.
+
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory 2.30.2-rc1, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker Community Contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.30.3](https://www.spinnaker.io/changelogs/1.30.3-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+Here's the BOM for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 9e69fcd6cd17f31e35eeb7d443cdbf9c2d9ac187
+    version: 2.30.2-rc1
+  deck:
+    commit: 7737669d9a68843f448cc4c93ac2a6ea3485f95e
+    version: 2.30.2-rc1
+  dinghy:
+    commit: 5250de80948732c8caac6ffc5293a8af80a63a0f
+    version: 2.30.2-rc1
+  echo:
+    commit: 56844c654cd1b3981686933a9d5bc68011ee2bae
+    version: 2.30.2-rc1
+  fiat:
+    commit: 30319b57d40a7e9fd61067b7e0d9fb73bf9a6c46
+    version: 2.30.2-rc1
+  front50:
+    commit: ec0919166ced870668d787708c249945e9291a01
+    version: 2.30.2-rc1
+  gate:
+    commit: df941ff5c34d14e794c8784c28a1b30b28754971
+    version: 2.30.2-rc1
+  igor:
+    commit: 67b4c66f33b8b97b89e6b052654bebfea460a41f
+    version: 2.30.2-rc1
+  kayenta:
+    commit: 4d82ef4a72129a715749005235ce0d6ba4778603
+    version: 2.30.2-rc1
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 638d81c8d3186b6deb8829574c6ac5b65c88c94a
+    version: 2.30.2-rc1
+  rosco:
+    commit: e74de6eaccbed6301505d9f3d2f6745b410211a7
+    version: 2.30.2-rc1
+  terraformer:
+    commit: 650746ae3f596f9c6458987487c81840c85dd2a0
+    version: 2.30.2-rc1
+timestamp: "2023-08-29 01:03:06"
+version: 2.30.2-rc1
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Clouddriver - 2.30.1...2.30.2-rc1
+
+  - chore(cd): update base service version to clouddriver:2023.08.25.16.41.50.release-1.30.x (#933)
+  - chore(cd): update base service version to clouddriver:2023.08.28.14.14.14.release-1.30.x (#937)
+
+#### Armory Deck - 2.30.1...2.30.2-rc1
+
+
+#### Dinghy™ - 2.30.1...2.30.2-rc1
+
+
+#### Armory Echo - 2.30.1...2.30.2-rc1
+
+
+#### Armory Fiat - 2.30.1...2.30.2-rc1
+
+
+#### Armory Front50 - 2.30.1...2.30.2-rc1
+
+
+#### Armory Gate - 2.30.1...2.30.2-rc1
+
+  - fix: esapi CVE scan report (#602) (#603)
+
+#### Armory Igor - 2.30.1...2.30.2-rc1
+
+
+#### Armory Kayenta - 2.30.1...2.30.2-rc1
+
+
+#### Armory Orca - 2.30.1...2.30.2-rc1
+
+
+#### Armory Rosco - 2.30.1...2.30.2-rc1
+
+
+#### Terraformer™ - 2.30.1...2.30.2-rc1
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Clouddriver - 1.30.3
+
+  - fix(builds): Backport flag for installing aws cli (#6006)
+
+#### Spinnaker Deck - 1.30.3
+
+
+#### Spinnaker Echo - 1.30.3
+
+
+#### Spinnaker Fiat - 1.30.3
+
+
+#### Spinnaker Front50 - 1.30.3
+
+
+#### Spinnaker Gate - 1.30.3
+
+
+#### Spinnaker Igor - 1.30.3
+
+
+#### Spinnaker Kayenta - 1.30.3
+
+
+#### Spinnaker Orca - 1.30.3
+
+
+#### Spinnaker Rosco - 1.30.3
+
+

--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-30-2-rc1.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-30-2-rc1.md
@@ -171,8 +171,6 @@ version: 2.30.2-rc1
 
 #### Spinnaker Clouddriver - 1.30.3
 
-  - fix(builds): Backport flag for installing aws cli (#6006)
-
 #### Spinnaker Deck - 1.30.3
 
 

--- a/payload.json
+++ b/payload.json
@@ -2,234 +2,149 @@
   "armoryServices": [
     {
       "commitMessages": [
-        "chore(cd): update base service version to clouddriver:2023.07.19.19.07.34.release-1.30.x (#902)",
-        "chore(cd): update base service version to clouddriver:2023.07.21.18.23.46.release-1.30.x (#905)",
-        "chore(kubectl): upgrade kubectl version from 1.20.6 to 1.22.17 (backport #878) (#917)",
-        "chore(cd): update base service version to clouddriver:2023.08.17.03.37.47.release-1.30.x (#920)",
-        "chore(cd): update base service version to clouddriver:2023.08.17.06.57.33.release-1.30.x (#922)",
-        "chore(cd): update base service version to clouddriver:2023.08.18.20.50.29.release-1.30.x (#923)",
-        "fix: AWS CLI pip installation (#918) (#925)",
-        "chore(cd): update base service version to clouddriver:2023.08.18.23.44.54.release-1.30.x (#926)"
+        "chore(cd): update base service version to clouddriver:2023.08.25.16.41.50.release-1.30.x (#933)",
+        "chore(cd): update base service version to clouddriver:2023.08.28.14.14.14.release-1.30.x (#937)"
       ],
-      "currentVersion": "2.30.1",
+      "currentVersion": "2.30.2-rc1",
       "name": "Armory Clouddriver",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to igor:2023.08.17.02.51.58.release-1.30.x (#480)",
-        "chore(cd): update base service version to igor:2023.08.17.04.46.32.release-1.30.x (#481)",
-        "chore(cd): update base service version to igor:2023.08.18.20.06.35.release-1.30.x (#483)",
-        "chore(cd): update base service version to igor:2023.08.18.23.01.56.release-1.30.x (#484)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Armory Igor",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "Session duration support on AWS roles (#500) (#503)",
-        "fix: One more session timeout place (#501) (#505)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Terraformer™",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to rosco:2023.08.17.02.48.33.release-1.30.x (#558)",
-        "chore(cd): update base service version to rosco:2023.08.18.20.06.48.release-1.30.x (#559)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Armory Rosco",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to front50:2023.08.18.20.06.26.release-1.30.x (#576)",
-        "chore(cd): update base service version to front50:2023.08.18.23.02.05.release-1.30.x (#577)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Armory Front50",
-      "previousVersion": "2.30.0"
+      "previousVersion": "2.30.1"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.30.1",
+      "currentVersion": "2.30.2-rc1",
       "name": "Armory Deck",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to kayenta:2023.08.17.05.53.17.release-1.30.x (#458)",
-        "chore(cd): update base service version to kayenta:2023.08.19.00.43.42.release-1.30.x (#461)",
-        "chore(cd): update base service version to kayenta:2023.08.22.17.00.47.release-1.30.x (#463)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.30.0"
+      "previousVersion": "2.30.1"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.30.1",
+      "currentVersion": "2.30.2-rc1",
       "name": "Dinghy™",
-      "previousVersion": "2.30.0"
+      "previousVersion": "2.30.1"
     },
     {
-      "commitMessages": [
-        "chore(cd): update base service version to fiat:2023.08.17.02.48.22.release-1.30.x (#511)",
-        "chore(cd): update base service version to fiat:2023.08.18.20.06.20.release-1.30.x (#512)",
-        "chore(cd): update base service version to fiat:2023.08.22.18.06.01.release-1.30.x (#515)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Armory Fiat",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base orca version to 2023.08.15.19.18.48.release-1.30.x (#677)",
-        "chore(cd): update base orca version to 2023.08.17.02.56.00.release-1.30.x (#679)",
-        "chore(cd): update base orca version to 2023.08.17.04.55.06.release-1.30.x (#681)",
-        "chore(cd): update base orca version to 2023.08.18.20.16.18.release-1.30.x (#683)",
-        "chore(cd): update base orca version to 2023.08.18.23.14.04.release-1.30.x (#684)"
-      ],
-      "currentVersion": "2.30.1",
-      "name": "Armory Orca",
-      "previousVersion": "2.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to echo:2023.08.17.02.52.47.release-1.30.x (#604)",
-        "chore(cd): update base service version to echo:2023.08.17.04.48.12.release-1.30.x (#606)",
-        "chore(cd): update base service version to echo:2023.08.18.20.06.15.release-1.30.x (#607)",
-        "chore(cd): update base service version to echo:2023.08.18.23.04.19.release-1.30.x (#608)"
-      ],
-      "currentVersion": "2.30.1",
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
       "name": "Armory Echo",
-      "previousVersion": "2.30.0"
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Armory Fiat",
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Armory Front50",
+      "previousVersion": "2.30.1"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to gate:2023.08.17.02.52.18.release-1.30.x (#592)",
-        "chore(cd): update base service version to gate:2023.08.17.04.50.02.release-1.30.x (#593)",
-        "chore(cd): update base service version to gate:2023.08.18.20.06.31.release-1.30.x (#595)",
-        "chore(cd): update base service version to gate:2023.08.18.23.02.38.release-1.30.x (#596)"
+        "fix: esapi CVE scan report (#602) (#603)"
       ],
-      "currentVersion": "2.30.1",
+      "currentVersion": "2.30.2-rc1",
       "name": "Armory Gate",
-      "previousVersion": "2.30.0"
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Armory Igor",
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Armory Orca",
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Armory Rosco",
+      "previousVersion": "2.30.1"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.30.2-rc1",
+      "name": "Terraformer™",
+      "previousVersion": "2.30.1"
     }
   ],
-  "armoryVersion": "2.30.1",
+  "armoryVersion": "2.30.2-rc1",
   "ossServices": [
     {
       "commitMessages": [
-        "feat: Add the possibility to update the default handler for the Global Resource Property Registry. (#5963) (#5973)",
-        "fix(gce): remove the duplicate cache attribute \"subnet\" and update the test (#5977) (#5986)",
-        "chore(dependencies): Autobump korkVersion (#5998)",
-        "chore(dependencies): Autobump fiatVersion (#5999)",
-        "chore(dependencies): Autobump korkVersion (#6001)",
-        "chore(dependencies): Autobump fiatVersion (#6002)"
+        "fix(builds): Backport flag for installing aws cli (#6006)"
       ],
       "currentVersion": "1.30.3",
       "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1155)",
-        "chore(dependencies): Autobump fiatVersion (#1156)",
-        "chore(dependencies): Autobump korkVersion (#1158)",
-        "chore(dependencies): Autobump fiatVersion (#1159)"
-      ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Igor",
-      "previousVersion": "1.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1010)",
-        "chore(dependencies): Autobump korkVersion (#1011)"
-      ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1292)",
-        "chore(dependencies): Autobump fiatVersion (#1293)",
-        "chore(dependencies): Autobump korkVersion (#1295)",
-        "chore(dependencies): Autobump fiatVersion (#1296)"
-      ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.30.0"
+      "previousVersion": "1.30.3"
     },
     {
       "commitMessages": [],
       "currentVersion": "1.30.3",
       "name": "Spinnaker Deck",
-      "previousVersion": "1.30.0"
+      "previousVersion": "1.30.3"
     },
     {
-      "commitMessages": [
-        "chore(dependencies): Autobump orcaVersion (#978)",
-        "chore(dependencies): Autobump orcaVersion (#982)",
-        "fix(orca): Fix orca contributors status. (backport #977) (#981)"
-      ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.30.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1088)",
-        "chore(dependencies): Autobump korkVersion (#1089)",
-        "fix(ssl): Removed unused deprecated okHttpClientConfig from retrofitConfig. (#1082) (#1091)"
-      ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.30.0"
-    },
-    {
-      "commitMessages": [
-        "fix(waiting-executions) : concurrent waiting executions doesn't follow FIFO (backport #4415) (#4503)",
-        "chore(dependencies): Autobump korkVersion (#4505)",
-        "chore(dependencies): Autobump fiatVersion (#4506)",
-        "chore(dependencies): Autobump korkVersion (#4509)",
-        "chore(dependencies): Autobump fiatVersion (#4510)"
-      ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.30.0"
-    },
-    {
-      "commitMessages": [
-        "fix(gha): Fix github status log and add tests (#1316) (#1317)",
-        "chore(dependencies): Autobump korkVersion (#1326)",
-        "chore(dependencies): Autobump fiatVersion (#1327)",
-        "chore(dependencies): Autobump korkVersion (#1329)",
-        "chore(dependencies): Autobump fiatVersion (#1330)"
-      ],
+      "commitMessages": [],
       "currentVersion": "1.30.3",
       "name": "Spinnaker Echo",
-      "previousVersion": "1.30.0"
+      "previousVersion": "1.30.3"
     },
     {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1687)",
-        "chore(dependencies): Autobump fiatVersion (#1688)",
-        "chore(dependencies): Autobump korkVersion (#1690)",
-        "chore(dependencies): Autobump fiatVersion (#1691)"
-      ],
+      "commitMessages": [],
+      "currentVersion": "1.30.3",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.30.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.3",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.30.3"
+    },
+    {
+      "commitMessages": [],
       "currentVersion": "1.30.3",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.30.0"
+      "previousVersion": "1.30.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.3",
+      "name": "Spinnaker Igor",
+      "previousVersion": "1.30.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.3",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.30.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.3",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.30.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.3",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.30.3"
     }
   ],
   "ossVersion": "1.30.3",
-  "prerelease": false,
+  "prerelease": true,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -242,40 +157,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "e83f27627c37921732db249ca823b2e6485a6f97",
-        "version": "2.30.1"
+        "commit": "9e69fcd6cd17f31e35eeb7d443cdbf9c2d9ac187",
+        "version": "2.30.2-rc1"
       },
       "deck": {
         "commit": "7737669d9a68843f448cc4c93ac2a6ea3485f95e",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "dinghy": {
         "commit": "5250de80948732c8caac6ffc5293a8af80a63a0f",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "echo": {
         "commit": "56844c654cd1b3981686933a9d5bc68011ee2bae",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "fiat": {
         "commit": "30319b57d40a7e9fd61067b7e0d9fb73bf9a6c46",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "front50": {
         "commit": "ec0919166ced870668d787708c249945e9291a01",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "gate": {
-        "commit": "2dc9b4b767ab502faaa1b99c131eb7263cf519da",
-        "version": "2.30.1"
+        "commit": "df941ff5c34d14e794c8784c28a1b30b28754971",
+        "version": "2.30.2-rc1"
       },
       "igor": {
         "commit": "67b4c66f33b8b97b89e6b052654bebfea460a41f",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "kayenta": {
         "commit": "4d82ef4a72129a715749005235ce0d6ba4778603",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -287,18 +202,18 @@
       },
       "orca": {
         "commit": "638d81c8d3186b6deb8829574c6ac5b65c88c94a",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "rosco": {
         "commit": "e74de6eaccbed6301505d9f3d2f6745b410211a7",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       },
       "terraformer": {
         "commit": "650746ae3f596f9c6458987487c81840c85dd2a0",
-        "version": "2.30.1"
+        "version": "2.30.2-rc1"
       }
     },
-    "timestamp": "2023-08-23 17:49:50",
-    "version": "2.30.1"
+    "timestamp": "2023-08-29 01:03:06",
+    "version": "2.30.2-rc1"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2023.08.25.16.41.50.release-1.30.x (#933)",
        "chore(cd): update base service version to clouddriver:2023.08.28.14.14.14.release-1.30.x (#937)"
      ],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Clouddriver",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Deck",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Dinghy™",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Echo",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Fiat",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Front50",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [
        "fix: esapi CVE scan report (#602) (#603)"
      ],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Gate",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Igor",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Kayenta",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Orca",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Armory Rosco",
      "previousVersion": "2.30.1"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.30.2-rc1",
      "name": "Terraformer™",
      "previousVersion": "2.30.1"
    }
  ],
  "armoryVersion": "2.30.2-rc1",
  "ossServices": [
    {
      "commitMessages": [
        "fix(builds): Backport flag for installing aws cli (#6006)"
      ],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Deck",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Echo",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Front50",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Gate",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Igor",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Orca",
      "previousVersion": "1.30.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.3",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.30.3"
    }
  ],
  "ossVersion": "1.30.3",
  "prerelease": true,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "9e69fcd6cd17f31e35eeb7d443cdbf9c2d9ac187",
        "version": "2.30.2-rc1"
      },
      "deck": {
        "commit": "7737669d9a68843f448cc4c93ac2a6ea3485f95e",
        "version": "2.30.2-rc1"
      },
      "dinghy": {
        "commit": "5250de80948732c8caac6ffc5293a8af80a63a0f",
        "version": "2.30.2-rc1"
      },
      "echo": {
        "commit": "56844c654cd1b3981686933a9d5bc68011ee2bae",
        "version": "2.30.2-rc1"
      },
      "fiat": {
        "commit": "30319b57d40a7e9fd61067b7e0d9fb73bf9a6c46",
        "version": "2.30.2-rc1"
      },
      "front50": {
        "commit": "ec0919166ced870668d787708c249945e9291a01",
        "version": "2.30.2-rc1"
      },
      "gate": {
        "commit": "df941ff5c34d14e794c8784c28a1b30b28754971",
        "version": "2.30.2-rc1"
      },
      "igor": {
        "commit": "67b4c66f33b8b97b89e6b052654bebfea460a41f",
        "version": "2.30.2-rc1"
      },
      "kayenta": {
        "commit": "4d82ef4a72129a715749005235ce0d6ba4778603",
        "version": "2.30.2-rc1"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "638d81c8d3186b6deb8829574c6ac5b65c88c94a",
        "version": "2.30.2-rc1"
      },
      "rosco": {
        "commit": "e74de6eaccbed6301505d9f3d2f6745b410211a7",
        "version": "2.30.2-rc1"
      },
      "terraformer": {
        "commit": "650746ae3f596f9c6458987487c81840c85dd2a0",
        "version": "2.30.2-rc1"
      }
    },
    "timestamp": "2023-08-29 01:03:06",
    "version": "2.30.2-rc1"
  }
}
```