### PR TITLE
docs(fix): Fix compile error caused by unclosed shortcode tag

### DIFF
--- a/content/en/plugins/scale-agent/install/advanced/service-deploy/helm.md
+++ b/content/en/plugins/scale-agent/install/advanced/service-deploy/helm.md
@@ -166,7 +166,7 @@ helm install armory-agent armory-charts/agent-k8s-full \
 --namespace=<agent-namespace> \
 --set-file agentyml=<path-to>/armory-agent.yml \
 --values=<path-to>/values.yaml
-```
+{{< /highlight >}}
 
 ## Examples
 


### PR DESCRIPTION
Fix compile error caused by unclosed shortcode tag.
