### PR TITLE
chore(release): add release notes for 2.32.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -335,7 +335,7 @@ theme = "forest"
 [[params.versions]]
   version = "Armory CD v2.31"
   githubbranch = "v2.31"
-  url = "https://v2-31.docs.armory.io/continuous-deployment/"
+  url = "https://docs.armory.io/continuous-deployment/"
 
 [[params.versions]]
   version = "Armory CD v2.30"

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-0.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-0.md
@@ -3,7 +3,6 @@ title: v2.28.0 Armory Continuous Deployment Release (Spinnaker™ v1.28.0)
 toc_hide: true
 version: 02.28.0
 date: 2022-07-20
-hidden: true
 description: >
   Release notes for Armory Continuous Deployment (Armory CD) v2.28.0
 ---

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-1.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-1.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.1 Armory Continuous Deployment Release (Spinnaker™ v1.28.1)
 toc_hide: true
-version: 2.28.1
+version: 02.28.01
 date: 2022-11-23
 description: >
   Release notes for Armory Continuous Deployment v2.28.1

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-2.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-2.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.2 Armory Continuous Deployment Release (Spinnaker™ v1.28.4)
 toc_hide: true
-version: 2.28.2
+version: 02.28.02
 date: 2023-01-09
 description: >
   Release notes for Armory Continuous Deployment v2.28.2

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-3.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-3.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.3 Armory Continuous Deployment Release (Spinnaker™ v1.28.4)
 toc_hide: true
-version: 2.28.3
+version: 02.28.03
 date: 2023-01-26
 description: >
   Release notes for Armory Continuous Deployment v2.28.3

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-4.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-4.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.4 Armory Continuous Deployment Release (Spinnaker™ v1.28.4)
 toc_hide: true
-version: 2.28.4
+version: 02.28.04
 date: 2023-02-07
 description: >
   Release notes for Armory Continuous Deployment v2.28.4

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-5.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-5.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.5 Armory Continuous Deployment Release (Spinnaker™ v1.28.5)
 toc_hide: true
-version: 2.28.5
+version: 02.28.05
 date: 2023-03-07
 description: >
   Release notes for Armory Continuous Deployment v2.28.5

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-6.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-6.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.6 Armory Continuous Deployment Release (Spinnaker™ v1.28.6)
 toc_hide: true
-version: 2.28.6
+version: 02.28.06
 date: 2023-04-28
 description: >
   Release notes for Armory Continuous Deployment v2.28.6

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-7.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-28-7.md
@@ -1,7 +1,7 @@
 ---
 title: v2.28.7 Armory Continuous Deployment LTS Release (Spinnaker™ v1.28.0)
 toc_hide: true
-version: 2.28.7
+version: 02.28.07
 date: 2023-09-13
 description: >
   Release notes for Armory Continuous Deployment v2.28.7

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-1.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-1.md
@@ -18,7 +18,7 @@ FOR EXAMPLE, "Armory Continuous Deployment Release LTS" or "Armory Continuous De
 
 ## Required Armory Operator version
 
-To install, upgrade, or configure Armory CD 2.32.1, use Armory Operator 1.70 or later.
+To install, upgrade, or configure Armory CD 2.32.1, use Armory Operator 1.8.6 or later.
 
 ## Security
 
@@ -29,19 +29,150 @@ Armory scans the codebase as we develop and release software. Contact your Armor
 
 > Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
 
