### PR TITLE
chore(release): add release notes for 2.28.7

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-7.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-7.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.7 Armory Release (OSS Spinnaker™ v1.28.0)
 toc_hide: true
-version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+version: 2.28.7
 date: 2023-09-13
 description: >
   Release notes for Armory Continuous Deployment v2.28.7
@@ -24,8 +24,66 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 
 > Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
 
+{{< include "breaking-changes/bc-orca-rdbms-configured-utf8.md" >}}
+
+{{< include "breaking-changes/bc-kubectl-120.md" >}}
+
+{{< include "breaking-changes/bc-hal-deprecation.md" >}}
+
+{{< include "breaking-changes/bc-plugin-compatibility-2-28-0.md" >}}
+
 ## Known issues
 <!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+{{< include "known-issues/ki-app-attr-not-configured.md" >}}
+
+{{< include "known-issues/ki-secrets-and-spring-cloud.md" >}}
+
+{{< include "known-issues/ki-pipelines-as-code-gh-comments.md" >}}
+
+{{< include "known-issues/ki-spel-expr-art-binding.md" >}}
+
+## Early access
+
+### **Dynamic Rollback Timeout**
+
+To make the dynamic timeout available, you need to enable the feature flag in Orca and Deck.
+
+On the Orca side, the feature flag overrides the default value rollback timeout - 5 min - with a UI input from the user. You **must** add this block to the **orca.yml** file if you want to enable the dynamic rollback timeout feature.
+
+```
+{
+  "rollback:"
+  "timeout:"
+    "enabled: true"
+}
+```
+
+On the Deck side, the feature flag enhances the Rollback Cluster stage UI with timeout input.
+
+`window.spinnakerSettings.feature.dynamicRollbackTimeout = true;`
+
+The default is used if there is no value set in the UI.
+
+### **Pipelines as Code multi-branch enhancement**
+
+Now you can configure Pipelines as Code to pull Dinghy files from multiple branches on the same repo. Cut out the tedious task of managing multiple repos; have a single repo for Spinnaker application pipelines. See [Multiple branches]({{< ref "plugins/pipelines-as-code/install/configure#multiple-branches" >}}) for how to enable and configure this feature.
+
+### **Terraform template fix**
+
+Armory fixed an issue with SpEL expression failures appearing while using Terraformer to serialize data from a Terraform Plan execution. With this feature flag fix enabled, you will be able to use the Terraform template file provider. Please open a support ticket if you need this fix.
+
+### **Automatically Cancel Jenkins Jobs**
+
+You now have the ability to cancel triggered Jenkins jobs when a Spinnaker pipeline is canceled, giving you more control over your full Jenkins workflow. Learn more about Jenkins + Spinnaker in this [documentation](https://spinnaker.io/changelogs/1.29.0-changelog/#orca).
+
+### **Pipelines adapt to sub pipeline with manual judgment color**
+When a child/sub pipeline is running and requires a manual judgment, the parent pipeline provides a visual representation that the child pipeline has an manual judgement waiting. This [Github pull request](https://github.com/spinnaker/deck/pull/9863) shows a visual representation of the feature in action.
+
+### **Enhanced BitBucket Server pull request handling**
+
+Trigger Spinnaker pipelines natively when pull requests are opened in BitBucket with newly added events including PR opened, deleted, and declined. See [Triggering pipelines with Bitbucket Server](https://spinnaker.io/docs/guides/user/pipeline/triggers/bitbucket-events/) in the Spinnaker docs for details.
+
 
 ## Highlighted updates
 
@@ -35,6 +93,15 @@ Each item category (such as UI) under here should be an h3 (###). List the follo
 - Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
 -->
 
+### Clouddriver
+* Addressed an issue where deploying to an ECS cluster with tags was failing
+
+### Orca
+* Fixed an issue where Blue/Green(Red/Black) in the non-default namespace for kubernetes was failing
+* Fixed an issue where a missing “namespace” attribute in a HTTP call was being sent while fetching manifest details from Clouddriver. 
+
+### Deck
+* Fixed some bugs related to Clone CX when instance types are incompatible. For full details, visit the [Github PR](https://github.com/spinnaker/deck/pull/9901#issue-1435271029)
 
 
 

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-7.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-7.md
@@ -1,0 +1,194 @@
+---
+title: v2.28.7 Armory Release (OSS Spinnaker™ v1.28.0)
+toc_hide: true
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+date: 2023-09-13
+description: >
+  Release notes for Armory Continuous Deployment v2.28.7
+---
+
+## 2023/09/13 Release Notes
+
+> Note: If you're experiencing production issues after upgrading Spinnaker, rollback to a previous working version and please report issues to [http://go.armory.io/support](http://go.armory.io/support).
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory 2.28.7, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker Community Contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.28.0](https://www.spinnaker.io/changelogs/1.28.0-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+Here's the BOM for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 50b4f4881597a374a9ba85aac90c0c0b9b22cee5
+    version: 2.28.7
+  deck:
+    commit: 5e7cef7a443e096cf8158c0c405c3ebbf8b97c35
+    version: 2.28.7
+  dinghy:
+    commit: 912007004f7720b418cd133301c7fb20207e1f2f
+    version: 2.28.7
+  echo:
+    commit: a602d9d5def0815cb52bdf6d695ca69cbf0abe3b
+    version: 2.28.7
+  fiat:
+    commit: d0874307a60cbc457616569be910f4142c152586
+    version: 2.28.7
+  front50:
+    commit: 3292cf2715a9e52bb4690601d4fd877407505ced
+    version: 2.28.7
+  gate:
+    commit: c8058f4362f3f4ad108fa146d628a162445c7579
+    version: 2.28.7
+  igor:
+    commit: 00998fa8b33acd6db5ffa8722e37593f608e9f64
+    version: 2.28.7
+  kayenta:
+    commit: 3da923fd822202425b90a181c9734910c5c4a609
+    version: 2.28.7
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 27a66c125270377772675b0e24d93566d878cfb9
+    version: 2.28.7
+  rosco:
+    commit: 27d4a2b4a1d5f099b68471303d4fd14af156d46d
+    version: 2.28.7
+  terraformer:
+    commit: ea9b0255b7d446bcbf0f0d4e03fc8699b7508431
+    version: 2.28.7
+timestamp: "2023-06-01 05:41:58"
+version: 2.28.7
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Echo - 2.28.6...2.28.7
+
+
+#### Armory Kayenta - 2.28.6...2.28.7
+
+  - chore(cd): update base service version to kayenta:2023.06.01.03.10.17.release-1.28.x (#443)
+
+#### Armory Igor - 2.28.6...2.28.7
+
+  - chore(cd): update base service version to igor:2023.03.27.19.09.31.release-1.28.x (#426)
+  - chore(cd): update armory-commons version to 3.11.5 (#450)
+  - chore(cd): update armory-commons version to 3.11.6 (#453)
+
+#### Armory Gate - 2.28.6...2.28.7
+
+
+#### Armory Orca - 2.28.6...2.28.7
+
+  - chore(cd): update base orca version to 2023.05.18.14.27.20.release-1.28.x (#645)
+
+#### Armory Deck - 2.28.6...2.28.7
+
+  - chore(cd): update base deck version to 2023.0.0-20230430115438.release-1.28.x (#1334)
+
+#### Armory Fiat - 2.28.6...2.28.7
+
+  - chore(cd): update armory-commons version to 3.11.5 (#472)
+  - chore(cd): update armory-commons version to 3.11.6 (#476)
+
+#### Armory Rosco - 2.28.6...2.28.7
+
+
+#### Armory Front50 - 2.28.6...2.28.7
+
+
+#### Terraformer™ - 2.28.6...2.28.7
+
+
+#### Armory Clouddriver - 2.28.6...2.28.7
+
+  - chore(cd): update base service version to clouddriver:2023.05.30.19.45.25.release-1.28.x (#880)
+
+#### Dinghy™ - 2.28.6...2.28.7
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Echo - 1.28.0
+
+
+#### Spinnaker Kayenta - 1.28.0
+
+  - chore(dependencies): Autobump orcaVersion (#963)
+
+#### Spinnaker Igor - 1.28.0
+
+  - chore(dependencies): Autobump fiatVersion (#1101)
+
+#### Spinnaker Gate - 1.28.0
+
+
+#### Spinnaker Orca - 1.28.0
+
+  - fix(deployment): fixed missing namespace while fetching manifest details from clouddriver (#4453) (#4455)
+
+#### Spinnaker Deck - 1.28.0
+
+  - fix(aws): Fixing bugs related to clone CX when instance types are incompatible with image/region (backport #9901) (#9975)
+
+#### Spinnaker Fiat - 1.28.0
+
+
+#### Spinnaker Rosco - 1.28.0
+
+
+#### Spinnaker Front50 - 1.28.0
+
+
+#### Spinnaker Clouddriver - 1.28.0
+
+  - chore(dependencies): Autobump fiatVersion (#5916)
+

--- a/payload.json
+++ b/payload.json
@@ -2,148 +2,166 @@
   "armoryServices": [
     {
       "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Terraformer™",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Igor",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to clouddriver:2023.08.25.16.41.50.release-1.30.x (#933)",
-        "chore(cd): update base service version to clouddriver:2023.08.28.14.14.14.release-1.30.x (#937)"
-      ],
-      "currentVersion": "2.30.2",
-      "name": "Armory Clouddriver",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Rosco",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [
-        "fix: esapi CVE scan report (#602) (#603)"
-      ],
-      "currentVersion": "2.30.2",
-      "name": "Armory Gate",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Front50",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Deck",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Dinghy™",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Fiat",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
-      "name": "Armory Orca",
-      "previousVersion": "2.30.1"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.30.2",
+      "currentVersion": "2.28.7",
       "name": "Armory Echo",
-      "previousVersion": "2.30.1"
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to kayenta:2023.06.01.03.10.17.release-1.28.x (#443)"
+      ],
+      "currentVersion": "2.28.7",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to igor:2023.03.27.19.09.31.release-1.28.x (#426)",
+        "chore(cd): update armory-commons version to 3.11.5 (#450)",
+        "chore(cd): update armory-commons version to 3.11.6 (#453)"
+      ],
+      "currentVersion": "2.28.7",
+      "name": "Armory Igor",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.7",
+      "name": "Armory Gate",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base orca version to 2023.05.18.14.27.20.release-1.28.x (#645)"
+      ],
+      "currentVersion": "2.28.7",
+      "name": "Armory Orca",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base deck version to 2023.0.0-20230430115438.release-1.28.x (#1334)"
+      ],
+      "currentVersion": "2.28.7",
+      "name": "Armory Deck",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update armory-commons version to 3.11.5 (#472)",
+        "chore(cd): update armory-commons version to 3.11.6 (#476)"
+      ],
+      "currentVersion": "2.28.7",
+      "name": "Armory Fiat",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.7",
+      "name": "Armory Rosco",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.7",
+      "name": "Armory Front50",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.7",
+      "name": "Terraformer™",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to clouddriver:2023.05.30.19.45.25.release-1.28.x (#880)"
+      ],
+      "currentVersion": "2.28.7",
+      "name": "Armory Clouddriver",
+      "previousVersion": "2.28.6"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.28.7",
+      "name": "Dinghy™",
+      "previousVersion": "2.28.6"
     }
   ],
-  "armoryVersion": "2.30.2",
+  "armoryVersion": "2.28.7",
   "ossServices": [
     {
       "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Igor",
-      "previousVersion": "1.30.3"
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.28.0"
     },
     {
       "commitMessages": [
-        "fix(builds): Backport flag for installing aws cli (#6006)"
+        "chore(dependencies): Autobump orcaVersion (#963)"
       ],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.30.3"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.30.3"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Gate",
-      "previousVersion": "1.30.3"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.30.3"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.30.3"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.30.3",
+      "currentVersion": "1.28.0",
       "name": "Spinnaker Kayenta",
-      "previousVersion": "1.30.3"
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump fiatVersion (#1101)"
+      ],
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Igor",
+      "previousVersion": "1.28.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.30.3"
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Gate",
+      "previousVersion": "1.28.0"
     },
     {
-      "commitMessages": [],
-      "currentVersion": "1.30.3",
+      "commitMessages": [
+        "fix(deployment): fixed missing namespace while fetching manifest details from clouddriver (#4453) (#4455)"
+      ],
+      "currentVersion": "1.28.0",
       "name": "Spinnaker Orca",
-      "previousVersion": "1.30.3"
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [
+        "fix(aws): Fixing bugs related to clone CX when instance types are incompatible with image/region (backport #9901) (#9975)"
+      ],
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.28.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.30.3",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.30.3"
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.28.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump fiatVersion (#5916)"
+      ],
+      "currentVersion": "1.28.0",
+      "name": "Spinnaker Clouddriver",
+      "previousVersion": "1.28.0"
     }
   ],
-  "ossVersion": "1.30.3",
+  "ossVersion": "1.28.0",
   "prerelease": false,
   "stack": {
     "artifactSources": {
@@ -157,40 +175,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "9e69fcd6cd17f31e35eeb7d443cdbf9c2d9ac187",
-        "version": "2.30.2"
+        "commit": "50b4f4881597a374a9ba85aac90c0c0b9b22cee5",
+        "version": "2.28.7"
       },
       "deck": {
-        "commit": "7737669d9a68843f448cc4c93ac2a6ea3485f95e",
-        "version": "2.30.2"
+        "commit": "5e7cef7a443e096cf8158c0c405c3ebbf8b97c35",
+        "version": "2.28.7"
       },
       "dinghy": {
-        "commit": "5250de80948732c8caac6ffc5293a8af80a63a0f",
-        "version": "2.30.2"
+        "commit": "912007004f7720b418cd133301c7fb20207e1f2f",
+        "version": "2.28.7"
       },
       "echo": {
-        "commit": "56844c654cd1b3981686933a9d5bc68011ee2bae",
-        "version": "2.30.2"
+        "commit": "a602d9d5def0815cb52bdf6d695ca69cbf0abe3b",
+        "version": "2.28.7"
       },
       "fiat": {
-        "commit": "30319b57d40a7e9fd61067b7e0d9fb73bf9a6c46",
-        "version": "2.30.2"
+        "commit": "d0874307a60cbc457616569be910f4142c152586",
+        "version": "2.28.7"
       },
       "front50": {
-        "commit": "ec0919166ced870668d787708c249945e9291a01",
-        "version": "2.30.2"
+        "commit": "3292cf2715a9e52bb4690601d4fd877407505ced",
+        "version": "2.28.7"
       },
       "gate": {
-        "commit": "df941ff5c34d14e794c8784c28a1b30b28754971",
-        "version": "2.30.2"
+        "commit": "c8058f4362f3f4ad108fa146d628a162445c7579",
+        "version": "2.28.7"
       },
       "igor": {
-        "commit": "67b4c66f33b8b97b89e6b052654bebfea460a41f",
-        "version": "2.30.2"
+        "commit": "00998fa8b33acd6db5ffa8722e37593f608e9f64",
+        "version": "2.28.7"
       },
       "kayenta": {
-        "commit": "4d82ef4a72129a715749005235ce0d6ba4778603",
-        "version": "2.30.2"
+        "commit": "3da923fd822202425b90a181c9734910c5c4a609",
+        "version": "2.28.7"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -201,19 +219,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "638d81c8d3186b6deb8829574c6ac5b65c88c94a",
-        "version": "2.30.2"
+        "commit": "27a66c125270377772675b0e24d93566d878cfb9",
+        "version": "2.28.7"
       },
       "rosco": {
-        "commit": "e74de6eaccbed6301505d9f3d2f6745b410211a7",
-        "version": "2.30.2"
+        "commit": "27d4a2b4a1d5f099b68471303d4fd14af156d46d",
+        "version": "2.28.7"
       },
       "terraformer": {
-        "commit": "650746ae3f596f9c6458987487c81840c85dd2a0",
-        "version": "2.30.2"
+        "commit": "ea9b0255b7d446bcbf0f0d4e03fc8699b7508431",
+        "version": "2.28.7"
       }
     },
-    "timestamp": "2023-08-29 01:03:06",
-    "version": "2.30.2"
+    "timestamp": "2023-06-01 05:41:58",
+    "version": "2.28.7"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [],
      "currentVersion": "2.28.7",
      "name": "Armory Echo",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to kayenta:2023.06.01.03.10.17.release-1.28.x (#443)"
      ],
      "currentVersion": "2.28.7",
      "name": "Armory Kayenta",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to igor:2023.03.27.19.09.31.release-1.28.x (#426)",
        "chore(cd): update armory-commons version to 3.11.5 (#450)",
        "chore(cd): update armory-commons version to 3.11.6 (#453)"
      ],
      "currentVersion": "2.28.7",
      "name": "Armory Igor",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.7",
      "name": "Armory Gate",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [
        "chore(cd): update base orca version to 2023.05.18.14.27.20.release-1.28.x (#645)"
      ],
      "currentVersion": "2.28.7",
      "name": "Armory Orca",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [
        "chore(cd): update base deck version to 2023.0.0-20230430115438.release-1.28.x (#1334)"
      ],
      "currentVersion": "2.28.7",
      "name": "Armory Deck",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [
        "chore(cd): update armory-commons version to 3.11.5 (#472)",
        "chore(cd): update armory-commons version to 3.11.6 (#476)"
      ],
      "currentVersion": "2.28.7",
      "name": "Armory Fiat",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.7",
      "name": "Armory Rosco",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.7",
      "name": "Armory Front50",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.7",
      "name": "Terraformer™",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2023.05.30.19.45.25.release-1.28.x (#880)"
      ],
      "currentVersion": "2.28.7",
      "name": "Armory Clouddriver",
      "previousVersion": "2.28.6"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.28.7",
      "name": "Dinghy™",
      "previousVersion": "2.28.6"
    }
  ],
  "armoryVersion": "2.28.7",
  "ossServices": [
    {
      "commitMessages": [],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Echo",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump orcaVersion (#963)"
      ],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#1101)"
      ],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Igor",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Gate",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "fix(deployment): fixed missing namespace while fetching manifest details from clouddriver (#4453) (#4455)"
      ],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Orca",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "fix(aws): Fixing bugs related to clone CX when instance types are incompatible with image/region (backport #9901) (#9975)"
      ],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Deck",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Front50",
      "previousVersion": "1.28.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#5916)"
      ],
      "currentVersion": "1.28.0",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.28.0"
    }
  ],
  "ossVersion": "1.28.0",
  "prerelease": false,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "50b4f4881597a374a9ba85aac90c0c0b9b22cee5",
        "version": "2.28.7"
      },
      "deck": {
        "commit": "5e7cef7a443e096cf8158c0c405c3ebbf8b97c35",
        "version": "2.28.7"
      },
      "dinghy": {
        "commit": "912007004f7720b418cd133301c7fb20207e1f2f",
        "version": "2.28.7"
      },
      "echo": {
        "commit": "a602d9d5def0815cb52bdf6d695ca69cbf0abe3b",
        "version": "2.28.7"
      },
      "fiat": {
        "commit": "d0874307a60cbc457616569be910f4142c152586",
        "version": "2.28.7"
      },
      "front50": {
        "commit": "3292cf2715a9e52bb4690601d4fd877407505ced",
        "version": "2.28.7"
      },
      "gate": {
        "commit": "c8058f4362f3f4ad108fa146d628a162445c7579",
        "version": "2.28.7"
      },
      "igor": {
        "commit": "00998fa8b33acd6db5ffa8722e37593f608e9f64",
        "version": "2.28.7"
      },
      "kayenta": {
        "commit": "3da923fd822202425b90a181c9734910c5c4a609",
        "version": "2.28.7"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "27a66c125270377772675b0e24d93566d878cfb9",
        "version": "2.28.7"
      },
      "rosco": {
        "commit": "27d4a2b4a1d5f099b68471303d4fd14af156d46d",
        "version": "2.28.7"
      },
      "terraformer": {
        "commit": "ea9b0255b7d446bcbf0f0d4e03fc8699b7508431",
        "version": "2.28.7"
      }
    },
    "timestamp": "2023-06-01 05:41:58",
    "version": "2.28.7"
  }
}
```