### PR TITLE
Create(docs.armory.io): Version Explanation

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/versionexplain.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/versionexplain.md
@@ -1,0 +1,13 @@
+## Release Number Layout
+<details>
+  <summary>Click to Expand</summary>
+Armory release numbers help customers to distinguish the complexity of the release
+<pre><!-- language: lang-none -->
+| Armory CD Sample | 
+| ---------------- | 
+|  2  .  28  .  7  | 
+    \      \     \
+     \      \     Dot Release ("Dot" Version. Contains Bug Fixes, CVE Updates, and Limited Feature Flags)
+      \      Major Release (Long Term Support(LTS) and Feature Releases. Contains Major Feature changes, Fixes, and CVE Updates)
+      Indicates Armory CD Spinnaker Project (A "1" denotes the OSS Spinnaker Project)
+</pre></details>

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/versionexplain.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/versionexplain.md
@@ -1,13 +1,13 @@
 ## Release Number Layout
 <details>
   <summary>Click to Expand</summary>
-Armory release numbers help customers to distinguish the complexity of the release
+Armory release numbers help customers to distinguish releases at a glance
 <pre><!-- language: lang-none -->
 | Armory CD Sample | 
 | ---------------- | 
 |  2  .  28  .  7  | 
     \      \     \
-     \      \     Dot Release ("Dot" Version. Contains Bug Fixes, CVE Updates, and Limited Feature Flags)
-      \      Major Release (Long Term Support(LTS) and Feature Releases. Contains Major Feature changes, Fixes, and CVE Updates)
+     \      \     Dot Release ("Dot" Version. Contains Bug Fixes, CVE Updates, and Some Flagged Features)
+      \      Major Release (Long Term Support(LTS) and Feature Releases. Contains Major Feature, Base Code and Library changes, Fixes, and CVE Updates)
       Indicates Armory CD Spinnaker Project (A "1" denotes the OSS Spinnaker Project)
 </pre></details>


### PR DESCRIPTION
Create a .md that should be added to the beginning of the `rn-armory-spinnaker` _index.md, just under the description, but before he indexing of the versions

The Version pages should be updated to stop calling the 2.x releases as "minor" versions

This is loosely tied to [CDSH-529]

[CDSH-529]: https://armory.atlassian.net/browse/CDSH-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