+### AWS Lambda plugin migrated to OSS
+Starting from Armory version 2.32.0 (OSS version 1.32.0), the AWS Lambda plugin has been migrated to OSS codebase.
+If you are using the AWS Lambda plugin, you will need to disable/remove it when upgrading to Armory version 2.32.0+ to
+avoid compatibility issues.
+
+Additionally, the AWS Lambda stages are now enabled using the Deck feature flag `feature.lambdaAdditionalStages = true;`
+as shown in the configuration block below.
+{{< highlight yaml "linenos=table,hl_lines=12" >}}
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      deck:
+        settings-local.js: |
+          ...
+          window.spinnakerSettings.feature.functions = true;
+          // Enable the AWS Lambda pipeline stages in Deck using the feature flag
+          window.spinnakerSettings.feature.lambdaAdditionalStages = true; 
+          ...
+      clouddriver:
+        aws:
+          enabled: true
+          features:
+            lambda:
+              enabled: true
+      ## Remove the AWS Lambda plugin from the Armory CD configuration.
+      #gate:
+      #  spinnaker:
+      #    extensibility:
+      #      deck-proxy:
+      #        enabled: true
+      #        plugins:
+      #          Aws.LambdaDeploymentPlugin:
+      #            enabled: true
+      #            version: <version>
+      #      repositories:
+      #        awsLambdaDeploymentPluginRepo:
+      #          url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json  
+      #orca:
+      #  spinnaker:
+      #    extensibility:
+      #      plugins:
+      #        Aws.LambdaDeploymentPlugin:
+      #          enabled: true
+      #          version: <version>
+      #          extensions:
+      #            Aws.LambdaDeploymentStage:
+      #              enabled: true
+      #      repositories:
+      #        awsLambdaDeploymentPluginRepo:
+      #          id: awsLambdaDeploymentPluginRepo
+      #          url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json
+{{< /highlight >}}
+
+
+Related OSS PRs:
+- https://github.com/spinnaker/orca/pull/4449
+- https://github.com/spinnaker/deck/pull/9988
+
 ## Known issues
 <!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
 
 ## Highlighted updates
-
 <!--
 Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
 - Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
 - Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
 -->
