### PR TITLE
chore(release): add release notes for 2.32.4

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-4.md
+++ b/content/en/continuous-deployment/release-notes/rn-armory-spinnaker/armoryspinnaker_v2-32-4.md
@@ -1,0 +1,380 @@
+---
+title: v2.32.4 Armory Continuous Deployment Release (Spinnaker™ v1.32.0)
+toc_hide: true
+version: 2.32.4
+date: 2024-08-30
+description: >
+  Release notes for Armory Continuous Deployment v2.32.4.
+---
+
+<!-- 
+MAKE SURE TO ADD 'LTS' OR 'FEATURE' TO THE TITLE TO INDICATE RELEASE CATEGORY. 
+FOR EXAMPLE, "Armory Continuous Deployment Release LTS" or "Armory Continuous Deployment Release Feature" so users know release category and support time period 
+-->
+
+## 2024/08/30 release notes
+
+>Note: If you experience production issues after upgrading Armory Continuous Deployment, roll back to a previous working version and report issues to [http://go.armory.io/support](http://go.armory.io/support).
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory CD 2.32.4, use Armory Operator 1.8.6 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+### AWS Lambda plugin migrated to OSS
+Starting from Armory version 2.32.0 (OSS version 1.32.0), the AWS Lambda plugin has been migrated to OSS codebase.
+If you are using the AWS Lambda plugin, you will need to disable/remove it when upgrading to Armory version 2.32.0+ to
+avoid compatibility issues.
+
+Additionally, the AWS Lambda stages are now enabled using the Deck feature flag `feature.lambdaAdditionalStages = true;`
+as shown in the configuration block below.
+{{< highlight yaml "linenos=table,hl_lines=12" >}}
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      deck:
+        settings-local.js: |
+          ...
+          window.spinnakerSettings.feature.functions = true;
+          // Enable the AWS Lambda pipeline stages in Deck using the feature flag
+          window.spinnakerSettings.feature.lambdaAdditionalStages = true; 
+          ...
+      clouddriver:
+        aws:
+          enabled: true
+          features:
+            lambda:
+              enabled: true
+      ## Remove the AWS Lambda plugin from the Armory CD configuration.
+      #gate:
+      #  spinnaker:
+      #    extensibility:
+      #      deck-proxy:
+      #        enabled: true
+      #        plugins:
+      #          Aws.LambdaDeploymentPlugin:
+      #            enabled: true
+      #            version: <version>
+      #      repositories:
+      #        awsLambdaDeploymentPluginRepo:
+      #          url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json  
+      #orca:
+      #  spinnaker:
+      #    extensibility:
+      #      plugins:
+      #        Aws.LambdaDeploymentPlugin:
+      #          enabled: true
+      #          version: <version>
+      #          extensions:
+      #            Aws.LambdaDeploymentStage:
+      #              enabled: true
+      #      repositories:
+      #        awsLambdaDeploymentPluginRepo:
+      #          id: awsLambdaDeploymentPluginRepo
+      #          url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json
+{{< /highlight >}}
+
+
+Related OSS PRs:
+- https://github.com/spinnaker/orca/pull/4449
+- https://github.com/spinnaker/deck/pull/9988
+
+
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+### Terraformer support for AWS S3 Artifact Store
+OSS Spinnaker 1.32.0 introduced support for [artifact storage](https://spinnaker.io/changelogs/1.32.0-changelog/#artifact-store) 
+with AWS S3. This feature compresses `embdedded/base64` artifacts to `remote/base64` and uploads them to an AWS S3 bucket significantly 
+reducing the artifact size in the execution context. 
+
+Armory version 2.32.0 adds support for the same feature for the Terraform Integration stage.
+
+>Note: The artifact-store feature is disabled by default. To enable the artifact-store feature the following configuration is required:
+```yaml
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      spinnaker:
+        artifact-store:
+        enabled: true
+        s3:
+          enabled: true
+          region: <S3Bucket Region>
+          bucket: <S3Bucket Name>
+```
+
+When enabling the artifact-store feature it is recommended to deploy the services in this order:
+1. Clouddriver service
+2. Terraformer service
+3. Orca service
+4. Rosco service
+
+### Enable Jenkins job triggers for jobs located sub-folders
+When defining a Jenkins job in a sub-folder, the path contains forward slashes. By enabling this feature, Armory CD will be
+able to trigger Jenkins jobs located in sub-folders, correctly matching the job path.
+```yaml
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      echo:
+        feature:
+          igor:
+            jobNameAsQueryParameter: true
+      orca:
+        feature:
+          igor:
+            jobNameAsQueryParameter: true
+      igor:
+        feature:
+          igor:
+            jobNameAsQueryParameter: true
+```
+
+### Pipeline As Code: Bitbucket fallback support for default branch
+By default, Dinghy uses the `master` branch in your repository and fallbacks to `main` if `master` doesn’t exist.
+If you wish to use a different branch in your repository, you can configure that using the `repoConfig` tag in your YAML configuration.
+```yaml
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      dinghy:
+        repoConfig:
+        - branch: some_branch
+          provider: bitbucket-server
+          repo: my-bitbucket-repository
+```
+
+### Performance improvements for the search executions API operations
+The search executions API operations have been optimized to improve performance and reduce the time taken to search for pipelines by triggerType or eventId.
+
+### RunJob stage improvement
+RunJob stage now persist any External Log links after the deletion of the pods. This enhancement ensures that the External Log links are available even after the pods are deleted.
+
+### Task View loading support for Paginated requests
+Task View now supports paginated requests for loading tasks. This enhancement ensures that the Task View loads tasks more efficiently,
+avoiding timeouts when loading an application with high number of tasks.  
+
+To enable this feature, set the `window.spinnakerSettings.tasksViewLimitPerPage = <number>` flag to the desired number in the `settings-local.js` deck profile. For example:
+
+{{< highlight yaml "linenos=table,hl_lines=11" >}}
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      deck:
+        settings-local.js: |
+          ...
+          window.spinnakerSettings.tasksViewLimitPerPage = 100; 
+          ...
+{{< /highlight >}}
+
+
+###  Spinnaker community contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.32.4](https://www.spinnaker.io/changelogs/1.32.4-changelog/) changelog for details.
+
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+<details><summary>Expand to see the BOM</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 2736c8796b346d892fb68180ed1534cd882c5f6c
+    version: 2.32.4
+  deck:
+    commit: 9f22fea76ec0ce4ad425a09fd5793372d077f243
+    version: 2.32.4
+  dinghy:
+    commit: f5b14ffba75721322ada662f2325e80ec86347de
+    version: 2.32.4
+  echo:
+    commit: e376d0eb3f19fd3027820bb013b0fbf9fee98e55
+    version: 2.32.4
+  fiat:
+    commit: b674ce72dc02d7e39008bfbf2a551b3d1cc9544e
+    version: 2.32.4
+  front50:
+    commit: b774859c8e27ebfd90455cf0e5f3583eb9afe5d4
+    version: 2.32.4
+  gate:
+    commit: 9a3705729990d170a142b297d2df150fac71bf0f
+    version: 2.32.4
+  igor:
+    commit: c4e429724d83aae802796cda7c5d9b39ce6efba1
+    version: 2.32.4
+  kayenta:
+    commit: bccd150fcc8a7cb7df537ec6269bce5d2843c703
+    version: 2.32.4
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 9feaae8ddcf27315da951b4a51ffc7f0c4d4ffe6
+    version: 2.32.4
+  rosco:
+    commit: dfe611ffdd2cf9ae7c524fb9970af47350ca5e96
+    version: 2.32.4
+  terraformer:
+    commit: 709bc0b11d21230009e34a3229443e943db9036f
+    version: 2.32.4
+timestamp: "2024-08-29 13:18:29"
+version: 2.32.4
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Igor - 2.32.3...2.32.4
+
+  - chore(build): Updating Build dependencies (#613) (#624)
+
+#### Armory Echo - 2.32.3...2.32.4
+
+  - chore(build): Updating Build dependencies (#723) (#739)
+
+#### Armory Kayenta - 2.32.3...2.32.4
+
+
+#### Armory Fiat - 2.32.3...2.32.4
+
+  - chore(build): Updating Build dependencies (#613) (#626)
+
+#### Armory Deck - 2.32.3...2.32.4
+
+  - chore(cd): update base deck version to 2024.0.0-20240610151853.release-1.32.x (#1421)
+  - chore(cd): update base deck version to 2024.0.0-20240808191000.release-1.32.x (#1427)
+
+#### Armory Rosco - 2.32.3...2.32.4
+
+
+#### Armory Clouddriver - 2.32.3...2.32.4
+
+  - chore(cd): update base service version to clouddriver:2024.05.15.16.46.29.release-1.32.x (#1127)
+  - chore(cd): update base service version to clouddriver:2024.06.05.17.20.53.release-1.32.x (#1129)
+  - chore(build): Updating Build dependencies (#1140) (#1169)
+  - chore(cd): update base service version to clouddriver:2024.08.08.19.07.30.release-1.32.x (#1156)
+
+#### Armory Front50 - 2.32.3...2.32.4
+
+  - chore(cd): update base service version to front50:2024.06.11.18.14.17.release-1.32.x (#692)
+  - chore(build): Updating Build dependencies (#697) (#713)
+  - chore(cd): update base service version to front50:2024.08.23.02.19.43.release-1.32.x (#715)
+
+#### Armory Gate - 2.32.3...2.32.4
+
+  - chore(build): Updating Build dependencies (#732) (#750)
+
+#### Terraformer™ - 2.32.3...2.32.4
+
+  - chore(terraformer): Backport fixes (#571) (#573)
+
+#### Armory Orca - 2.32.3...2.32.4
+
+  - chore(cd): update base orca version to 2024.06.10.16.25.01.release-1.32.x (#893)
+  - chore(build): Updating Build dependencies (#911) (#935)
+
+#### Dinghy™ - 2.32.3...2.32.4
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Kayenta - 1.32.4
+- fix(stackdriver): handle null timeSeries and empty points (backport #1047) (#1048)
+
+#### Spinnaker Echo - 1.32.4
+
+
+#### Spinnaker Orca - 1.32.4
+
+- fix(check-pre-condition): CheckPrecondition doesn't evaluate expression correctly after upstream stages get restarted (#4682) (#4719)
+- fix(jenkins): Wrong Job name encoding in query params for Artifacts/Properties (#4722) (#4725)
+- fix(blueGreen): Scaling replicaSets should not be considered for deletion (#4728) (#4732)
+- feat(build): add orca-integration module to exercise the just-built docker image (backport #4721) (#4737)
+
+#### Spinnaker Fiat - 1.32.4
+
+
+#### Spinnaker Gate - 1.32.4
+
+
+#### Spinnaker Clouddriver - 1.32.4
+
+- fix(gcp): Relaxed health check for GCP accounts (#6200) (#6204)
+- fix(ClusterController): Fix GetClusters returning only the last 2 providers clusterNames of application (#6210) (#6211)
+- feat(build): add clouddriver-integration module to exercise the just-built docker imageTest docker image (backport #6206) (#6222) 
+- chore(gcp): Adding STRONG_COOKIE_AFFINITY in gcp LB model (#6259) (#6260)
+
+
+#### Spinnaker Rosco - 1.32.4
+
+
+#### Spinnaker Deck - 1.32.4
+
+- fix(lambda): Invoke stage excludedArtifactTypes not including the embedded-artifact type (#10097) (#10102)
+- feat(taskView): Implement opt-in paginated request for TaskView (backport #10093) (#10094)
+- fix(pipeline): Handle render/validation when stageTimeoutMs is a Spel expression (#10103) (#10106)
+- fix(redblack): fixing redblack onchange values (#10107) (#10111)
+- fix(lambda): Export LambdaRoute stage on aws module (#10116) (#10117)
+- chore(gcp): Adding STRONG_COOKIE_AFFINITY in gcp LB model (#10124) (#10125)
+
+#### Spinnaker Igor - 1.32.4
+
+
+#### Spinnaker Front50 - 1.32.4
+
+- fix(front50-gcs): Fix ObjectType filenames for GCS Front50 persistent store (#1493) (#1496)
+- fix(migrator): GCS to SQL migrator APPLICATION_PERMISSION objectType fix (#1466) (#1472)

--- a/payload.json
+++ b/payload.json
@@ -1,218 +1,168 @@
 {
   "armoryServices": [
     {
-      "commitMessages": [],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Dinghy™",
-      "previousVersion": "2.34.0"
-    },
-    {
       "commitMessages": [
-        "chore(cd): update base service version to gate:2024.08.09.02.35.08.release-1.34.x (#744)",
-        "chore(cd): update base service version to gate:2024.08.10.04.22.27.release-1.34.x (#745)",
-        "chore(cd): update base service version to gate:2024.08.16.23.57.38.release-1.34.x (#746)",
-        "chore(cd): update base service version to gate:2024.08.17.03.15.23.release-1.34.x (#747)"
+        "chore(build): Updating Build dependencies (#613) (#624)"
       ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Gate",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to rosco:2024.08.17.00.00.56.release-1.34.x (#684)"
-      ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Rosco",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to igor:2024.08.17.03.16.09.release-1.34.x (#623)"
-      ],
-      "currentVersion": "2.34.1-rc1",
+      "currentVersion": "2.32.4",
       "name": "Armory Igor",
-      "previousVersion": "2.34.0"
+      "previousVersion": "2.32.3"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to fiat:2024.08.16.23.56.14.release-1.34.x (#625)"
+        "chore(build): Updating Build dependencies (#723) (#739)"
       ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Fiat",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(terraformer): Backport fixes (#571)"
-      ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Terraformer™",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to kayenta:2024.08.08.20.11.17.release-1.34.x (#549)",
-        "chore(cd): update base service version to kayenta:2024.08.17.05.49.51.release-1.34.x (#552)"
-      ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to front50:2024.08.16.23.58.39.release-1.34.x (#708)",
-        "chore(cd): update base service version to front50:2024.08.18.02.21.08.release-1.34.x (#711)",
-        "chore(cd): update base service version to front50:2024.08.23.16.11.18.release-1.34.x (#712)"
-      ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Front50",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base orca version to 2024.08.17.02.35.16.release-1.34.x (#932)",
-        "chore(cd): update base orca version to 2024.08.17.03.26.59.release-1.34.x (#933)"
-      ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Orca",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base deck version to 2024.0.0-20240808191056.release-1.34.x (#1428)"
-      ],
-      "currentVersion": "2.34.1-rc1",
-      "name": "Armory Deck",
-      "previousVersion": "2.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(cd): update base service version to echo:2024.08.16.23.59.20.release-1.34.x (#737)",
-        "chore(cd): update base service version to echo:2024.08.17.03.16.29.release-1.34.x (#738)"
-      ],
-      "currentVersion": "2.34.1-rc1",
+      "currentVersion": "2.32.4",
       "name": "Armory Echo",
-      "previousVersion": "2.34.0"
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.4",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.32.3"
     },
     {
       "commitMessages": [
-        "chore(cd): update base service version to clouddriver:2024.08.08.19.08.20.release-1.34.x (#1157)",
-        "chore(cd): update base service version to clouddriver:2024.08.17.00.37.38.release-1.34.x (#1160)",
-        "chore(cd): update base service version to clouddriver:2024.08.17.03.54.14.release-1.34.x (#1161)",
-        "chore(cd): update base service version to clouddriver:2024.08.17.21.27.20.release-1.34.x (#1163)",
-        "chore(cd): update base service version to clouddriver:2024.08.18.02.43.56.release-1.34.x (#1165)"
+        "chore(build): Updating Build dependencies (#613) (#626)"
       ],
-      "currentVersion": "2.34.1-rc1",
+      "currentVersion": "2.32.4",
+      "name": "Armory Fiat",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base deck version to 2024.0.0-20240610151853.release-1.32.x (#1421)",
+        "chore(cd): update base deck version to 2024.0.0-20240808191000.release-1.32.x (#1427)"
+      ],
+      "currentVersion": "2.32.4",
+      "name": "Armory Deck",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.4",
+      "name": "Armory Rosco",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to clouddriver:2024.05.15.16.46.29.release-1.32.x (#1127)",
+        "chore(cd): update base service version to clouddriver:2024.06.05.17.20.53.release-1.32.x (#1129)",
+        "chore(build): Updating Build dependencies (#1140) (#1169)",
+        "chore(cd): update base service version to clouddriver:2024.08.08.19.07.30.release-1.32.x (#1156)"
+      ],
+      "currentVersion": "2.32.4",
       "name": "Armory Clouddriver",
-      "previousVersion": "2.34.0"
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to front50:2024.06.11.18.14.17.release-1.32.x (#692)",
+        "chore(build): Updating Build dependencies (#697) (#713)",
+        "chore(cd): update base service version to front50:2024.08.23.02.19.43.release-1.32.x (#715)"
+      ],
+      "currentVersion": "2.32.4",
+      "name": "Armory Front50",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [
+        "chore(build): Updating Build dependencies (#732) (#750)"
+      ],
+      "currentVersion": "2.32.4",
+      "name": "Armory Gate",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [
+        "chore(terraformer): Backport fixes (#571) (#573)"
+      ],
+      "currentVersion": "2.32.4",
+      "name": "Terraformer™",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base orca version to 2024.06.10.16.25.01.release-1.32.x (#893)",
+        "chore(build): Updating Build dependencies (#911) (#935)"
+      ],
+      "currentVersion": "2.32.4",
+      "name": "Armory Orca",
+      "previousVersion": "2.32.3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.32.4",
+      "name": "Dinghy™",
+      "previousVersion": "2.32.3"
     }
   ],
-  "armoryVersion": "2.34.1-rc1",
+  "armoryVersion": "2.32.4",
   "ossServices": [
     {
-      "commitMessages": [
-        "fix(web/test): stop leaking system properties from FunctionalSpec (#1798) (#1818)",
-        "fix(core): remove ErrorPageSecurityFilter bean named errorPageSecurityInterceptor (#1817)",
-        "chore(dependencies): Autobump korkVersion (#1821)",
-        "chore(dependencies): Autobump fiatVersion (#1822)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Gate",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1106)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1253)",
-        "chore(dependencies): Autobump fiatVersion (#1250)",
-        "chore(dependencies): Autobump korkVersion (#1272)",
-        "chore(dependencies): Autobump fiatVersion (#1273)"
-      ],
-      "currentVersion": "1.34.5",
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
       "name": "Spinnaker Igor",
-      "previousVersion": "1.34.0"
+      "previousVersion": "1.32.0"
     },
     {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1156)",
-        "chore(dependencies): Autobump korkVersion (#1153)",
-        "chore(dependencies): Autobump korkVersion (#1177)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "fix(stackdriver): handle null timeSeries and empty points (#1047) (#1050)",
-        "chore(dependencies): Autobump orcaVersion (#1058)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1488)",
-        "chore(dependencies): Autobump fiatVersion (#1489)",
-        "fix(gha): only bump halyard on master (#1490) (#1491)",
-        "fix(front50-gcs): Fix ObjectType filenames for GCS Front50 persistent store (#1493) (#1494)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#4776)",
-        "chore(dependencies): Autobump fiatVersion (#4777)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(gcp): Adding STRONG_COOKIE_AFFINITY in gcp LB model (#10124) (#10127)"
-      ],
-      "currentVersion": "1.34.5",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.34.0"
-    },
-    {
-      "commitMessages": [
-        "chore(dependencies): Autobump korkVersion (#1417)",
-        "feat(pipelinetriggers): set pipeline-cache.filterFront50Pipelines to true by default (#1416)",
-        "chore(dependencies): Autobump fiatVersion (#1413)",
-        "chore(dependencies): Autobump korkVersion (#1440)",
-        "chore(dependencies): Autobump fiatVersion (#1441)"
-      ],
-      "currentVersion": "1.34.5",
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
       "name": "Spinnaker Echo",
-      "previousVersion": "1.34.0"
+      "previousVersion": "1.32.0"
     },
     {
-      "commitMessages": [
-        "chore(gcp): Adding STRONG_COOKIE_AFFINITY in gcp LB model (#6259) (#6262)",
-        "chore(dependencies): Autobump korkVersion (#6266)",
-        "chore(dependencies): Autobump fiatVersion (#6267)",
-        "fix(gha): only bump halyard on master (#6268) (#6269)",
-        "fix(gha): remove whitespace from BRANCH in release.yml (#6271) (#6272)"
-      ],
-      "currentVersion": "1.34.5",
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
       "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.34.0"
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Gate",
+      "previousVersion": "1.32.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.32.0",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.32.0"
     }
   ],
-  "ossVersion": "1.34.5",
-  "prerelease": true,
+  "ossVersion": "1.32.0",
+  "prerelease": false,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -225,40 +175,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "7602c40d66f8d99254c740ac782fb4c7a8e547db",
-        "version": "2.34.1-rc1"
+        "commit": "2736c8796b346d892fb68180ed1534cd882c5f6c",
+        "version": "2.32.4"
       },
       "deck": {
-        "commit": "4e15526f16000326035436c57783415b5e5c1d72",
-        "version": "2.34.1-rc1"
+        "commit": "9f22fea76ec0ce4ad425a09fd5793372d077f243",
+        "version": "2.32.4"
       },
       "dinghy": {
-        "commit": "fbba492fb3d6c116d75f9ca959f6b5d84ab473a6",
-        "version": "2.34.1-rc1"
+        "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
+        "version": "2.32.4"
       },
       "echo": {
-        "commit": "391b1f4924679a0ce23c216d4b0d8bc4cfdd9ed5",
-        "version": "2.34.1-rc1"
+        "commit": "e376d0eb3f19fd3027820bb013b0fbf9fee98e55",
+        "version": "2.32.4"
       },
       "fiat": {
-        "commit": "df367d6ed0185b61abcea1e943109503a4b7928b",
-        "version": "2.34.1-rc1"
+        "commit": "b674ce72dc02d7e39008bfbf2a551b3d1cc9544e",
+        "version": "2.32.4"
       },
       "front50": {
-        "commit": "eb8691d3c549c86ba3547b0710828b9f37c62f38",
-        "version": "2.34.1-rc1"
+        "commit": "b774859c8e27ebfd90455cf0e5f3583eb9afe5d4",
+        "version": "2.32.4"
       },
       "gate": {
-        "commit": "f54a45abcf7a622e4233e471723c2b54d3972c5d",
-        "version": "2.34.1-rc1"
+        "commit": "9a3705729990d170a142b297d2df150fac71bf0f",
+        "version": "2.32.4"
       },
       "igor": {
-        "commit": "0ddc88fc33b097ca8d822e91591218c2216dbbc2",
-        "version": "2.34.1-rc1"
+        "commit": "c4e429724d83aae802796cda7c5d9b39ce6efba1",
+        "version": "2.32.4"
       },
       "kayenta": {
-        "commit": "b8983452be0897fc98a6c47d84f8689a9e0e623b",
-        "version": "2.34.1-rc1"
+        "commit": "bccd150fcc8a7cb7df537ec6269bce5d2843c703",
+        "version": "2.32.4"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -269,19 +219,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "9385c93a4ce4f30a5484989b0b9913b6cd7e24d6",
-        "version": "2.34.1-rc1"
+        "commit": "9feaae8ddcf27315da951b4a51ffc7f0c4d4ffe6",
+        "version": "2.32.4"
       },
       "rosco": {
-        "commit": "f0e9fdb04e392820324f5edb72c0ff46b5307701",
-        "version": "2.34.1-rc1"
+        "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
+        "version": "2.32.4"
       },
       "terraformer": {
-        "commit": "d4b6e9f53f3a2b595ce25e0b044318d47fd239b6",
-        "version": "2.34.1-rc1"
+        "commit": "709bc0b11d21230009e34a3229443e943db9036f",
+        "version": "2.32.4"
       }
     },
-    "timestamp": "2024-08-29 12:35:20",
-    "version": "2.34.1-rc1"
+    "timestamp": "2024-08-29 13:18:29",
+    "version": "2.32.4"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [
        "chore(build): Updating Build dependencies (#613) (#624)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Igor",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(build): Updating Build dependencies (#723) (#739)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Echo",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.4",
      "name": "Armory Kayenta",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(build): Updating Build dependencies (#613) (#626)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Fiat",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(cd): update base deck version to 2024.0.0-20240610151853.release-1.32.x (#1421)",
        "chore(cd): update base deck version to 2024.0.0-20240808191000.release-1.32.x (#1427)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Deck",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.4",
      "name": "Armory Rosco",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2024.05.15.16.46.29.release-1.32.x (#1127)",
        "chore(cd): update base service version to clouddriver:2024.06.05.17.20.53.release-1.32.x (#1129)",
        "chore(build): Updating Build dependencies (#1140) (#1169)",
        "chore(cd): update base service version to clouddriver:2024.08.08.19.07.30.release-1.32.x (#1156)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Clouddriver",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to front50:2024.06.11.18.14.17.release-1.32.x (#692)",
        "chore(build): Updating Build dependencies (#697) (#713)",
        "chore(cd): update base service version to front50:2024.08.23.02.19.43.release-1.32.x (#715)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Front50",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(build): Updating Build dependencies (#732) (#750)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Gate",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(terraformer): Backport fixes (#571) (#573)"
      ],
      "currentVersion": "2.32.4",
      "name": "Terraformer™",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [
        "chore(cd): update base orca version to 2024.06.10.16.25.01.release-1.32.x (#893)",
        "chore(build): Updating Build dependencies (#911) (#935)"
      ],
      "currentVersion": "2.32.4",
      "name": "Armory Orca",
      "previousVersion": "2.32.3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.32.4",
      "name": "Dinghy™",
      "previousVersion": "2.32.3"
    }
  ],
  "armoryVersion": "2.32.4",
  "ossServices": [
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Igor",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Echo",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Deck",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Front50",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Gate",
      "previousVersion": "1.32.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.32.0",
      "name": "Spinnaker Orca",
      "previousVersion": "1.32.0"
    }
  ],
  "ossVersion": "1.32.0",
  "prerelease": false,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "2736c8796b346d892fb68180ed1534cd882c5f6c",
        "version": "2.32.4"
      },
      "deck": {
        "commit": "9f22fea76ec0ce4ad425a09fd5793372d077f243",
        "version": "2.32.4"
      },
      "dinghy": {
        "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
        "version": "2.32.4"
      },
      "echo": {
        "commit": "e376d0eb3f19fd3027820bb013b0fbf9fee98e55",
        "version": "2.32.4"
      },
      "fiat": {
        "commit": "b674ce72dc02d7e39008bfbf2a551b3d1cc9544e",
        "version": "2.32.4"
      },
      "front50": {
        "commit": "b774859c8e27ebfd90455cf0e5f3583eb9afe5d4",
        "version": "2.32.4"
      },
      "gate": {
        "commit": "9a3705729990d170a142b297d2df150fac71bf0f",
        "version": "2.32.4"
      },
      "igor": {
        "commit": "c4e429724d83aae802796cda7c5d9b39ce6efba1",
        "version": "2.32.4"
      },
      "kayenta": {
        "commit": "bccd150fcc8a7cb7df537ec6269bce5d2843c703",
        "version": "2.32.4"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "9feaae8ddcf27315da951b4a51ffc7f0c4d4ffe6",
        "version": "2.32.4"
      },
      "rosco": {
        "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
        "version": "2.32.4"
      },
      "terraformer": {
        "commit": "709bc0b11d21230009e34a3229443e943db9036f",
        "version": "2.32.4"
      }
    },
    "timestamp": "2024-08-29 13:18:29",
    "version": "2.32.4"
  }
}
```