### PR TITLE
chore(release): add release notes for 2.30.3-rc1

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-30-3-rc1.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-30-3-rc1.md
@@ -1,0 +1,258 @@
+---
+title: v2.30.3-rc1 Armory Release (OSS Spinnaker™ v1.30.4)
+toc_hide: true
+date: 2023-10-02
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+description: >
+  Release notes for Armory Continuous Deployment v2.30.3-rc1. A beta release is not meant for installation in production environments.
+
+---
+
+## 2023/10/02 Release Notes
+
+## Disclaimer
+
+This pre-release software is to allow limited access to test or beta versions of the Armory services (“Services”) and to provide feedback and comments to Armory regarding the use of such Services. By using Services, you agree to be bound by the terms and conditions set forth herein.
+
+Your Feedback is important and we welcome any feedback, analysis, suggestions and comments (including, but not limited to, bug reports and test results) (collectively, “Feedback”) regarding the Services. Any Feedback you provide will become the property of Armory and you agree that Armory may use or otherwise exploit all or part of your feedback or any derivative thereof in any manner without any further remuneration, compensation or credit to you. You represent and warrant that any Feedback which is provided by you hereunder is original work made solely by you and does not infringe any third party intellectual property rights.
+
+Any Feedback provided to Armory shall be considered Armory Confidential Information and shall be covered by any confidentiality agreements between you and Armory.
+
+You acknowledge that you are using the Services on a purely voluntary basis, as a means of assisting, and in consideration of the opportunity to assist Armory to use, implement, and understand various facets of the Services. You acknowledge and agree that nothing herein or in your voluntary submission of Feedback creates any employment relationship between you and Armory.
+
+Armory may, in its sole discretion, at any time, terminate or discontinue all or your access to the Services. You acknowledge and agree that all such decisions by Armory are final and Armory will have no liability with respect to such decisions.
+
+YOUR USE OF THE SERVICES IS AT YOUR OWN RISK. THE SERVICES, THE ARMORY TOOLS AND THE CONTENT ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. ARMORY AND ITS LICENSORS MAKE NO REPRESENTATION, WARRANTY, OR GUARANTY AS TO THE RELIABILITY, TIMELINESS, QUALITY, SUITABILITY, TRUTH, AVAILABILITY, ACCURACY OR COMPLETENESS OF THE SERVICES, THE ARMORY TOOLS OR ANY CONTENT. ARMORY EXPRESSLY DISCLAIMS ON ITS OWN BEHALF AND ON BEHALF OF ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS ANY AND ALL WARRANTIES INCLUDING, WITHOUT LIMITATION (A) THE USE OF THE SERVICES OR THE ARMORY TOOLS WILL BE TIMELY, UNINTERRUPTED OR ERROR-FREE OR OPERATE IN COMBINATION WITH ANY OTHER HARDWARE, SOFTWARE, SYSTEM OR DATA, (B) THE SERVICES AND THE ARMORY TOOLS AND/OR THEIR QUALITY WILL MEET CUSTOMER”S REQUIREMENTS OR EXPECTATIONS, (C) ANY CONTENT WILL BE ACCURATE OR RELIABLE, (D) ERRORS OR DEFECTS WILL BE CORRECTED, OR (E) THE SERVICES, THE ARMORY TOOLS OR THE SERVER(S) THAT MAKE THE SERVICES AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. CUSTOMER AGREES THAT ARMORY SHALL NOT BE RESPONSIBLE FOR THE AVAILABILITY OR ACTS OR OMISSIONS OF ANY THIRD PARTY, INCLUDING ANY THIRD-PARTY APPLICATION OR PRODUCT, AND ARMORY HEREBY DISCLAIMS ANY AND ALL LIABILITY IN CONNECTION WITH SUCH THIRD PARTIES.
+
+IN NO EVENT SHALL ARMORY, ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS BE LIABLE UNDER THIS AGREEMENT FOR ANY CONSEQUENTIAL, SPECIAL, LOST PROFITS, INDIRECT OR OTHER DAMAGES, INCLUDING BUT NOT LIMITED TO LOST PROFITS, LOSS OF BUSINESS, COST OF COVER WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF ARMORY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. IN ANY EVENT, ARMORY, ITS EMPLOYEES’, AGENTS’, ATTORNEYS’, CONSULTANTS’ OR CONTRACTORS’ AGGREGATE LIABILITY UNDER THIS AGREEMENT FOR ANY CLAIM SHALL BE STRICTLY LIMITED TO $100.00. SOME STATES DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+
+You acknowledge that Armory has provided the Services in reliance upon the limitations of liability set forth herein and that the same is an essential basis of the bargain between the parties.
+
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory 2.30.3-rc1, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker Community Contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.30.4](https://www.spinnaker.io/changelogs/1.30.4-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+Here's the BOM for this version.
+<details><summary>Expand</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 767aa739e9c38d2ec7822e9e9a1838b69a56d4c0
+    version: 2.30.3-rc1
+  deck:
+    commit: 18e1727665cc52111760bf8e7f41cbf23da3b1a9
+    version: 2.30.3-rc1
+  dinghy:
+    commit: a3b59d9e4b810cc968d0f5e8e8370e1670574768
+    version: 2.30.3-rc1
+  echo:
+    commit: 2ef241fd3da29fb70cdb05432d022f0edd752d51
+    version: 2.30.3-rc1
+  fiat:
+    commit: 5d44e1f53d2f33b17f8decfb057a18cfe4b6fa08
+    version: 2.30.3-rc1
+  front50:
+    commit: 5d9bb31f65f96087be30ce96cea1b6d481a6bef4
+    version: 2.30.3-rc1
+  gate:
+    commit: 04598366642300d6f028df33b6206b5ce75f1038
+    version: 2.30.3-rc1
+  igor:
+    commit: f3d890427c79b7db6cf5fcb681e30542df97ff7c
+    version: 2.30.3-rc1
+  kayenta:
+    commit: 1d2f5193ec681b5122fe7c34da6bbd569da8e0b8
+    version: 2.30.3-rc1
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: ba62a86ef3af0007506b589a4272e3c2e03de00b
+    version: 2.30.3-rc1
+  rosco:
+    commit: a2b4662a40281e553de2182b680d5fd7e6bc3955
+    version: 2.30.3-rc1
+  terraformer:
+    commit: 249e7be18074af100212ddd554d9fb35afd65873
+    version: 2.30.3-rc1
+timestamp: "2023-09-29 15:15:45"
+version: 2.30.3-rc1
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Gate - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base service version to gate:2023.09.01.01.26.23.release-1.30.x (#608)
+  - chore(cd): update base service version to gate:2023.09.07.17.47.28.release-1.30.x (#612)
+  - chore(ci): removed aquasec scan action (#616) (#622)
+
+#### Armory Rosco - 2.30.2...2.30.3-rc1
+
+  - chore(ci): removed aquasec scan action (#565) (#568)
+
+#### Armory Orca - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base orca version to 2023.09.07.17.59.31.release-1.30.x (#693)
+  - chore(ci): removed aquasec scan action (#695) (#706)
+  - chore(cd): update base orca version to 2023.09.26.15.03.20.release-1.30.x (#721)
+
+#### Armory Fiat - 2.30.2...2.30.3-rc1
+
+  - chore(ci): removed aquasec scan action (#523) (#526)
+
+#### Armory Echo - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base service version to echo:2023.09.07.17.49.13.release-1.30.x (#616)
+  - chore(ci): removed aquasec scan action (#618) (#622)
+
+#### Dinghy™ - 2.30.2...2.30.3-rc1
+
+  - chore(ci): removed aquasec scan action (#489) (#492)
+  - chore(ci): removing aquasec scans for any push (#497) (#499)
+  - chore(log): Bumped up dinghy and plank versions. (backport #490) (#505)
+
+#### Armory Kayenta - 2.30.2...2.30.3-rc1
+
+  - chore(ci): removed aquasec scan action (#469) (#471)
+
+#### Armory Clouddriver - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base service version to clouddriver:2023.08.29.09.35.30.release-1.30.x (#945)
+  - chore(cd): update base service version to clouddriver:2023.09.07.19.02.07.release-1.30.x (#953)
+  - chore(cd): update base service version to clouddriver:2023.09.07.22.04.28.release-1.30.x (#955)
+  - chore(cd): update base service version to clouddriver:2023.09.08.02.48.03.release-1.30.x (#958)
+  - chore(cd): update base service version to clouddriver:2023.09.08.03.51.25.release-1.30.x (#959)
+  - chore(cd): update base service version to clouddriver:2023.09.08.04.42.03.release-1.30.x (#962)
+  - chore(cd): update base service version to clouddriver:2023.09.08.05.40.38.release-1.30.x (#963)
+  - chore(cd): update base service version to clouddriver:2023.09.08.14.33.30.release-1.30.x (#965)
+  - chore(cd): update base service version to clouddriver:2023.09.16.22.42.11.release-1.30.x (#976)
+  - chore(cd): update base service version to clouddriver:2023.09.20.19.03.35.release-1.30.x (#980)
+  - chore(ci): removed aquasec scan action (#971) (#983)
+  - fix: CVE-2023-37920 (#977) (#992)
+
+#### Armory Front50 - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base service version to front50:2023.09.07.17.50.48.release-1.30.x (#588)
+  - chore(ci): removed aquasec scan action (#590) (#594)
+  - chore(cd): update base service version to front50:2023.09.25.18.58.31.release-1.30.x (#601)
+  - fix(dependencies): match google cloud storage version to this set in OSS, and bump OSS front50 version. (#602)
+
+#### Terraformer™ - 2.30.2...2.30.3-rc1
+
+  - chore(ci): removing aquasec scans on push (#517) (#519)
+  - chore(ci): removed aquasec scan action (#510) (#512)
+
+#### Armory Deck - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base deck version to 2023.0.0-20230918174859.release-1.30.x (#1342)
+  - chore(cd): update base deck version to 2023.0.0-20230920215154.release-1.30.x (#1343)
+  - chore(ci): removed aquasec scan action (#1340) (#1345)
+  - chore(ci): removing docker build and aquasec scans (#1350)
+
+#### Armory Igor - 2.30.2...2.30.3-rc1
+
+  - chore(cd): update base service version to igor:2023.09.07.17.50.00.release-1.30.x (#491)
+  - chore(ci): removed aquasec scan action (#495) (#508)
+
+
+### Spinnaker
+
+
+#### Spinnaker Gate - 1.30.4
+
+  - fix(cachingFilter: Allow disabling the content caching filter (#1699) (#1700)
+  - chore(dependencies): Autobump fiatVersion (#1708)
+
+#### Spinnaker Rosco - 1.30.4
+
+
+#### Spinnaker Orca - 1.30.4
+
+  - chore(dependencies): Autobump fiatVersion (#4520)
+  - fix(vpc): add data annotation to vpc (#4534) (#4536)
+  - fix: duplicate entry exception for correlation_ids table. (#4521) (#4532)
+
+#### Spinnaker Fiat - 1.30.4
+
+
+#### Spinnaker Echo - 1.30.4
+
+  - chore(dependencies): Autobump fiatVersion (#1338)
+
+#### Spinnaker Kayenta - 1.30.4
+
+
+#### Spinnaker Clouddriver - 1.30.4
+
+  - chore(dependencies): Autobump fiatVersion (#6017)
+  - chore(gha): update to docker/login-action@v2 to stay up to date (#5920) (#6020)
+  - chore(deps): bump actions/cache from 2 to 3 (#5926) (#6022)
+  - chore(deps): bump actions/checkout from 2 to 3 (#5924) (#6024)
+  - chore(gha): replace action for creating github releases (backport #5929) (#6026)
+  - chore(deps): bump actions/setup-java from 2 to 3 (#5928) (#6029)
+  - chore(deps): bump docker/build-push-action from 3 to 4 (#5927) (#6030)
+  - chore(gha): replace deprecated set-output commands with environment files (#5930) (#6032)
+  - fix: Fix docker build in GHA by removing some of the GHA tools (#6033) (#6035)
+  - feat(lambda): Lambda calls default timeout after 50 seconds causing longer running lambdas to fail.  This adds configurable timeouts for lambda invocations (#6041) (#6044)
+  - fix(lambda): Lambda is leaking threads on agent refreshes.  remove the custom threadpool (#6048) (#6051)
+
+#### Spinnaker Front50 - 1.30.4
+
+  - chore(dependencies): Autobump fiatVersion (#1388)
+  - fix(dependency): fix dependency version leak of google-api-services-storage from kork in front50-web (#1302) (#1393)
+
+#### Spinnaker Deck - 1.30.4
+
+  - Revert "fix(core): conditionally hide expression evaluation warning messages (#9771)" (#10021) (#10024)
+  - fix: Scaling bounds should parse float not int (#10026) (#10031)
+
+#### Spinnaker Igor - 1.30.4
+
+  - chore(dependencies): Autobump fiatVersion (#1167)
+

--- a/payload.json
+++ b/payload.json
@@ -1,168 +1,222 @@
 {
   "armoryServices": [
     {
-      "commitMessages": [],
-      "currentVersion": "2.28.7",
-      "name": "Armory Echo",
-      "previousVersion": "2.28.6"
-    },
-    {
       "commitMessages": [
-        "chore(cd): update base service version to kayenta:2023.06.01.03.10.17.release-1.28.x (#443)"
+        "chore(cd): update base service version to gate:2023.09.01.01.26.23.release-1.30.x (#608)",
+        "chore(cd): update base service version to gate:2023.09.07.17.47.28.release-1.30.x (#612)",
+        "chore(ci): removed aquasec scan action (#616) (#622)"
       ],
-      "currentVersion": "2.28.7",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to igor:2023.03.27.19.09.31.release-1.28.x (#426)",
-        "chore(cd): update armory-commons version to 3.11.5 (#450)",
-        "chore(cd): update armory-commons version to 3.11.6 (#453)"
-      ],
-      "currentVersion": "2.28.7",
-      "name": "Armory Igor",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.7",
+      "currentVersion": "2.30.3-rc1",
       "name": "Armory Gate",
-      "previousVersion": "2.28.6"
+      "previousVersion": "2.30.2"
     },
     {
       "commitMessages": [
-        "chore(cd): update base orca version to 2023.05.18.14.27.20.release-1.28.x (#645)"
+        "chore(ci): removed aquasec scan action (#565) (#568)"
       ],
-      "currentVersion": "2.28.7",
-      "name": "Armory Orca",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base deck version to 2023.0.0-20230430115438.release-1.28.x (#1334)"
-      ],
-      "currentVersion": "2.28.7",
-      "name": "Armory Deck",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update armory-commons version to 3.11.5 (#472)",
-        "chore(cd): update armory-commons version to 3.11.6 (#476)"
-      ],
-      "currentVersion": "2.28.7",
-      "name": "Armory Fiat",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.7",
+      "currentVersion": "2.30.3-rc1",
       "name": "Armory Rosco",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.7",
-      "name": "Armory Front50",
-      "previousVersion": "2.28.6"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.28.7",
-      "name": "Terraformer™",
-      "previousVersion": "2.28.6"
+      "previousVersion": "2.30.2"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to clouddriver:2023.05.30.19.45.25.release-1.28.x (#880)"
+        "chore(cd): update base orca version to 2023.09.07.17.59.31.release-1.30.x (#693)",
+        "chore(ci): removed aquasec scan action (#695) (#706)",
+        "chore(cd): update base orca version to 2023.09.26.15.03.20.release-1.30.x (#721)"
       ],
-      "currentVersion": "2.28.7",
-      "name": "Armory Clouddriver",
-      "previousVersion": "2.28.6"
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Orca",
+      "previousVersion": "2.30.2"
     },
     {
-      "commitMessages": [],
-      "currentVersion": "2.28.7",
+      "commitMessages": [
+        "chore(ci): removed aquasec scan action (#523) (#526)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Fiat",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to echo:2023.09.07.17.49.13.release-1.30.x (#616)",
+        "chore(ci): removed aquasec scan action (#618) (#622)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Echo",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(ci): removed aquasec scan action (#489) (#492)",
+        "chore(ci): removing aquasec scans for any push (#497) (#499)",
+        "chore(log): Bumped up dinghy and plank versions. (backport #490) (#505)"
+      ],
+      "currentVersion": "2.30.3-rc1",
       "name": "Dinghy™",
-      "previousVersion": "2.28.6"
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(ci): removed aquasec scan action (#469) (#471)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to clouddriver:2023.08.29.09.35.30.release-1.30.x (#945)",
+        "chore(cd): update base service version to clouddriver:2023.09.07.19.02.07.release-1.30.x (#953)",
+        "chore(cd): update base service version to clouddriver:2023.09.07.22.04.28.release-1.30.x (#955)",
+        "chore(cd): update base service version to clouddriver:2023.09.08.02.48.03.release-1.30.x (#958)",
+        "chore(cd): update base service version to clouddriver:2023.09.08.03.51.25.release-1.30.x (#959)",
+        "chore(cd): update base service version to clouddriver:2023.09.08.04.42.03.release-1.30.x (#962)",
+        "chore(cd): update base service version to clouddriver:2023.09.08.05.40.38.release-1.30.x (#963)",
+        "chore(cd): update base service version to clouddriver:2023.09.08.14.33.30.release-1.30.x (#965)",
+        "chore(cd): update base service version to clouddriver:2023.09.16.22.42.11.release-1.30.x (#976)",
+        "chore(cd): update base service version to clouddriver:2023.09.20.19.03.35.release-1.30.x (#980)",
+        "chore(ci): removed aquasec scan action (#971) (#983)",
+        "fix: CVE-2023-37920 (#977) (#992)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Clouddriver",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to front50:2023.09.07.17.50.48.release-1.30.x (#588)",
+        "chore(ci): removed aquasec scan action (#590) (#594)",
+        "chore(cd): update base service version to front50:2023.09.25.18.58.31.release-1.30.x (#601)",
+        "fix(dependencies): match google cloud storage version to this set in OSS, and bump OSS front50 version. (#602)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Front50",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(ci): removing aquasec scans on push (#517) (#519)",
+        "chore(ci): removed aquasec scan action (#510) (#512)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Terraformer™",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base deck version to 2023.0.0-20230918174859.release-1.30.x (#1342)",
+        "chore(cd): update base deck version to 2023.0.0-20230920215154.release-1.30.x (#1343)",
+        "chore(ci): removed aquasec scan action (#1340) (#1345)",
+        "chore(ci): removing docker build and aquasec scans (#1350)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Deck",
+      "previousVersion": "2.30.2"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to igor:2023.09.07.17.50.00.release-1.30.x (#491)",
+        "chore(ci): removed aquasec scan action (#495) (#508)"
+      ],
+      "currentVersion": "2.30.3-rc1",
+      "name": "Armory Igor",
+      "previousVersion": "2.30.2"
     }
   ],
-  "armoryVersion": "2.28.7",
+  "armoryVersion": "2.30.3-rc1",
   "ossServices": [
     {
-      "commitMessages": [],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.28.0"
-    },
-    {
       "commitMessages": [
-        "chore(dependencies): Autobump orcaVersion (#963)"
+        "fix(cachingFilter: Allow disabling the content caching filter (#1699) (#1700)",
+        "chore(dependencies): Autobump fiatVersion (#1708)"
       ],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump fiatVersion (#1101)"
-      ],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Igor",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.28.0",
+      "currentVersion": "1.30.4",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "fix(deployment): fixed missing namespace while fetching manifest details from clouddriver (#4453) (#4455)"
-      ],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [
-        "fix(aws): Fixing bugs related to clone CX when instance types are incompatible with image/region (backport #9901) (#9975)"
-      ],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.30.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.28.0",
+      "currentVersion": "1.30.4",
       "name": "Spinnaker Rosco",
-      "previousVersion": "1.28.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.28.0",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.30.0"
     },
     {
       "commitMessages": [
-        "chore(dependencies): Autobump fiatVersion (#5916)"
+        "chore(dependencies): Autobump fiatVersion (#4520)",
+        "fix(vpc): add data annotation to vpc (#4534) (#4536)",
+        "fix: duplicate entry exception for correlation_ids table. (#4521) (#4532)"
       ],
-      "currentVersion": "1.28.0",
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump fiatVersion (#1338)"
+      ],
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump fiatVersion (#6017)",
+        "chore(gha): update to docker/login-action@v2 to stay up to date (#5920) (#6020)",
+        "chore(deps): bump actions/cache from 2 to 3 (#5926) (#6022)",
+        "chore(deps): bump actions/checkout from 2 to 3 (#5924) (#6024)",
+        "chore(gha): replace action for creating github releases (backport #5929) (#6026)",
+        "chore(deps): bump actions/setup-java from 2 to 3 (#5928) (#6029)",
+        "chore(deps): bump docker/build-push-action from 3 to 4 (#5927) (#6030)",
+        "chore(gha): replace deprecated set-output commands with environment files (#5930) (#6032)",
+        "fix: Fix docker build in GHA by removing some of the GHA tools (#6033) (#6035)",
+        "feat(lambda): Lambda calls default timeout after 50 seconds causing longer running lambdas to fail.  This adds configurable timeouts for lambda invocations (#6041) (#6044)",
+        "fix(lambda): Lambda is leaking threads on agent refreshes.  remove the custom threadpool (#6048) (#6051)"
+      ],
+      "currentVersion": "1.30.4",
       "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.28.0"
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump fiatVersion (#1388)",
+        "fix(dependency): fix dependency version leak of google-api-services-storage from kork in front50-web (#1302) (#1393)"
+      ],
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [
+        "Revert \"fix(core): conditionally hide expression evaluation warning messages (#9771)\" (#10021) (#10024)",
+        "fix: Scaling bounds should parse float not int (#10026) (#10031)"
+      ],
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.30.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump fiatVersion (#1167)"
+      ],
+      "currentVersion": "1.30.4",
+      "name": "Spinnaker Igor",
+      "previousVersion": "1.30.0"
     }
   ],
-  "ossVersion": "1.28.0",
-  "prerelease": false,
+  "ossVersion": "1.30.4",
+  "prerelease": true,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -175,40 +229,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "50b4f4881597a374a9ba85aac90c0c0b9b22cee5",
-        "version": "2.28.7"
+        "commit": "767aa739e9c38d2ec7822e9e9a1838b69a56d4c0",
+        "version": "2.30.3-rc1"
       },
       "deck": {
-        "commit": "5e7cef7a443e096cf8158c0c405c3ebbf8b97c35",
-        "version": "2.28.7"
+        "commit": "18e1727665cc52111760bf8e7f41cbf23da3b1a9",
+        "version": "2.30.3-rc1"
       },
       "dinghy": {
-        "commit": "912007004f7720b418cd133301c7fb20207e1f2f",
-        "version": "2.28.7"
+        "commit": "a3b59d9e4b810cc968d0f5e8e8370e1670574768",
+        "version": "2.30.3-rc1"
       },
       "echo": {
-        "commit": "a602d9d5def0815cb52bdf6d695ca69cbf0abe3b",
-        "version": "2.28.7"
+        "commit": "2ef241fd3da29fb70cdb05432d022f0edd752d51",
+        "version": "2.30.3-rc1"
       },
       "fiat": {
-        "commit": "d0874307a60cbc457616569be910f4142c152586",
-        "version": "2.28.7"
+        "commit": "5d44e1f53d2f33b17f8decfb057a18cfe4b6fa08",
+        "version": "2.30.3-rc1"
       },
       "front50": {
-        "commit": "3292cf2715a9e52bb4690601d4fd877407505ced",
-        "version": "2.28.7"
+        "commit": "5d9bb31f65f96087be30ce96cea1b6d481a6bef4",
+        "version": "2.30.3-rc1"
       },
       "gate": {
-        "commit": "c8058f4362f3f4ad108fa146d628a162445c7579",
-        "version": "2.28.7"
+        "commit": "04598366642300d6f028df33b6206b5ce75f1038",
+        "version": "2.30.3-rc1"
       },
       "igor": {
-        "commit": "00998fa8b33acd6db5ffa8722e37593f608e9f64",
-        "version": "2.28.7"
+        "commit": "f3d890427c79b7db6cf5fcb681e30542df97ff7c",
+        "version": "2.30.3-rc1"
       },
       "kayenta": {
-        "commit": "3da923fd822202425b90a181c9734910c5c4a609",
-        "version": "2.28.7"
+        "commit": "1d2f5193ec681b5122fe7c34da6bbd569da8e0b8",
+        "version": "2.30.3-rc1"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -219,19 +273,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "27a66c125270377772675b0e24d93566d878cfb9",
-        "version": "2.28.7"
+        "commit": "ba62a86ef3af0007506b589a4272e3c2e03de00b",
+        "version": "2.30.3-rc1"
       },
       "rosco": {
-        "commit": "27d4a2b4a1d5f099b68471303d4fd14af156d46d",
-        "version": "2.28.7"
+        "commit": "a2b4662a40281e553de2182b680d5fd7e6bc3955",
+        "version": "2.30.3-rc1"
       },
       "terraformer": {
-        "commit": "ea9b0255b7d446bcbf0f0d4e03fc8699b7508431",
-        "version": "2.28.7"
+        "commit": "249e7be18074af100212ddd554d9fb35afd65873",
+        "version": "2.30.3-rc1"
       }
     },
-    "timestamp": "2023-06-01 05:41:58",
-    "version": "2.28.7"
+    "timestamp": "2023-09-29 15:15:45",
+    "version": "2.30.3-rc1"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [
        "chore(cd): update base service version to gate:2023.09.01.01.26.23.release-1.30.x (#608)",
        "chore(cd): update base service version to gate:2023.09.07.17.47.28.release-1.30.x (#612)",
        "chore(ci): removed aquasec scan action (#616) (#622)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Gate",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(ci): removed aquasec scan action (#565) (#568)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Rosco",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base orca version to 2023.09.07.17.59.31.release-1.30.x (#693)",
        "chore(ci): removed aquasec scan action (#695) (#706)",
        "chore(cd): update base orca version to 2023.09.26.15.03.20.release-1.30.x (#721)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Orca",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(ci): removed aquasec scan action (#523) (#526)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Fiat",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to echo:2023.09.07.17.49.13.release-1.30.x (#616)",
        "chore(ci): removed aquasec scan action (#618) (#622)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Echo",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(ci): removed aquasec scan action (#489) (#492)",
        "chore(ci): removing aquasec scans for any push (#497) (#499)",
        "chore(log): Bumped up dinghy and plank versions. (backport #490) (#505)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Dinghy™",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(ci): removed aquasec scan action (#469) (#471)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Kayenta",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2023.08.29.09.35.30.release-1.30.x (#945)",
        "chore(cd): update base service version to clouddriver:2023.09.07.19.02.07.release-1.30.x (#953)",
        "chore(cd): update base service version to clouddriver:2023.09.07.22.04.28.release-1.30.x (#955)",
        "chore(cd): update base service version to clouddriver:2023.09.08.02.48.03.release-1.30.x (#958)",
        "chore(cd): update base service version to clouddriver:2023.09.08.03.51.25.release-1.30.x (#959)",
        "chore(cd): update base service version to clouddriver:2023.09.08.04.42.03.release-1.30.x (#962)",
        "chore(cd): update base service version to clouddriver:2023.09.08.05.40.38.release-1.30.x (#963)",
        "chore(cd): update base service version to clouddriver:2023.09.08.14.33.30.release-1.30.x (#965)",
        "chore(cd): update base service version to clouddriver:2023.09.16.22.42.11.release-1.30.x (#976)",
        "chore(cd): update base service version to clouddriver:2023.09.20.19.03.35.release-1.30.x (#980)",
        "chore(ci): removed aquasec scan action (#971) (#983)",
        "fix: CVE-2023-37920 (#977) (#992)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Clouddriver",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to front50:2023.09.07.17.50.48.release-1.30.x (#588)",
        "chore(ci): removed aquasec scan action (#590) (#594)",
        "chore(cd): update base service version to front50:2023.09.25.18.58.31.release-1.30.x (#601)",
        "fix(dependencies): match google cloud storage version to this set in OSS, and bump OSS front50 version. (#602)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Front50",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(ci): removing aquasec scans on push (#517) (#519)",
        "chore(ci): removed aquasec scan action (#510) (#512)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Terraformer™",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base deck version to 2023.0.0-20230918174859.release-1.30.x (#1342)",
        "chore(cd): update base deck version to 2023.0.0-20230920215154.release-1.30.x (#1343)",
        "chore(ci): removed aquasec scan action (#1340) (#1345)",
        "chore(ci): removing docker build and aquasec scans (#1350)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Deck",
      "previousVersion": "2.30.2"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to igor:2023.09.07.17.50.00.release-1.30.x (#491)",
        "chore(ci): removed aquasec scan action (#495) (#508)"
      ],
      "currentVersion": "2.30.3-rc1",
      "name": "Armory Igor",
      "previousVersion": "2.30.2"
    }
  ],
  "armoryVersion": "2.30.3-rc1",
  "ossServices": [
    {
      "commitMessages": [
        "fix(cachingFilter: Allow disabling the content caching filter (#1699) (#1700)",
        "chore(dependencies): Autobump fiatVersion (#1708)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Gate",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#4520)",
        "fix(vpc): add data annotation to vpc (#4534) (#4536)",
        "fix: duplicate entry exception for correlation_ids table. (#4521) (#4532)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Orca",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#1338)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Echo",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#6017)",
        "chore(gha): update to docker/login-action@v2 to stay up to date (#5920) (#6020)",
        "chore(deps): bump actions/cache from 2 to 3 (#5926) (#6022)",
        "chore(deps): bump actions/checkout from 2 to 3 (#5924) (#6024)",
        "chore(gha): replace action for creating github releases (backport #5929) (#6026)",
        "chore(deps): bump actions/setup-java from 2 to 3 (#5928) (#6029)",
        "chore(deps): bump docker/build-push-action from 3 to 4 (#5927) (#6030)",
        "chore(gha): replace deprecated set-output commands with environment files (#5930) (#6032)",
        "fix: Fix docker build in GHA by removing some of the GHA tools (#6033) (#6035)",
        "feat(lambda): Lambda calls default timeout after 50 seconds causing longer running lambdas to fail.  This adds configurable timeouts for lambda invocations (#6041) (#6044)",
        "fix(lambda): Lambda is leaking threads on agent refreshes.  remove the custom threadpool (#6048) (#6051)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#1388)",
        "fix(dependency): fix dependency version leak of google-api-services-storage from kork in front50-web (#1302) (#1393)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Front50",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [
        "Revert \"fix(core): conditionally hide expression evaluation warning messages (#9771)\" (#10021) (#10024)",
        "fix: Scaling bounds should parse float not int (#10026) (#10031)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Deck",
      "previousVersion": "1.30.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump fiatVersion (#1167)"
      ],
      "currentVersion": "1.30.4",
      "name": "Spinnaker Igor",
      "previousVersion": "1.30.0"
    }
  ],
  "ossVersion": "1.30.4",
  "prerelease": true,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "767aa739e9c38d2ec7822e9e9a1838b69a56d4c0",
        "version": "2.30.3-rc1"
      },
      "deck": {
        "commit": "18e1727665cc52111760bf8e7f41cbf23da3b1a9",
        "version": "2.30.3-rc1"
      },
      "dinghy": {
        "commit": "a3b59d9e4b810cc968d0f5e8e8370e1670574768",
        "version": "2.30.3-rc1"
      },
      "echo": {
        "commit": "2ef241fd3da29fb70cdb05432d022f0edd752d51",
        "version": "2.30.3-rc1"
      },
      "fiat": {
        "commit": "5d44e1f53d2f33b17f8decfb057a18cfe4b6fa08",
        "version": "2.30.3-rc1"
      },
      "front50": {
        "commit": "5d9bb31f65f96087be30ce96cea1b6d481a6bef4",
        "version": "2.30.3-rc1"
      },
      "gate": {
        "commit": "04598366642300d6f028df33b6206b5ce75f1038",
        "version": "2.30.3-rc1"
      },
      "igor": {
        "commit": "f3d890427c79b7db6cf5fcb681e30542df97ff7c",
        "version": "2.30.3-rc1"
      },
      "kayenta": {
        "commit": "1d2f5193ec681b5122fe7c34da6bbd569da8e0b8",
        "version": "2.30.3-rc1"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "ba62a86ef3af0007506b589a4272e3c2e03de00b",
        "version": "2.30.3-rc1"
      },
      "rosco": {
        "commit": "a2b4662a40281e553de2182b680d5fd7e6bc3955",
        "version": "2.30.3-rc1"
      },
      "terraformer": {
        "commit": "249e7be18074af100212ddd554d9fb35afd65873",
        "version": "2.30.3-rc1"
      }
    },
    "timestamp": "2023-09-29 15:15:45",
    "version": "2.30.3-rc1"
  }
}
```