### PR TITLE
feat(self serve error): Update versions

### DIFF
--- a/content/en/plugins/self-serve-error-management/index.md
+++ b/content/en/plugins/self-serve-error-management/index.md
@@ -27,6 +27,11 @@ Installing the plugin consists of the following:
 
 | Spinnaker Version | Self-Serve Error Management Plugin Version |
 |-------------------|-----------------------------|
+| 1.36.x            | 0.0.3 |
+| 1.35.x            | 0.0.3 |
+| 1.34.x            | 0.1.0 |
+| 1.33.x            | 0.1.0 |
+| 1.32.x            | 0.1.0 |
 | 1.31.x            | 0.1.0 | 
 | 1.30.x            | 0.1.0 | 
 | 1.29.x            | 0.1.0                       |


### PR DESCRIPTION
self-serve-error-management-0.0.3 was released for compatibility with 2.35.x and 2.36.x versions