+### Terraformer support for AWS S3 Artifact Store
+OSS Spinnaker 1.32.0 introduced support for [artifact storage](https://spinnaker.io/changelogs/1.32.0-changelog/#artifact-store) 
+with AWS S3. This feature compresses `embdedded/base64` artifacts to `remote/base64` and uploads them to an AWS S3 bucket significantly 
+reducing the artifact size in the execution context. 
 
+Armory version 2.32.0 adds support for the same feature for the Terraform Integration stage.
 
+>Note: The artifact-store feature is disabled by default. To enable the artifact-store feature the following configuration is required:
+```yaml
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      spinnaker:
+        artifact-store:
+        enabled: true
+        s3:
+          enabled: true
+          region: <S3Bucket Region>
+          bucket: <S3Bucket Name>
+```
 
+When enabling the artifact-store feature it is recommended to deploy the services in this order:
+1. Clouddriver service
+2. Terraformer service
+3. Orca service
+4. Rosco service
+
+### Enable Jenkins job triggers for jobs located sub-folders
+When defining a Jenkins job in a sub-folder, the path contains forward slashes. By enabling this feature, Armory CD will be
+able to trigger Jenkins jobs located in sub-folders, correctly matching the job path.
+```yaml
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      echo:
+        feature:
+          igor:
+            jobNameAsQueryParameter: true
+      orca:
+        feature:
+          igor:
+            jobNameAsQueryParameter: true
+      igor:
+        feature:
+          igor:
+            jobNameAsQueryParameter: true
+```
+
+### Pipeline As Code: Bitbucket fallback support for default branch
+By default, Dinghy uses the `master` branch in your repository and fallbacks to `main` if `master` doesn’t exist.
+If you wish to use a different branch in your repository, you can configure that using the `repoConfig` tag in your YAML configuration.
+```yaml
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      dinghy:
+        repoConfig:
+        - branch: some_branch
+          provider: bitbucket-server
+          repo: my-bitbucket-repository
+```
 
 ###  Spinnaker community contributions
 

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-1.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-1.md
@@ -1,7 +1,7 @@
 ---
 title: v2.32.1 Armory Continuous Deployment Release (Spinnaker™ v1.32.4)
 toc_hide: true
-version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+version: 2.32.1
 date: 2024-03-14
 description: >
   Release notes for Armory Continuous Deployment v2.32.1.

--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-1.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-1.md
@@ -1,0 +1,239 @@
+---
+title: v2.32.1 Armory Continuous Deployment Release (Spinnaker™ v1.32.4)
+toc_hide: true
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+date: 2024-03-14
+description: >
+  Release notes for Armory Continuous Deployment v2.32.1.
+---
+
+<!-- 
+MAKE SURE TO ADD 'LTS' OR 'FEATURE' TO THE TITLE TO INDICATE RELEASE CATEGORY. 
+FOR EXAMPLE, "Armory Continuous Deployment Release LTS" or "Armory Continuous Deployment Release Feature" so users know release category and support time period 
+-->
+
+## 2024/03/14 release notes
+
+>Note: If you experience production issues after upgrading Armory Continuous Deployment, roll back to a previous working version and report issues to [http://go.armory.io/support](http://go.armory.io/support).
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory CD 2.32.1, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker community contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.32.4](https://www.spinnaker.io/changelogs/1.32.4-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+<details><summary>Expand to see the BOM</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: b29acea67a40b4145431137ba96454c1d1bf0d73
+    version: 2.32.1
+  deck:
+    commit: e7c8c0982afe9a49ab6c3d230f3aaa38e874eb30
+    version: 2.32.1
+  dinghy:
+    commit: f5b14ffba75721322ada662f2325e80ec86347de
+    version: 2.32.1
+  echo:
+    commit: 9d2abeeea4341e5ba94654925ba6488a9038af3f
+    version: 2.32.1
+  fiat:
+    commit: 3f3fe6bf09708847a0f853bc74f6755920a4312b
+    version: 2.32.1
+  front50:
+    commit: ba318cd2c445f14e5d6c3db87fa1658549385403
+    version: 2.32.1
+  gate:
+    commit: dd64887668a2e2212667ca942e0bfd303aa34c60
+    version: 2.32.1
+  igor:
+    commit: 9339ab63ab3d85ebcb00131033d19f26ad436f05
+    version: 2.32.1
+  kayenta:
+    commit: bccd150fcc8a7cb7df537ec6269bce5d2843c703
+    version: 2.32.1
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 9d45d87956abd9aad29ef8f9858e602e72d78c3c
+    version: 2.32.1
+  rosco:
+    commit: dfe611ffdd2cf9ae7c524fb9970af47350ca5e96
+    version: 2.32.1
+  terraformer:
+    commit: 6dbdb8b4c277cca4285b4d29d10f6cf3765f7590
+    version: 2.32.1
+timestamp: "2024-03-12 14:53:28"
+version: 2.32.1
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Front50 - 2.32.0...2.32.1
+
+  - chore(cd): update armory-commons version to 3.15.3 (#659)
+  - chore(cd): update armory-commons version to 3.15.4 (#660)
+  - Fixing gcs dependencies (#662)
+  - chore(armory-commons): Update armory-commons to 3.15.4 (#665)
+  - chore(cd): update base service version to front50:2024.03.08.16.52.13.release-1.32.x (#666)
+  - chore(cd): update base service version to front50:2024.03.08.19.18.53.release-1.32.x (#667)
+
+#### Armory Clouddriver - 2.32.0...2.32.1
+
+  - chore(cd): update base service version to clouddriver:2024.02.27.14.37.13.release-1.32.x (#1083)
+  - chore(cd): update armory-commons version to 3.15.3 (#1086)
+  - chore(cd): update armory-commons version to 3.15.4 (#1088)
+  - chore(cd): update base service version to clouddriver:2024.03.08.19.52.28.release-1.32.x (#1091)
+
+#### Armory Deck - 2.32.0...2.32.1
+
+
+#### Armory Orca - 2.32.0...2.32.1
+
+  - chore(cd): update base orca version to 2024.02.27.15.33.36.release-1.32.x (#833)
+  - chore(cd): update armory-commons version to 3.15.3 (#836)
+  - chore(cd): update armory-commons version to 3.15.4 (#837)
+  - chore(cd): update base orca version to 2024.03.08.16.54.30.release-1.32.x (#840)
+  - chore(cd): update base orca version to 2024.03.08.19.21.42.release-1.32.x (#841)
+
+#### Dinghy™ - 2.32.0...2.32.1
+
+
+#### Armory Gate - 2.32.0...2.32.1
+
+  - fix: esapi CVE scan report (#602) (#700)
+  - chore(cd): update armory-commons version to 3.15.4 (#704)
+  - chore(cd): update base service version to gate:2024.03.08.19.17.43.release-1.32.x (#707)
+
+#### Armory Rosco - 2.32.0...2.32.1
+
+  - chore(cd): update armory-commons version to 3.15.3 (#647)
+  - chore(cd): update armory-commons version to 3.15.4 (#648)
+  - chore(cd): update base service version to rosco:2024.03.08.16.49.31.release-1.32.x (#650)
+
+#### Armory Echo - 2.32.0...2.32.1
+
+  - chore(cd): update base service version to echo:2024.02.27.15.33.43.release-1.32.x (#692)
+  - chore(cd): update armory-commons version to 3.15.3 (#694)
+  - chore(cd): update armory-commons version to 3.15.4 (#695)
+  - chore(cd): update base service version to echo:2024.03.08.16.50.19.release-1.32.x (#697)
+  - chore(cd): update base service version to echo:2024.03.08.19.17.18.release-1.32.x (#698)
+
+#### Terraformer™ - 2.32.0...2.32.1
+
+  - fix(remote/artifacts): Passing user to clouddriver when using remote store (#548) (#549)
+
+#### Armory Fiat - 2.32.0...2.32.1
+
+  - chore(cd): update armory-commons version to 3.15.4 (#587)
+  - chore(cd): update base service version to fiat:2024.03.08.16.48.59.release-1.32.x (#590)
+
+#### Armory Kayenta - 2.32.0...2.32.1
+
+  - chore(cd): update armory-commons version to 3.15.4 (#524)
+  - chore(cd): update base service version to kayenta:2024.03.08.20.48.11.release-1.32.x (#525)
+
+#### Armory Igor - 2.32.0...2.32.1
+
+  - chore(cd): update base service version to igor:2024.02.27.15.32.19.release-1.32.x (#579)
+  - chore(cd): update armory-commons version to 3.15.3 (#581)
+  - chore(cd): update armory-commons version to 3.15.4 (#582)
+  - chore(cd): update base service version to igor:2024.03.08.16.52.17.release-1.32.x (#584)
+  - chore(cd): update base service version to igor:2024.03.08.19.18.39.release-1.32.x (#585)
+
+
+### Spinnaker
+
+
+#### Spinnaker Front50 - 1.32.4
+
+  - chore(dependencies): Autobump korkVersion (#1439)
+  - chore(dependencies): Autobump fiatVersion (#1440)
+
+#### Spinnaker Clouddriver - 1.32.4
+
+  - fix: Change the agent type name to not include the account name since this would generate LOTS of tables and cause problems long term (#6158) (#6165)
+  - chore(dependencies): Autobump korkVersion (#6169)
+  - chore(dependencies): Autobump fiatVersion (#6170)
+
+#### Spinnaker Deck - 1.32.4
+
+
+#### Spinnaker Orca - 1.32.4
+
+  - fix(jenkins): Enable properties and artifacts with job name as query parameter (#4661) (#4664)
+  - chore(dependencies): Autobump korkVersion (#4667)
+  - chore(dependencies): Autobump fiatVersion (#4668)
+
+#### Spinnaker Gate - 1.32.4
+
+  - chore(dependencies): Autobump korkVersion (#1773)
+  - chore(dependencies): Autobump fiatVersion (#1774)
+
+#### Spinnaker Rosco - 1.32.4
+
+  - chore(dependencies): Autobump korkVersion (#1077)
+
+#### Spinnaker Echo - 1.32.4
+
+  - fix(jenkins): Enable properties and artifacts with job name as query parameter (#1393) (#1396)
+  - chore(dependencies): Autobump korkVersion (#1398)
+  - chore(dependencies): Autobump fiatVersion (#1399)
+
+#### Spinnaker Fiat - 1.32.4
+
+  - chore(dependencies): Autobump korkVersion (#1145)
+
+#### Spinnaker Kayenta - 1.32.4
+
+  - chore(dependencies): Autobump orcaVersion (#1023)
+
+#### Spinnaker Igor - 1.32.4
+
+  - fix(jenkins): Enable properties and artifacts with job name as query parameter (#1230) (#1233)
+  - chore(dependencies): Autobump korkVersion (#1235)
+  - chore(dependencies): Autobump fiatVersion (#1236)
+

--- a/layouts/partials/list-recent-release-notes.html
+++ b/layouts/partials/list-recent-release-notes.html
@@ -39,7 +39,7 @@ Armory release numbers help customers to distinguish releases at a glance.
 
         {{/* this will pick out the first {major}.{minor}.{patch} numbers */}}
         {{ $semverSlice := findRE "[0-9]+" .Title }}
-        {{ if and (ge (len $semverSlice) 4) (lt (len $displayedTitles) 4) }}
+        {{ if and (ge (len $semverSlice) 3) (lt (len $displayedTitles) 3) }}
           {{if and (le ( index $semverSlice 0 ) $semverActiveMajor) (lt ( index $semverSlice 1 ) $semverActiveMinor)  }}
             {{ $semverActiveMajor = index $semverSlice 0 }}
             {{ $semverActiveMinor = index $semverSlice 1 }}

--- a/payload.json
+++ b/payload.json
@@ -2,100 +2,124 @@
   "armoryServices": [
     {
       "commitMessages": [
+        "chore(cd): update armory-commons version to 3.15.3 (#659)",
+        "chore(cd): update armory-commons version to 3.15.4 (#660)",
+        "Fixing gcs dependencies (#662)",
+        "chore(armory-commons): Update armory-commons to 3.15.4 (#665)",
         "chore(cd): update base service version to front50:2024.03.08.16.52.13.release-1.32.x (#666)",
         "chore(cd): update base service version to front50:2024.03.08.19.18.53.release-1.32.x (#667)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Front50",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "chore(cd): update base service version to clouddriver:2024.02.27.14.37.13.release-1.32.x (#1083)",
+        "chore(cd): update armory-commons version to 3.15.3 (#1086)",
+        "chore(cd): update armory-commons version to 3.15.4 (#1088)",
         "chore(cd): update base service version to clouddriver:2024.03.08.19.52.28.release-1.32.x (#1091)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Clouddriver",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Deck",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "chore(cd): update base orca version to 2024.02.27.15.33.36.release-1.32.x (#833)",
+        "chore(cd): update armory-commons version to 3.15.3 (#836)",
+        "chore(cd): update armory-commons version to 3.15.4 (#837)",
         "chore(cd): update base orca version to 2024.03.08.16.54.30.release-1.32.x (#840)",
         "chore(cd): update base orca version to 2024.03.08.19.21.42.release-1.32.x (#841)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Orca",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Dinghy™",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "fix: esapi CVE scan report (#602) (#700)",
+        "chore(cd): update armory-commons version to 3.15.4 (#704)",
         "chore(cd): update base service version to gate:2024.03.08.19.17.43.release-1.32.x (#707)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Gate",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "chore(cd): update armory-commons version to 3.15.3 (#647)",
+        "chore(cd): update armory-commons version to 3.15.4 (#648)",
         "chore(cd): update base service version to rosco:2024.03.08.16.49.31.release-1.32.x (#650)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Rosco",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "chore(cd): update base service version to echo:2024.02.27.15.33.43.release-1.32.x (#692)",
+        "chore(cd): update armory-commons version to 3.15.3 (#694)",
+        "chore(cd): update armory-commons version to 3.15.4 (#695)",
         "chore(cd): update base service version to echo:2024.03.08.16.50.19.release-1.32.x (#697)",
         "chore(cd): update base service version to echo:2024.03.08.19.17.18.release-1.32.x (#698)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Echo",
-      "previousVersion": "2.32.1-rc2"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.1-rc3",
-      "name": "Terraformer™",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "fix(remote/artifacts): Passing user to clouddriver when using remote store (#548) (#549)"
+      ],
+      "currentVersion": "2.32.1",
+      "name": "Terraformer™",
+      "previousVersion": "2.32.0"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update armory-commons version to 3.15.4 (#587)",
         "chore(cd): update base service version to fiat:2024.03.08.16.48.59.release-1.32.x (#590)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Fiat",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "chore(cd): update armory-commons version to 3.15.4 (#524)",
         "chore(cd): update base service version to kayenta:2024.03.08.20.48.11.release-1.32.x (#525)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Kayenta",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     },
     {
       "commitMessages": [
+        "chore(cd): update base service version to igor:2024.02.27.15.32.19.release-1.32.x (#579)",
+        "chore(cd): update armory-commons version to 3.15.3 (#581)",
+        "chore(cd): update armory-commons version to 3.15.4 (#582)",
         "chore(cd): update base service version to igor:2024.03.08.16.52.17.release-1.32.x (#584)",
         "chore(cd): update base service version to igor:2024.03.08.19.18.39.release-1.32.x (#585)"
       ],
-      "currentVersion": "2.32.1-rc3",
+      "currentVersion": "2.32.1",
       "name": "Armory Igor",
-      "previousVersion": "2.32.1-rc2"
+      "previousVersion": "2.32.0"
     }
   ],
-  "armoryVersion": "2.32.1-rc3",
+  "armoryVersion": "2.32.1",
   "ossServices": [
     {
       "commitMessages": [
@@ -104,31 +128,33 @@
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Front50",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
+        "fix: Change the agent type name to not include the account name since this would generate LOTS of tables and cause problems long term (#6158) (#6165)",
         "chore(dependencies): Autobump korkVersion (#6169)",
         "chore(dependencies): Autobump fiatVersion (#6170)"
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Deck",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
+        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#4661) (#4664)",
         "chore(dependencies): Autobump korkVersion (#4667)",
         "chore(dependencies): Autobump fiatVersion (#4668)"
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Orca",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
@@ -137,7 +163,7 @@
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
@@ -145,16 +171,17 @@
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Rosco",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
+        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#1393) (#1396)",
         "chore(dependencies): Autobump korkVersion (#1398)",
         "chore(dependencies): Autobump fiatVersion (#1399)"
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Echo",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
@@ -162,7 +189,7 @@
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Fiat",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
@@ -170,20 +197,21 @@
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Kayenta",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     },
     {
       "commitMessages": [
+        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#1230) (#1233)",
         "chore(dependencies): Autobump korkVersion (#1235)",
         "chore(dependencies): Autobump fiatVersion (#1236)"
       ],
       "currentVersion": "1.32.4",
       "name": "Spinnaker Igor",
-      "previousVersion": "1.32.3"
+      "previousVersion": "1.32.0"
     }
   ],
   "ossVersion": "1.32.4",
-  "prerelease": true,
+  "prerelease": false,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -197,39 +225,39 @@
     "services": {
       "clouddriver": {
         "commit": "b29acea67a40b4145431137ba96454c1d1bf0d73",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "deck": {
         "commit": "e7c8c0982afe9a49ab6c3d230f3aaa38e874eb30",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "dinghy": {
         "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "echo": {
         "commit": "9d2abeeea4341e5ba94654925ba6488a9038af3f",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "fiat": {
         "commit": "3f3fe6bf09708847a0f853bc74f6755920a4312b",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "front50": {
         "commit": "ba318cd2c445f14e5d6c3db87fa1658549385403",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "gate": {
         "commit": "dd64887668a2e2212667ca942e0bfd303aa34c60",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "igor": {
         "commit": "9339ab63ab3d85ebcb00131033d19f26ad436f05",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "kayenta": {
         "commit": "bccd150fcc8a7cb7df537ec6269bce5d2843c703",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -241,18 +269,18 @@
       },
       "orca": {
         "commit": "9d45d87956abd9aad29ef8f9858e602e72d78c3c",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "rosco": {
         "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       },
       "terraformer": {
         "commit": "6dbdb8b4c277cca4285b4d29d10f6cf3765f7590",
-        "version": "2.32.1-rc3"
+        "version": "2.32.1"
       }
     },
     "timestamp": "2024-03-12 14:53:28",
-    "version": "2.32.1-rc3"
+    "version": "2.32.1"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [
        "chore(cd): update armory-commons version to 3.15.3 (#659)",
        "chore(cd): update armory-commons version to 3.15.4 (#660)",
        "Fixing gcs dependencies (#662)",
        "chore(armory-commons): Update armory-commons to 3.15.4 (#665)",
        "chore(cd): update base service version to front50:2024.03.08.16.52.13.release-1.32.x (#666)",
        "chore(cd): update base service version to front50:2024.03.08.19.18.53.release-1.32.x (#667)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Front50",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2024.02.27.14.37.13.release-1.32.x (#1083)",
        "chore(cd): update armory-commons version to 3.15.3 (#1086)",
        "chore(cd): update armory-commons version to 3.15.4 (#1088)",
        "chore(cd): update base service version to clouddriver:2024.03.08.19.52.28.release-1.32.x (#1091)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Clouddriver",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.1",
      "name": "Armory Deck",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update base orca version to 2024.02.27.15.33.36.release-1.32.x (#833)",
        "chore(cd): update armory-commons version to 3.15.3 (#836)",
        "chore(cd): update armory-commons version to 3.15.4 (#837)",
        "chore(cd): update base orca version to 2024.03.08.16.54.30.release-1.32.x (#840)",
        "chore(cd): update base orca version to 2024.03.08.19.21.42.release-1.32.x (#841)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Orca",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.1",
      "name": "Dinghy™",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "fix: esapi CVE scan report (#602) (#700)",
        "chore(cd): update armory-commons version to 3.15.4 (#704)",
        "chore(cd): update base service version to gate:2024.03.08.19.17.43.release-1.32.x (#707)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Gate",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update armory-commons version to 3.15.3 (#647)",
        "chore(cd): update armory-commons version to 3.15.4 (#648)",
        "chore(cd): update base service version to rosco:2024.03.08.16.49.31.release-1.32.x (#650)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Rosco",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to echo:2024.02.27.15.33.43.release-1.32.x (#692)",
        "chore(cd): update armory-commons version to 3.15.3 (#694)",
        "chore(cd): update armory-commons version to 3.15.4 (#695)",
        "chore(cd): update base service version to echo:2024.03.08.16.50.19.release-1.32.x (#697)",
        "chore(cd): update base service version to echo:2024.03.08.19.17.18.release-1.32.x (#698)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Echo",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "fix(remote/artifacts): Passing user to clouddriver when using remote store (#548) (#549)"
      ],
      "currentVersion": "2.32.1",
      "name": "Terraformer™",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update armory-commons version to 3.15.4 (#587)",
        "chore(cd): update base service version to fiat:2024.03.08.16.48.59.release-1.32.x (#590)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Fiat",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update armory-commons version to 3.15.4 (#524)",
        "chore(cd): update base service version to kayenta:2024.03.08.20.48.11.release-1.32.x (#525)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Kayenta",
      "previousVersion": "2.32.0"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to igor:2024.02.27.15.32.19.release-1.32.x (#579)",
        "chore(cd): update armory-commons version to 3.15.3 (#581)",
        "chore(cd): update armory-commons version to 3.15.4 (#582)",
        "chore(cd): update base service version to igor:2024.03.08.16.52.17.release-1.32.x (#584)",
        "chore(cd): update base service version to igor:2024.03.08.19.18.39.release-1.32.x (#585)"
      ],
      "currentVersion": "2.32.1",
      "name": "Armory Igor",
      "previousVersion": "2.32.0"
    }
  ],
  "armoryVersion": "2.32.1",
  "ossServices": [
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1439)",
        "chore(dependencies): Autobump fiatVersion (#1440)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Front50",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "fix: Change the agent type name to not include the account name since this would generate LOTS of tables and cause problems long term (#6158) (#6165)",
        "chore(dependencies): Autobump korkVersion (#6169)",
        "chore(dependencies): Autobump fiatVersion (#6170)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Deck",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#4661) (#4664)",
        "chore(dependencies): Autobump korkVersion (#4667)",
        "chore(dependencies): Autobump fiatVersion (#4668)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Orca",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1773)",
        "chore(dependencies): Autobump fiatVersion (#1774)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Gate",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1077)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#1393) (#1396)",
        "chore(dependencies): Autobump korkVersion (#1398)",
        "chore(dependencies): Autobump fiatVersion (#1399)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Echo",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump korkVersion (#1145)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump orcaVersion (#1023)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [
        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#1230) (#1233)",
        "chore(dependencies): Autobump korkVersion (#1235)",
        "chore(dependencies): Autobump fiatVersion (#1236)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Igor",
      "previousVersion": "1.32.0"
    }
  ],
  "ossVersion": "1.32.4",
  "prerelease": false,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "b29acea67a40b4145431137ba96454c1d1bf0d73",
        "version": "2.32.1"
      },
      "deck": {
        "commit": "e7c8c0982afe9a49ab6c3d230f3aaa38e874eb30",
        "version": "2.32.1"
      },
      "dinghy": {
        "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
        "version": "2.32.1"
      },
      "echo": {
        "commit": "9d2abeeea4341e5ba94654925ba6488a9038af3f",
        "version": "2.32.1"
      },
      "fiat": {
        "commit": "3f3fe6bf09708847a0f853bc74f6755920a4312b",
        "version": "2.32.1"
      },
      "front50": {
        "commit": "ba318cd2c445f14e5d6c3db87fa1658549385403",
        "version": "2.32.1"
      },
      "gate": {
        "commit": "dd64887668a2e2212667ca942e0bfd303aa34c60",
        "version": "2.32.1"
      },
      "igor": {
        "commit": "9339ab63ab3d85ebcb00131033d19f26ad436f05",
        "version": "2.32.1"
      },
      "kayenta": {
        "commit": "bccd150fcc8a7cb7df537ec6269bce5d2843c703",
        "version": "2.32.1"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "9d45d87956abd9aad29ef8f9858e602e72d78c3c",
        "version": "2.32.1"
      },
      "rosco": {
        "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
        "version": "2.32.1"
      },
      "terraformer": {
        "commit": "6dbdb8b4c277cca4285b4d29d10f6cf3765f7590",
        "version": "2.32.1"
      }
    },
    "timestamp": "2024-03-12 14:53:28",
    "version": "2.32.1"
  }
}
```