### PR TITLE
chore(release): add release notes for 2.35.0-rc4

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-35-0-rc4.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-35-0-rc4.md
@@ -1,0 +1,201 @@
+---
+title: v2.35.0-rc4 Armory Continuous Deployment Release (Spinnaker™ v1.35.5)
+toc_hide: true
+date: 2025-01-23
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+description: >
+  Release notes for Armory Continuous Deployment v2.35.0-rc4. A beta release is not meant for installation in production environments.
+
+---
+
+## 2025/01/23 release notes
+
+## Disclaimer
+
+This pre-release software is to allow limited access to test or beta versions of the Armory services (“Services”) and to provide feedback and comments to Armory regarding the use of such Services. By using Services, you agree to be bound by the terms and conditions set forth herein.
+
+Your Feedback is important and we welcome any feedback, analysis, suggestions and comments (including, but not limited to, bug reports and test results) (collectively, “Feedback”) regarding the Services. Any Feedback you provide will become the property of Armory and you agree that Armory may use or otherwise exploit all or part of your feedback or any derivative thereof in any manner without any further remuneration, compensation or credit to you. You represent and warrant that any Feedback which is provided by you hereunder is original work made solely by you and does not infringe any third party intellectual property rights.
+
+Any Feedback provided to Armory shall be considered Armory Confidential Information and shall be covered by any confidentiality agreements between you and Armory.
+
+You acknowledge that you are using the Services on a purely voluntary basis, as a means of assisting, and in consideration of the opportunity to assist Armory to use, implement, and understand various facets of the Services. You acknowledge and agree that nothing herein or in your voluntary submission of Feedback creates any employment relationship between you and Armory.
+
+Armory may, in its sole discretion, at any time, terminate or discontinue all or your access to the Services. You acknowledge and agree that all such decisions by Armory are final and Armory will have no liability with respect to such decisions.
+
+YOUR USE OF THE SERVICES IS AT YOUR OWN RISK. THE SERVICES, THE ARMORY TOOLS AND THE CONTENT ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. ARMORY AND ITS LICENSORS MAKE NO REPRESENTATION, WARRANTY, OR GUARANTY AS TO THE RELIABILITY, TIMELINESS, QUALITY, SUITABILITY, TRUTH, AVAILABILITY, ACCURACY OR COMPLETENESS OF THE SERVICES, THE ARMORY TOOLS OR ANY CONTENT. ARMORY EXPRESSLY DISCLAIMS ON ITS OWN BEHALF AND ON BEHALF OF ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS ANY AND ALL WARRANTIES INCLUDING, WITHOUT LIMITATION (A) THE USE OF THE SERVICES OR THE ARMORY TOOLS WILL BE TIMELY, UNINTERRUPTED OR ERROR-FREE OR OPERATE IN COMBINATION WITH ANY OTHER HARDWARE, SOFTWARE, SYSTEM OR DATA, (B) THE SERVICES AND THE ARMORY TOOLS AND/OR THEIR QUALITY WILL MEET CUSTOMER”S REQUIREMENTS OR EXPECTATIONS, (C) ANY CONTENT WILL BE ACCURATE OR RELIABLE, (D) ERRORS OR DEFECTS WILL BE CORRECTED, OR (E) THE SERVICES, THE ARMORY TOOLS OR THE SERVER(S) THAT MAKE THE SERVICES AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. CUSTOMER AGREES THAT ARMORY SHALL NOT BE RESPONSIBLE FOR THE AVAILABILITY OR ACTS OR OMISSIONS OF ANY THIRD PARTY, INCLUDING ANY THIRD-PARTY APPLICATION OR PRODUCT, AND ARMORY HEREBY DISCLAIMS ANY AND ALL LIABILITY IN CONNECTION WITH SUCH THIRD PARTIES.
+
+IN NO EVENT SHALL ARMORY, ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS BE LIABLE UNDER THIS AGREEMENT FOR ANY CONSEQUENTIAL, SPECIAL, LOST PROFITS, INDIRECT OR OTHER DAMAGES, INCLUDING BUT NOT LIMITED TO LOST PROFITS, LOSS OF BUSINESS, COST OF COVER WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF ARMORY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. IN ANY EVENT, ARMORY, ITS EMPLOYEES’, AGENTS’, ATTORNEYS’, CONSULTANTS’ OR CONTRACTORS’ AGGREGATE LIABILITY UNDER THIS AGREEMENT FOR ANY CLAIM SHALL BE STRICTLY LIMITED TO $100.00. SOME STATES DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+
+You acknowledge that Armory has provided the Services in reliance upon the limitations of liability set forth herein and that the same is an essential basis of the bargain between the parties.
+
+
+## Required Armory Operator version
+
+To install, upgrade, or configure Armory CD 2.35.0-rc4, use Armory Operator 1.70 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker community contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.35.5](https://www.spinnaker.io/changelogs/1.35.5-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+<details><summary>Expand to see the BOM</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: f0e7a7470b06b6a8a007f1494bc1d97ea6d4a52c
+    version: 2.35.0-rc4
+  deck:
+    commit: b04971d387e1a0664f536427976c0d64733044b5
+    version: 2.35.0-rc4
+  dinghy:
+    commit: 50041173d1a043493409059e7fa5d7a1a80fb553
+    version: 2.35.0-rc4
+  echo:
+    commit: 6117e5941dda2f2faa52639cba5e8449b0a64d0c
+    version: 2.35.0-rc4
+  fiat:
+    commit: ce4a5e689b66fce9f5aa4e3039f0fe1af5e69f74
+    version: 2.35.0-rc4
+  front50:
+    commit: 900b169d3cea95992d781e22939bb5fa1224a75d
+    version: 2.35.0-rc4
+  gate:
+    commit: af49faafbd341109028335630f25c46e9077bc1f
+    version: 2.35.0-rc4
+  igor:
+    commit: 56f0c75e06b79f2e3029b0b0da323a2d6c0dff6f
+    version: 2.35.0-rc4
+  kayenta:
+    commit: 8c63692f834f965848a6f238035d0fb01fbc2834
+    version: 2.35.0-rc4
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 9e94501096394c824bbfca5be5707d0d2c5f1713
+    version: 2.35.0-rc4
+  rosco:
+    commit: 9259f32ee4c6beb1bf1da32c0161590ecf3de800
+    version: 2.35.0-rc4
+  terraformer:
+    commit: 9756bee07eaabbb25b54812996314c22554ec1c0
+    version: 2.35.0-rc4
+timestamp: "2025-01-23 23:27:17"
+version: 2.35.0-rc4
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Rosco - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Echo - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Terraformer™ - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Front50 - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Fiat - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Deck - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Gate - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Orca - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Clouddriver - 2.35.0-rc3...2.35.0-rc4
+
+  - chore(cd): update base service version to clouddriver:2025.01.03.20.45.15.release-1.35.x (#1207)
+
+#### Dinghy™ - 2.35.0-rc3...2.35.0-rc4
+
+
+#### Armory Kayenta - 2.35.0-rc3...2.35.0-rc4
+
+  - chore(cd): update base service version to kayenta:2025.01.22.22.30.54.release-1.35.x (#575)
+
+#### Armory Igor - 2.35.0-rc3...2.35.0-rc4
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Rosco - 1.35.5
+
+
+#### Spinnaker Echo - 1.35.5
+
+
+#### Spinnaker Front50 - 1.35.5
+
+
+#### Spinnaker Fiat - 1.35.5
+
+
+#### Spinnaker Deck - 1.35.5
+
+
+#### Spinnaker Gate - 1.35.5
+
+
+#### Spinnaker Orca - 1.35.5
+
+
+#### Spinnaker Clouddriver - 1.35.5
+
+  - fix(mergify): Mergify config needs adjusting for latest mergify releases (#6321) (#6327)
+
+#### Spinnaker Kayenta - 1.35.5
+
+  - chore(dependencies): Autobump orcaVersion (#1076)
+
+#### Spinnaker Igor - 1.35.5
+
+

--- a/payload.json
+++ b/payload.json
@@ -2,145 +2,150 @@
   "armoryServices": [
     {
       "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Echo",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Igor",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Fiat",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Deck",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
+      "currentVersion": "2.35.0-rc4",
       "name": "Armory Rosco",
-      "previousVersion": "2.32.4"
+      "previousVersion": "2.35.0-rc3"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Clouddriver",
-      "previousVersion": "2.32.4"
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Echo",
+      "previousVersion": "2.35.0-rc3"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Gate",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Front50",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
+      "currentVersion": "2.35.0-rc4",
       "name": "Terraformer™",
-      "previousVersion": "2.32.4"
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Front50",
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Fiat",
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Deck",
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Gate",
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Orca",
+      "previousVersion": "2.35.0-rc3"
     },
     {
       "commitMessages": [
-        "chore(build): Updating Build dependencies (backport #544) (#553)",
-        "chore(cd): update base service version to kayenta:2024.08.08.22.44.15.release-1.32.x (#550)"
+        "chore(cd): update base service version to clouddriver:2025.01.03.20.45.15.release-1.35.x (#1207)"
       ],
-      "currentVersion": "2.32.5",
-      "name": "Armory Kayenta",
-      "previousVersion": "2.32.4"
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Clouddriver",
+      "previousVersion": "2.35.0-rc3"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.32.5",
-      "name": "Armory Orca",
-      "previousVersion": "2.32.4"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.32.5",
+      "currentVersion": "2.35.0-rc4",
       "name": "Dinghy™",
-      "previousVersion": "2.32.4"
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [
+        "chore(cd): update base service version to kayenta:2025.01.22.22.30.54.release-1.35.x (#575)"
+      ],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Kayenta",
+      "previousVersion": "2.35.0-rc3"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.35.0-rc4",
+      "name": "Armory Igor",
+      "previousVersion": "2.35.0-rc3"
     }
   ],
-  "armoryVersion": "2.32.5",
+  "armoryVersion": "2.35.0-rc4",
   "ossServices": [
     {
       "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.32.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Igor",
-      "previousVersion": "1.32.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.32.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.32.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.32.0",
+      "currentVersion": "1.35.5",
       "name": "Spinnaker Rosco",
-      "previousVersion": "1.32.0"
+      "previousVersion": "1.35.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.32.0"
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.35.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Gate",
-      "previousVersion": "1.32.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.32.0",
+      "currentVersion": "1.35.5",
       "name": "Spinnaker Front50",
-      "previousVersion": "1.32.0"
+      "previousVersion": "1.35.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.32.0",
-      "name": "Spinnaker Kayenta",
-      "previousVersion": "1.32.0"
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.35.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.32.0",
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.35.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Gate",
+      "previousVersion": "1.35.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.35.5",
       "name": "Spinnaker Orca",
-      "previousVersion": "1.32.0"
+      "previousVersion": "1.35.0"
+    },
+    {
+      "commitMessages": [
+        "fix(mergify): Mergify config needs adjusting for latest mergify releases (#6321) (#6327)"
+      ],
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Clouddriver",
+      "previousVersion": "1.35.0"
+    },
+    {
+      "commitMessages": [
+        "chore(dependencies): Autobump orcaVersion (#1076)"
+      ],
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Kayenta",
+      "previousVersion": "1.35.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.35.5",
+      "name": "Spinnaker Igor",
+      "previousVersion": "1.35.0"
     }
   ],
-  "ossVersion": "1.32.0",
-  "prerelease": false,
+  "ossVersion": "1.35.5",
+  "prerelease": true,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -153,40 +158,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "2736c8796b346d892fb68180ed1534cd882c5f6c",
-        "version": "2.32.5"
+        "commit": "f0e7a7470b06b6a8a007f1494bc1d97ea6d4a52c",
+        "version": "2.35.0-rc4"
       },
       "deck": {
-        "commit": "9f22fea76ec0ce4ad425a09fd5793372d077f243",
-        "version": "2.32.5"
+        "commit": "b04971d387e1a0664f536427976c0d64733044b5",
+        "version": "2.35.0-rc4"
       },
       "dinghy": {
-        "commit": "f5b14ffba75721322ada662f2325e80ec86347de",
-        "version": "2.32.5"
+        "commit": "50041173d1a043493409059e7fa5d7a1a80fb553",
+        "version": "2.35.0-rc4"
       },
       "echo": {
-        "commit": "e376d0eb3f19fd3027820bb013b0fbf9fee98e55",
-        "version": "2.32.5"
+        "commit": "6117e5941dda2f2faa52639cba5e8449b0a64d0c",
+        "version": "2.35.0-rc4"
       },
       "fiat": {
-        "commit": "b674ce72dc02d7e39008bfbf2a551b3d1cc9544e",
-        "version": "2.32.5"
+        "commit": "ce4a5e689b66fce9f5aa4e3039f0fe1af5e69f74",
+        "version": "2.35.0-rc4"
       },
       "front50": {
-        "commit": "b774859c8e27ebfd90455cf0e5f3583eb9afe5d4",
-        "version": "2.32.5"
+        "commit": "900b169d3cea95992d781e22939bb5fa1224a75d",
+        "version": "2.35.0-rc4"
       },
       "gate": {
-        "commit": "9a3705729990d170a142b297d2df150fac71bf0f",
-        "version": "2.32.5"
+        "commit": "af49faafbd341109028335630f25c46e9077bc1f",
+        "version": "2.35.0-rc4"
       },
       "igor": {
-        "commit": "c4e429724d83aae802796cda7c5d9b39ce6efba1",
-        "version": "2.32.5"
+        "commit": "56f0c75e06b79f2e3029b0b0da323a2d6c0dff6f",
+        "version": "2.35.0-rc4"
       },
       "kayenta": {
-        "commit": "1d0be49daf965910063c3ee611da1453b4fc5a2a",
-        "version": "2.32.5"
+        "commit": "8c63692f834f965848a6f238035d0fb01fbc2834",
+        "version": "2.35.0-rc4"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -197,19 +202,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "9feaae8ddcf27315da951b4a51ffc7f0c4d4ffe6",
-        "version": "2.32.5"
+        "commit": "9e94501096394c824bbfca5be5707d0d2c5f1713",
+        "version": "2.35.0-rc4"
       },
       "rosco": {
-        "commit": "dfe611ffdd2cf9ae7c524fb9970af47350ca5e96",
-        "version": "2.32.5"
+        "commit": "9259f32ee4c6beb1bf1da32c0161590ecf3de800",
+        "version": "2.35.0-rc4"
       },
       "terraformer": {
-        "commit": "709bc0b11d21230009e34a3229443e943db9036f",
-        "version": "2.32.5"
+        "commit": "9756bee07eaabbb25b54812996314c22554ec1c0",
+        "version": "2.35.0-rc4"
       }
     },
-    "timestamp": "2024-09-02 08:31:29",
-    "version": "2.32.5"
+    "timestamp": "2025-01-23 23:27:17",
+    "version": "2.35.0-rc4"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Rosco",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Echo",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Terraformer™",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Front50",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Fiat",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Deck",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Gate",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Orca",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to clouddriver:2025.01.03.20.45.15.release-1.35.x (#1207)"
      ],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Clouddriver",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Dinghy™",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [
        "chore(cd): update base service version to kayenta:2025.01.22.22.30.54.release-1.35.x (#575)"
      ],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Kayenta",
      "previousVersion": "2.35.0-rc3"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.35.0-rc4",
      "name": "Armory Igor",
      "previousVersion": "2.35.0-rc3"
    }
  ],
  "armoryVersion": "2.35.0-rc4",
  "ossServices": [
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Echo",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Front50",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Deck",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Gate",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Orca",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [
        "fix(mergify): Mergify config needs adjusting for latest mergify releases (#6321) (#6327)"
      ],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [
        "chore(dependencies): Autobump orcaVersion (#1076)"
      ],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.35.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.35.5",
      "name": "Spinnaker Igor",
      "previousVersion": "1.35.0"
    }
  ],
  "ossVersion": "1.35.5",
  "prerelease": true,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "f0e7a7470b06b6a8a007f1494bc1d97ea6d4a52c",
        "version": "2.35.0-rc4"
      },
      "deck": {
        "commit": "b04971d387e1a0664f536427976c0d64733044b5",
        "version": "2.35.0-rc4"
      },
      "dinghy": {
        "commit": "50041173d1a043493409059e7fa5d7a1a80fb553",
        "version": "2.35.0-rc4"
      },
      "echo": {
        "commit": "6117e5941dda2f2faa52639cba5e8449b0a64d0c",
        "version": "2.35.0-rc4"
      },
      "fiat": {
        "commit": "ce4a5e689b66fce9f5aa4e3039f0fe1af5e69f74",
        "version": "2.35.0-rc4"
      },
      "front50": {
        "commit": "900b169d3cea95992d781e22939bb5fa1224a75d",
        "version": "2.35.0-rc4"
      },
      "gate": {
        "commit": "af49faafbd341109028335630f25c46e9077bc1f",
        "version": "2.35.0-rc4"
      },
      "igor": {
        "commit": "56f0c75e06b79f2e3029b0b0da323a2d6c0dff6f",
        "version": "2.35.0-rc4"
      },
      "kayenta": {
        "commit": "8c63692f834f965848a6f238035d0fb01fbc2834",
        "version": "2.35.0-rc4"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "9e94501096394c824bbfca5be5707d0d2c5f1713",
        "version": "2.35.0-rc4"
      },
      "rosco": {
        "commit": "9259f32ee4c6beb1bf1da32c0161590ecf3de800",
        "version": "2.35.0-rc4"
      },
      "terraformer": {
        "commit": "9756bee07eaabbb25b54812996314c22554ec1c0",
        "version": "2.35.0-rc4"
      }
    },
    "timestamp": "2025-01-23 23:27:17",
    "version": "2.35.0-rc4"
  }
}
```