### PR TITLE
chore(release): add release notes for 2.32.2-rc6

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-32-2-rc6.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-32-2-rc6.md
@@ -1,0 +1,201 @@
+---
+title: v2.32.2-rc6 Armory Continuous Deployment Release (Spinnaker™ v1.32.4)
+toc_hide: true
+date: 2024-04-26
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+description: >
+  Release notes for Armory Continuous Deployment v2.32.2-rc6. A beta release is not meant for installation in production environments.
+
+---
+
+## 2024/04/26 release notes
+
+## Disclaimer
+
+This pre-release software is to allow limited access to test or beta versions of the Armory services (“Services”) and to provide feedback and comments to Armory regarding the use of such Services. By using Services, you agree to be bound by the terms and conditions set forth herein.
+
+Your Feedback is important and we welcome any feedback, analysis, suggestions and comments (including, but not limited to, bug reports and test results) (collectively, “Feedback”) regarding the Services. Any Feedback you provide will become the property of Armory and you agree that Armory may use or otherwise exploit all or part of your feedback or any derivative thereof in any manner without any further remuneration, compensation or credit to you. You represent and warrant that any Feedback which is provided by you hereunder is original work made solely by you and does not infringe any third party intellectual property rights.
+
+Any Feedback provided to Armory shall be considered Armory Confidential Information and shall be covered by any confidentiality agreements between you and Armory.
+
+You acknowledge that you are using the Services on a purely voluntary basis, as a means of assisting, and in consideration of the opportunity to assist Armory to use, implement, and understand various facets of the Services. You acknowledge and agree that nothing herein or in your voluntary submission of Feedback creates any employment relationship between you and Armory.
+
+Armory may, in its sole discretion, at any time, terminate or discontinue all or your access to the Services. You acknowledge and agree that all such decisions by Armory are final and Armory will have no liability with respect to such decisions.
+
+YOUR USE OF THE SERVICES IS AT YOUR OWN RISK. THE SERVICES, THE ARMORY TOOLS AND THE CONTENT ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. ARMORY AND ITS LICENSORS MAKE NO REPRESENTATION, WARRANTY, OR GUARANTY AS TO THE RELIABILITY, TIMELINESS, QUALITY, SUITABILITY, TRUTH, AVAILABILITY, ACCURACY OR COMPLETENESS OF THE SERVICES, THE ARMORY TOOLS OR ANY CONTENT. ARMORY EXPRESSLY DISCLAIMS ON ITS OWN BEHALF AND ON BEHALF OF ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS ANY AND ALL WARRANTIES INCLUDING, WITHOUT LIMITATION (A) THE USE OF THE SERVICES OR THE ARMORY TOOLS WILL BE TIMELY, UNINTERRUPTED OR ERROR-FREE OR OPERATE IN COMBINATION WITH ANY OTHER HARDWARE, SOFTWARE, SYSTEM OR DATA, (B) THE SERVICES AND THE ARMORY TOOLS AND/OR THEIR QUALITY WILL MEET CUSTOMER”S REQUIREMENTS OR EXPECTATIONS, (C) ANY CONTENT WILL BE ACCURATE OR RELIABLE, (D) ERRORS OR DEFECTS WILL BE CORRECTED, OR (E) THE SERVICES, THE ARMORY TOOLS OR THE SERVER(S) THAT MAKE THE SERVICES AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. CUSTOMER AGREES THAT ARMORY SHALL NOT BE RESPONSIBLE FOR THE AVAILABILITY OR ACTS OR OMISSIONS OF ANY THIRD PARTY, INCLUDING ANY THIRD-PARTY APPLICATION OR PRODUCT, AND ARMORY HEREBY DISCLAIMS ANY AND ALL LIABILITY IN CONNECTION WITH SUCH THIRD PARTIES.
+
+IN NO EVENT SHALL ARMORY, ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS BE LIABLE UNDER THIS AGREEMENT FOR ANY CONSEQUENTIAL, SPECIAL, LOST PROFITS, INDIRECT OR OTHER DAMAGES, INCLUDING BUT NOT LIMITED TO LOST PROFITS, LOSS OF BUSINESS, COST OF COVER WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF ARMORY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. IN ANY EVENT, ARMORY, ITS EMPLOYEES’, AGENTS’, ATTORNEYS’, CONSULTANTS’ OR CONTRACTORS’ AGGREGATE LIABILITY UNDER THIS AGREEMENT FOR ANY CLAIM SHALL BE STRICTLY LIMITED TO $100.00. SOME STATES DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+
+You acknowledge that Armory has provided the Services in reliance upon the limitations of liability set forth herein and that the same is an essential basis of the bargain between the parties.
+
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory CD 2.32.2-rc6, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker community contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.32.4](https://www.spinnaker.io/changelogs/1.32.4-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+<details><summary>Expand to see the BOM</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: b29acea67a40b4145431137ba96454c1d1bf0d73
+    version: 2.32.2-rc6
+  deck:
+    commit: 13f331421b292db61f14392e6932880aa5c49f25
+    version: 2.32.2-rc6
+  dinghy:
+    commit: f5b14ffba75721322ada662f2325e80ec86347de
+    version: 2.32.2-rc6
+  echo:
+    commit: 9d2abeeea4341e5ba94654925ba6488a9038af3f
+    version: 2.32.2-rc6
+  fiat:
+    commit: 5e1839ef81812c439fb37b411bd3b381131c8c40
+    version: 2.32.2-rc6
+  front50:
+    commit: ba318cd2c445f14e5d6c3db87fa1658549385403
+    version: 2.32.2-rc6
+  gate:
+    commit: c6654ca6e316eef474c59296120d3f9f34eb0bdf
+    version: 2.32.2-rc6
+  igor:
+    commit: 9339ab63ab3d85ebcb00131033d19f26ad436f05
+    version: 2.32.2-rc6
+  kayenta:
+    commit: bccd150fcc8a7cb7df537ec6269bce5d2843c703
+    version: 2.32.2-rc6
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: aa898e512f93921b8786ea790bfe1cb5abc12f2b
+    version: 2.32.2-rc6
+  rosco:
+    commit: dfe611ffdd2cf9ae7c524fb9970af47350ca5e96
+    version: 2.32.2-rc6
+  terraformer:
+    commit: 2dc7666ca2d25acb85ab2b9f8efc864599061c45
+    version: 2.32.2-rc6
+timestamp: "2024-04-25 15:56:08"
+version: 2.32.2-rc6
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Clouddriver - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Kayenta - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Echo - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Deck - 2.32.2-rc5...2.32.2-rc6
+
+  - chore(cd): update base deck version to 2024.0.0-20240425133704.release-1.32.x (#1403)
+  - chore(cd): update base deck version to 2024.0.0-20240425135304.release-1.32.x (#1404)
+
+#### Armory Fiat - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Gate - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Terraformer™ - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Rosco - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Dinghy™ - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Orca - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Igor - 2.32.2-rc5...2.32.2-rc6
+
+
+#### Armory Front50 - 2.32.2-rc5...2.32.2-rc6
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Clouddriver - 1.32.4
+
+
+#### Spinnaker Kayenta - 1.32.4
+
+
+#### Spinnaker Echo - 1.32.4
+
+
+#### Spinnaker Deck - 1.32.4
+
+  - fix(pipelineGraph): Handling exception when requisiteStageRefIds is not defined (#10086) (#10089)
+  - fix(lambdaStages): Exporting Lambda stages based on the feature flag settings (#10085) (#10092)
+
+#### Spinnaker Fiat - 1.32.4
+
+
+#### Spinnaker Gate - 1.32.4
+
+
+#### Spinnaker Rosco - 1.32.4
+
+
+#### Spinnaker Orca - 1.32.4
+
+
+#### Spinnaker Igor - 1.32.4
+
+
+#### Spinnaker Front50 - 1.32.4
+
+

--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-32-2-rc6.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-32-2-rc6.md
@@ -125,42 +125,54 @@ version: 2.32.2-rc6
 ### Armory
 
 
-#### Armory Clouddriver - 2.32.2-rc5...2.32.2-rc6
+#### Armory Clouddriver - 2.32.1...2.32.2-rc6
 
 
-#### Armory Kayenta - 2.32.2-rc5...2.32.2-rc6
+#### Armory Kayenta - 2.32.1...2.32.2-rc6
 
 
-#### Armory Echo - 2.32.2-rc5...2.32.2-rc6
+#### Armory Echo - 2.32.1...2.32.2-rc6
 
 
-#### Armory Deck - 2.32.2-rc5...2.32.2-rc6
+#### Armory Deck - 2.32.1...2.32.2-rc6
+- chore(cd): update base deck version to 2024.0.0-20240416232157.release-1.32.x (#1400)
+- chore(cd): update base deck version to 2024.0.0-20240425133704.release-1.32.x (#1403)
+- chore(cd): update base deck version to 2024.0.0-20240425135304.release-1.32.x (#1404)
 
-  - chore(cd): update base deck version to 2024.0.0-20240425133704.release-1.32.x (#1403)
-  - chore(cd): update base deck version to 2024.0.0-20240425135304.release-1.32.x (#1404)
-
-#### Armory Fiat - 2.32.2-rc5...2.32.2-rc6
-
-
-#### Armory Gate - 2.32.2-rc5...2.32.2-rc6
+#### Armory Fiat - 2.32.1...2.32.2-rc6
+- fix(build): Updating vault addr for gradle build (#597) (#598)
 
 
-#### Terraformer™ - 2.32.2-rc5...2.32.2-rc6
+#### Armory Gate - 2.32.1...2.32.2-rc6
+- chore(cd): update base service version to gate:2024.03.25.21.57.21.release-1.32.x (#712)
 
 
-#### Armory Rosco - 2.32.2-rc5...2.32.2-rc6
+#### Terraformer™ - 2.32.1...2.32.2-rc6
+- fix(tf-show): Reverting go-cmd implementation (#551) (#552)
+- Build: Removing full history fetch (#553) (#554)
+- Updating Dockerfile with harness email list and pull from Dockerhub (#550) (#556)
+- Fixing Dockerfile with missing tools (#557) (#558)
+- fix(build): Refarctoring Dockerfile to fix build failures (#559) (#560)
+- fix(build): Fixing Dockerfile for multi-build process (#561) (#562)
 
 
-#### Dinghy™ - 2.32.2-rc5...2.32.2-rc6
+#### Armory Rosco - 2.32.1...2.32.2-rc6
 
 
-#### Armory Orca - 2.32.2-rc5...2.32.2-rc6
+#### Dinghy™ - 2.32.1...2.32.2-rc6
 
 
-#### Armory Igor - 2.32.2-rc5...2.32.2-rc6
+#### Armory Orca - 2.32.1...2.32.2-rc6
+- chore(cd): update base orca version to 2024.04.15.20.03.44.release-1.32.x (#865)
+- chore(cd): update base orca version to 2024.04.15.22.28.52.release-1.32.x (#867)
+- chore(cd): update base orca version to 2024.03.26.22.19.53.release-1.32.x (#856)
+- chore(cd): update base orca version to 2024.04.02.15.59.15.release-1.32.x (#860)
 
 
-#### Armory Front50 - 2.32.2-rc5...2.32.2-rc6
+#### Armory Igor - 2.32.1...2.32.2-rc6
+
+
+#### Armory Front50 - 2.32.1...2.32.2-rc6
 
 
 
@@ -177,20 +189,27 @@ version: 2.32.2-rc6
 
 
 #### Spinnaker Deck - 1.32.4
-
-  - fix(pipelineGraph): Handling exception when requisiteStageRefIds is not defined (#10086) (#10089)
-  - fix(lambdaStages): Exporting Lambda stages based on the feature flag settings (#10085) (#10092)
+- fix(runJobs): Persist External Log links after the deletion of the pods (#10081) (#10084)
+- fix(pipelineGraph): Handling exception when requisiteStageRefIds is not defined (#10086) (#10089)
+- fix(lambdaStages): Exporting Lambda stages based on the feature flag settings (#10085) (#10092)
 
 #### Spinnaker Fiat - 1.32.4
 
 
 #### Spinnaker Gate - 1.32.4
+- fix(core): RetrofitError thrown on login (#1737) (#1779)
+
 
 
 #### Spinnaker Rosco - 1.32.4
 
 
 #### Spinnaker Orca - 1.32.4
+- perf(sql): Optimise searchForPipelinesByTrigger LIMIT and OFFSET SQL query (#4698) (#4699)
+- fix(SqlExecutionRepository): fixed bug in sql repository in orca-sql … (backport #4697) (#4701)
+- feat(servergroup): Allow users to opt-out of the target desired size check when verifying if the instances scaled up or down successfully (#4649) (#4653)
+- fix(queue): Fix `ZombieExecutionCheckingAgent` to handle queues with more than 100 items (#4648) (#4683)
+- fix(explicitRollback): Add configurable timeout for serverGroup lookup from Clouddriver API (#4686) (#4690)
 
 
 #### Spinnaker Igor - 1.32.4

--- a/payload.json
+++ b/payload.json
@@ -1,199 +1,149 @@
 {
   "armoryServices": [
     {
-      "commitMessages": [
-        "Adding aws mysql jdbc drivers (#816)",
-        "chore(cd): update armory-commons version to 3.14.4 (#832)",
-        "chore(cd): update armory-commons version to 3.14.5 (#835)",
-        "chore(cd): update base orca version to 2024.03.11.15.12.53.release-1.31.x (#843)",
-        "chore(cd): update base orca version to 2024.03.14.15.56.51.release-1.31.x (#848)",
-        "chore(cd): update base orca version to 2024.03.14.16.21.01.release-1.31.x (#849)"
-      ],
-      "currentVersion": "2.31.1",
-      "name": "Armory Orca",
-      "previousVersion": "2.31.0"
-    },
-    {
       "commitMessages": [],
-      "currentVersion": "2.31.1",
-      "name": "Terraformer™",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.31.1",
-      "name": "Armory Fiat",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to igor:2024.01.22.15.24.57.release-1.31.x (#555)",
-        "chore: OS Updates (#516) (#567)",
-        "chore(cd): update armory-commons version to 3.14.4 (#578)",
-        "chore(cd): update armory-commons version to 3.14.5 (#580)",
-        "chore(cd): update base service version to igor:2024.03.14.15.50.26.release-1.31.x (#589)"
-      ],
-      "currentVersion": "2.31.1",
-      "name": "Armory Igor",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.31.1",
-      "name": "Armory Deck",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update armory-commons version to 3.14.4 (#691)",
-        "chore(cd): update armory-commons version to 3.14.5 (#693)",
-        "chore(cd): update base service version to echo:2024.03.14.14.32.38.release-1.31.x (#701)",
-        "chore(cd): update base service version to echo:2024.03.14.16.01.06.release-1.31.x (#702)"
-      ],
-      "currentVersion": "2.31.1",
-      "name": "Armory Echo",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [
-        "fix(ci): Removing integration tests as not stable (backport #627) (#629)",
-        "chore(cd): update armory-commons version to 3.14.4 (#645)",
-        "chore(cd): update armory-commons version to 3.14.5 (#646)"
-      ],
-      "currentVersion": "2.31.1",
-      "name": "Armory Rosco",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to kayenta:2023.11.21.08.03.27.release-1.31.x (#499)",
-        "chore(cd): update armory-commons version to 3.14.4 (#521)",
-        "chore(cd): update armory-commons version to 3.14.5 (#522)"
-      ],
-      "currentVersion": "2.31.1",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [
-        "chore: Front50 OS upgrade (#604) (#640)",
-        "chore(cd): update armory-commons version to 3.14.4 (#657)",
-        "chore(cd): update armory-commons version to 3.14.5 (#658)",
-        "Updating force dependency on com.google.cloud:google-cloud-storage:1.108.0 (#663) (#664)"
-      ],
-      "currentVersion": "2.31.1",
-      "name": "Armory Front50",
-      "previousVersion": "2.31.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update armory-commons version to 3.14.4 (#1081)",
-        "chore(cd): update base service version to clouddriver:2024.02.27.14.37.01.release-1.31.x (#1082)",
-        "chore(cd): update armory-commons version to 3.14.5 (#1085)"
-      ],
-      "currentVersion": "2.31.1",
+      "currentVersion": "2.32.2-rc6",
       "name": "Armory Clouddriver",
-      "previousVersion": "2.31.0"
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Echo",
+      "previousVersion": "2.32.2-rc5"
     },
     {
       "commitMessages": [
-        "chore(gate): Removing Instance registration from Gate (backport #677) (#679)",
-        "fix(header): Fixing header plugin reference in config (backport #684) (#686)",
-        "chore(cd): update armory-commons version to 3.14.4 (#701)",
-        "chore(cd): update armory-commons version to 3.14.5 (#702)"
+        "chore(cd): update base deck version to 2024.0.0-20240425133704.release-1.32.x (#1403)",
+        "chore(cd): update base deck version to 2024.0.0-20240425135304.release-1.32.x (#1404)"
       ],
-      "currentVersion": "2.31.1",
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Deck",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Fiat",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
       "name": "Armory Gate",
-      "previousVersion": "2.31.0"
+      "previousVersion": "2.32.2-rc5"
     },
     {
-      "commitMessages": [
-        "chore(dependencies): v0.0.0-20240213103436-d0dc889db2c6 (backport #529) (#531)"
-      ],
-      "currentVersion": "2.31.1",
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Terraformer™",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Rosco",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
       "name": "Dinghy™",
-      "previousVersion": "2.31.0"
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Orca",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Igor",
+      "previousVersion": "2.32.2-rc5"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.2-rc6",
+      "name": "Armory Front50",
+      "previousVersion": "2.32.2-rc5"
     }
   ],
-  "armoryVersion": "2.31.1",
+  "armoryVersion": "2.32.2-rc6",
   "ossServices": [
     {
-      "commitMessages": [
-        "feat(servergroup): Allow users to opt-out of the target desired size check when verifying if the instances scaled up or down successfully (#4649) (#4652)",
-        "feat(jenkins): Enable Jenkins job triggers for jobs in sub-folders (#4618) (#4633)",
-        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#4661) (#4677)"
-      ],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.31.0"
-    },
-    {
       "commitMessages": [],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [
-        "feat(jenkins): Enable Jenkins job triggers for jobs in sub-folders (#1204) (#1215)",
-        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#1230) (#1240)"
-      ],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Igor",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [
-        "feat(jenkins): Enable Jenkins job triggers for jobs in sub-folders (#1373) (#1380)",
-        "fix(jenkins): Enable properties and artifacts with job name as query parameter (#1393) (#1403)"
-      ],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump orcaVersion (#1001)"
-      ],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.31.3",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.31.0"
-    },
-    {
-      "commitMessages": [
-        "fix: Change the agent type name to not include the account name since this would generate LOTS of tables and cause problems long term (#6158) (#6164)"
-      ],
-      "currentVersion": "1.31.3",
+      "currentVersion": "1.32.4",
       "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.31.0"
+      "previousVersion": "1.32.4"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.31.3",
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [
+        "fix(pipelineGraph): Handling exception when requisiteStageRefIds is not defined (#10086) (#10089)",
+        "fix(lambdaStages): Exporting Lambda stages based on the feature flag settings (#10085) (#10092)"
+      ],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.31.0"
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Igor",
+      "previousVersion": "1.32.4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.4",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.32.4"
     }
   ],
-  "ossVersion": "1.31.3",
-  "prerelease": false,
+  "ossVersion": "1.32.4",
+  "prerelease": true,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -206,40 +156,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "cb7a25cc5d610afc67346cf25af98082566e38f6",
-        "version": "2.31.1"
+        "commit": "b29acea67a40b4145431137ba96454c1d1bf0d73",
+        "version": "2.32.2-rc6"
       },
       "deck": {
-        "commit": "1dd95e4ef5ed631f24253bf917200c3cf52655af",
-        "version": "2.31.1"
+        "commit": "13f331421b292db61f14392e6932880aa5c49f25",
+        "version": "2.32.2-rc6"
       },
       "dinghy": {
-        "commit": "1bbb649f71d128d167229d72a1c94aa480f99684",
-        "version": "2.31.1"
+        "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
+        "version": "2.32.2-rc6"
       },
       "echo": {
-        "commit": "abefa81c6eac597a0db45e33ebaebd464cfdc5df",
-        "version": "2.31.1"
+        "commit": "9d2abeeea4341e5ba94654925ba6488a9038af3f",
+        "version": "2.32.2-rc6"
       },
       "fiat": {
-        "commit": "f1079f69f0184aae517680c48283cf9a52c9cf26",
-        "version": "2.31.1"
+        "commit": "5e1839ef81812c439fb37b411bd3b381131c8c40",
+        "version": "2.32.2-rc6"
       },
       "front50": {
-        "commit": "13814c48944265261af52c3929a4b96fc6c45add",
-        "version": "2.31.1"
+        "commit": "ba318cd2c445f14e5d6c3db87fa1658549385403",
+        "version": "2.32.2-rc6"
       },
       "gate": {
-        "commit": "abfb0120ca617cb5806c7f2082ab4f8e9d7190b2",
-        "version": "2.31.1"
+        "commit": "c6654ca6e316eef474c59296120d3f9f34eb0bdf",
+        "version": "2.32.2-rc6"
       },
       "igor": {
-        "commit": "a66db7a9037a4ddec4e131ec0b0bb137956a9395",
-        "version": "2.31.1"
+        "commit": "9339ab63ab3d85ebcb00131033d19f26ad436f05",
+        "version": "2.32.2-rc6"
       },
       "kayenta": {
-        "commit": "18b22f0e9ca778f354ec5ac8255d0014ba6339ff",
-        "version": "2.31.1"
+        "commit": "bccd150fcc8a7cb7df537ec6269bce5d2843c703",
+        "version": "2.32.2-rc6"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -250,19 +200,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "e46aab32af0ec1031eb216fc3fa2cf00f957aea0",
-        "version": "2.31.1"
+        "commit": "aa898e512f93921b8786ea790bfe1cb5abc12f2b",
+        "version": "2.32.2-rc6"
       },
       "rosco": {
-        "commit": "9812503db8271e32cd5d7960db12441fa8a39494",
-        "version": "2.31.1"
+        "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
+        "version": "2.32.2-rc6"
       },
       "terraformer": {
-        "commit": "50082463ccd180cb4763078671a105ab70dee5e6",
-        "version": "2.31.1"
+        "commit": "2dc7666ca2d25acb85ab2b9f8efc864599061c45",
+        "version": "2.32.2-rc6"
       }
     },
-    "timestamp": "2024-03-14 18:17:56",
-    "version": "2.31.1"
+    "timestamp": "2024-04-25 15:56:08",
+    "version": "2.32.2-rc6"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Clouddriver",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Kayenta",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Echo",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [
        "chore(cd): update base deck version to 2024.0.0-20240425133704.release-1.32.x (#1403)",
        "chore(cd): update base deck version to 2024.0.0-20240425135304.release-1.32.x (#1404)"
      ],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Deck",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Fiat",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Gate",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Terraformer™",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Rosco",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Dinghy™",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Orca",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Igor",
      "previousVersion": "2.32.2-rc5"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.2-rc6",
      "name": "Armory Front50",
      "previousVersion": "2.32.2-rc5"
    }
  ],
  "armoryVersion": "2.32.2-rc6",
  "ossServices": [
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Echo",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [
        "fix(pipelineGraph): Handling exception when requisiteStageRefIds is not defined (#10086) (#10089)",
        "fix(lambdaStages): Exporting Lambda stages based on the feature flag settings (#10085) (#10092)"
      ],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Deck",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Gate",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Orca",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Igor",
      "previousVersion": "1.32.4"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.4",
      "name": "Spinnaker Front50",
      "previousVersion": "1.32.4"
    }
  ],
  "ossVersion": "1.32.4",
  "prerelease": true,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "b29acea67a40b4145431137ba96454c1d1bf0d73",
        "version": "2.32.2-rc6"
      },
      "deck": {
        "commit": "13f331421b292db61f14392e6932880aa5c49f25",
        "version": "2.32.2-rc6"
      },
      "dinghy": {
        "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
        "version": "2.32.2-rc6"
      },
      "echo": {
        "commit": "9d2abeeea4341e5ba94654925ba6488a9038af3f",
        "version": "2.32.2-rc6"
      },
      "fiat": {
        "commit": "5e1839ef81812c439fb37b411bd3b381131c8c40",
        "version": "2.32.2-rc6"
      },
      "front50": {
        "commit": "ba318cd2c445f14e5d6c3db87fa1658549385403",
        "version": "2.32.2-rc6"
      },
      "gate": {
        "commit": "c6654ca6e316eef474c59296120d3f9f34eb0bdf",
        "version": "2.32.2-rc6"
      },
      "igor": {
        "commit": "9339ab63ab3d85ebcb00131033d19f26ad436f05",
        "version": "2.32.2-rc6"
      },
      "kayenta": {
        "commit": "bccd150fcc8a7cb7df537ec6269bce5d2843c703",
        "version": "2.32.2-rc6"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "aa898e512f93921b8786ea790bfe1cb5abc12f2b",
        "version": "2.32.2-rc6"
      },
      "rosco": {
        "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
        "version": "2.32.2-rc6"
      },
      "terraformer": {
        "commit": "2dc7666ca2d25acb85ab2b9f8efc864599061c45",
        "version": "2.32.2-rc6"
      }
    },
    "timestamp": "2024-04-25 15:56:08",
    "version": "2.32.2-rc6"
  }
}
```