### PR TITLE
chore(release): add release notes for 2.40.0-rc5

### DIFF
--- a/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-40-0-rc5.md
+++ b/content/en/continuous-deployment/release-notes/rn-prerelease-armory-spinnaker/armoryspinnaker_v2-40-0-rc5.md
@@ -1,0 +1,206 @@
+---
+title: v2.40.0-rc5 Armory Continuous Deployment Release (Spinnaker™ v1.40.0)
+toc_hide: true
+date: 2026-07-14
+version: <!-- version in 00.00.00 format ex 02.23.01 for sorting, grouping -->
+description: >
+  Release notes for Armory Continuous Deployment v2.40.0-rc5. A beta release is not meant for installation in production environments.
+
+---
+
+## 2026/07/14 release notes
+
+## Disclaimer
+
+This pre-release software is to allow limited access to test or beta versions of the Armory services (“Services”) and to provide feedback and comments to Armory regarding the use of such Services. By using Services, you agree to be bound by the terms and conditions set forth herein.
+
+Your Feedback is important and we welcome any feedback, analysis, suggestions and comments (including, but not limited to, bug reports and test results) (collectively, “Feedback”) regarding the Services. Any Feedback you provide will become the property of Armory and you agree that Armory may use or otherwise exploit all or part of your feedback or any derivative thereof in any manner without any further remuneration, compensation or credit to you. You represent and warrant that any Feedback which is provided by you hereunder is original work made solely by you and does not infringe any third party intellectual property rights.
+
+Any Feedback provided to Armory shall be considered Armory Confidential Information and shall be covered by any confidentiality agreements between you and Armory.
+
+You acknowledge that you are using the Services on a purely voluntary basis, as a means of assisting, and in consideration of the opportunity to assist Armory to use, implement, and understand various facets of the Services. You acknowledge and agree that nothing herein or in your voluntary submission of Feedback creates any employment relationship between you and Armory.
+
+Armory may, in its sole discretion, at any time, terminate or discontinue all or your access to the Services. You acknowledge and agree that all such decisions by Armory are final and Armory will have no liability with respect to such decisions.
+
+YOUR USE OF THE SERVICES IS AT YOUR OWN RISK. THE SERVICES, THE ARMORY TOOLS AND THE CONTENT ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. ARMORY AND ITS LICENSORS MAKE NO REPRESENTATION, WARRANTY, OR GUARANTY AS TO THE RELIABILITY, TIMELINESS, QUALITY, SUITABILITY, TRUTH, AVAILABILITY, ACCURACY OR COMPLETENESS OF THE SERVICES, THE ARMORY TOOLS OR ANY CONTENT. ARMORY EXPRESSLY DISCLAIMS ON ITS OWN BEHALF AND ON BEHALF OF ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS ANY AND ALL WARRANTIES INCLUDING, WITHOUT LIMITATION (A) THE USE OF THE SERVICES OR THE ARMORY TOOLS WILL BE TIMELY, UNINTERRUPTED OR ERROR-FREE OR OPERATE IN COMBINATION WITH ANY OTHER HARDWARE, SOFTWARE, SYSTEM OR DATA, (B) THE SERVICES AND THE ARMORY TOOLS AND/OR THEIR QUALITY WILL MEET CUSTOMER”S REQUIREMENTS OR EXPECTATIONS, (C) ANY CONTENT WILL BE ACCURATE OR RELIABLE, (D) ERRORS OR DEFECTS WILL BE CORRECTED, OR (E) THE SERVICES, THE ARMORY TOOLS OR THE SERVER(S) THAT MAKE THE SERVICES AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. CUSTOMER AGREES THAT ARMORY SHALL NOT BE RESPONSIBLE FOR THE AVAILABILITY OR ACTS OR OMISSIONS OF ANY THIRD PARTY, INCLUDING ANY THIRD-PARTY APPLICATION OR PRODUCT, AND ARMORY HEREBY DISCLAIMS ANY AND ALL LIABILITY IN CONNECTION WITH SUCH THIRD PARTIES.
+
+IN NO EVENT SHALL ARMORY, ITS EMPLOYEES, AGENTS, ATTORNEYS, CONSULTANTS, OR CONTRACTORS BE LIABLE UNDER THIS AGREEMENT FOR ANY CONSEQUENTIAL, SPECIAL, LOST PROFITS, INDIRECT OR OTHER DAMAGES, INCLUDING BUT NOT LIMITED TO LOST PROFITS, LOSS OF BUSINESS, COST OF COVER WHETHER BASED IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF ARMORY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. IN ANY EVENT, ARMORY, ITS EMPLOYEES’, AGENTS’, ATTORNEYS’, CONSULTANTS’ OR CONTRACTORS’ AGGREGATE LIABILITY UNDER THIS AGREEMENT FOR ANY CLAIM SHALL BE STRICTLY LIMITED TO $100.00. SOME STATES DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+
+You acknowledge that Armory has provided the Services in reliance upon the limitations of liability set forth herein and that the same is an essential basis of the bargain between the parties.
+
+
+## Required Armory Operator version
+{{% alert color="warning" title="Important" %}}
+[Armory Operator]({{< ref "armory-operator" >}}) has been deprecated and will is considered EOL. Please migrate to the [Kustomize]({{< ref "armory-operator-to-kustomize-migration" >}}) method of deployment.
+{{% /alert %}}
+
+To install, upgrade, or configure Armory CD 2.40.0-rc5, use Armory Operator 1.8.6 or later.
+
+## Security
+
+Armory scans the codebase as we develop and release software. Contact your Armory account representative for information about CVE scans for this release.
+
+## Breaking changes
+<!-- Copy/paste from the previous version if there are recent ones. We can drop breaking changes after 3 minor versions. Add new ones from OSS and Armory. -->
+
+> Breaking changes are kept in this list for 3 minor versions from when the change is introduced. For example, a breaking change introduced in 2.21.0 appears in the list up to and including the 2.24.x releases. It would not appear on 2.25.x release notes.
+
+## Known issues
+<!-- Copy/paste known issues from the previous version if they're not fixed. Add new ones from OSS and Armory. If there aren't any issues, state that so readers don't think we forgot to fill out this section. -->
+
+## Highlighted updates
+
+<!--
+Each item category (such as UI) under here should be an h3 (###). List the following info that service owners should be able to provide:
+- Major changes or new features we want to call out for Armory and OSS. Changes should be grouped under end user understandable sections. For example, instead of Deck, use UI. Instead of Fiat, use Permissions.
+- Fixes to any known issues from previous versions that we have in release notes. These can all be grouped under a Fixed issues H3.
+-->
+
+
+
+
+###  Spinnaker community contributions
+
+There have also been numerous enhancements, fixes, and features across all of Spinnaker's other services. See the
+[Spinnaker v1.40.0](https://www.spinnaker.io/changelogs/1.40.0-changelog/) changelog for details.
+
+## Detailed updates
+
+### Bill Of Materials (BOM)
+
+<details><summary>Expand to see the BOM</summary>
+<pre class="highlight">
+<code>artifactSources:
+  dockerRegistry: docker.io/armory
+dependencies:
+  redis:
+    commit: null
+    version: 2:2.8.4-2
+services:
+  clouddriver:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  deck:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  dinghy:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  echo:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  fiat:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  front50:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  gate:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  igor:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  kayenta:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  monitoring-daemon:
+    commit: null
+    version: 2.26.0
+  monitoring-third-party:
+    commit: null
+    version: 2.26.0
+  orca:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  rosco:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+  terraformer:
+    commit: 5316cdf53a2c78f78c116ff478012d58f9974e27
+    version: 2.40.0-rc5
+timestamp: "2026-07-14 09:27:26"
+version: 2.40.0-rc5
+</code>
+</pre>
+</details>
+
+### Armory
+
+
+#### Armory Dinghy - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Gate - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Terraformer - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Igor - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Kayenta - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Orca - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Rosco - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Clouddriver - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Deck - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Echo - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Fiat - 2.40.0-rc4...2.40.0-rc5
+
+
+#### Armory Front50 - 2.40.0-rc4...2.40.0-rc5
+
+
+
+### Spinnaker
+
+
+#### Spinnaker Dinghy - 1.40.0
+
+
+#### Spinnaker Gate - 1.40.0
+
+
+#### Spinnaker Terraformer - 1.40.0
+
+
+#### Spinnaker Igor - 1.40.0
+
+
+#### Spinnaker Kayenta - 1.40.0
+
+
+#### Spinnaker Orca - 1.40.0
+
+
+#### Spinnaker Rosco - 1.40.0
+
+
+#### Spinnaker Clouddriver - 1.40.0
+
+
+#### Spinnaker Deck - 1.40.0
+
+
+#### Spinnaker Echo - 1.40.0
+
+
+#### Spinnaker Fiat - 1.40.0
+
+
+#### Spinnaker Front50 - 1.40.0
+
+

--- a/payload.json
+++ b/payload.json
@@ -2,154 +2,154 @@
   "armoryServices": [
     {
       "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Orca",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
+      "currentVersion": "2.40.0-rc5",
       "name": "Armory Dinghy",
-      "previousVersion": "2.38.0"
+      "previousVersion": "2.40.0-rc4"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Rosco",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Clouddriver",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Deck",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Echo",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Fiat",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
-      "name": "Armory Front50",
-      "previousVersion": "2.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "2.39.0",
+      "currentVersion": "2.40.0-rc5",
       "name": "Armory Gate",
-      "previousVersion": "2.38.0"
+      "previousVersion": "2.40.0-rc4"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.39.0",
+      "currentVersion": "2.40.0-rc5",
       "name": "Armory Terraformer",
-      "previousVersion": "2.38.0"
+      "previousVersion": "2.40.0-rc4"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.39.0",
+      "currentVersion": "2.40.0-rc5",
       "name": "Armory Igor",
-      "previousVersion": "2.38.0"
+      "previousVersion": "2.40.0-rc4"
     },
     {
       "commitMessages": [],
-      "currentVersion": "2.39.0",
+      "currentVersion": "2.40.0-rc5",
       "name": "Armory Kayenta",
-      "previousVersion": "2.38.0"
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Orca",
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Rosco",
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Clouddriver",
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Deck",
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Echo",
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Fiat",
+      "previousVersion": "2.40.0-rc4"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "2.40.0-rc5",
+      "name": "Armory Front50",
+      "previousVersion": "2.40.0-rc4"
     }
   ],
-  "armoryVersion": "2.39.0",
+  "armoryVersion": "2.40.0-rc5",
   "ossServices": [
     {
       "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Orca",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
+      "currentVersion": "1.40.0",
       "name": "Spinnaker Dinghy",
-      "previousVersion": "1.38.0"
+      "previousVersion": "1.40.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Rosco",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Clouddriver",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Deck",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Echo",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Fiat",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
-      "name": "Spinnaker Front50",
-      "previousVersion": "1.38.0"
-    },
-    {
-      "commitMessages": [],
-      "currentVersion": "1.39.0",
+      "currentVersion": "1.40.0",
       "name": "Spinnaker Gate",
-      "previousVersion": "1.38.0"
+      "previousVersion": "1.40.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.39.0",
+      "currentVersion": "1.40.0",
       "name": "Spinnaker Terraformer",
-      "previousVersion": "1.38.0"
+      "previousVersion": "1.40.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.39.0",
+      "currentVersion": "1.40.0",
       "name": "Spinnaker Igor",
-      "previousVersion": "1.38.0"
+      "previousVersion": "1.40.0"
     },
     {
       "commitMessages": [],
-      "currentVersion": "1.39.0",
+      "currentVersion": "1.40.0",
       "name": "Spinnaker Kayenta",
-      "previousVersion": "1.38.0"
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Orca",
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Rosco",
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Clouddriver",
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Deck",
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Echo",
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Fiat",
+      "previousVersion": "1.40.0"
+    },
+    {
+      "commitMessages": [],
+      "currentVersion": "1.40.0",
+      "name": "Spinnaker Front50",
+      "previousVersion": "1.40.0"
     }
   ],
-  "ossVersion": "1.39.0",
-  "prerelease": false,
+  "ossVersion": "1.40.0",
+  "prerelease": true,
   "stack": {
     "artifactSources": {
       "dockerRegistry": "docker.io/armory"
@@ -162,40 +162,40 @@
     },
     "services": {
       "clouddriver": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "deck": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "dinghy": {
-        "commit": "babaa4704f1df8a6f6b42e533716396c8a0f529b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "echo": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "fiat": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "front50": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "gate": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "igor": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "kayenta": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "monitoring-daemon": {
         "commit": null,
@@ -206,19 +206,19 @@
         "version": "2.26.0"
       },
       "orca": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "rosco": {
-        "commit": "8f40c99bd0979c73db2c003b9dccc00dd960551b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       },
       "terraformer": {
-        "commit": "babaa4704f1df8a6f6b42e533716396c8a0f529b",
-        "version": "2.39.0"
+        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
+        "version": "2.40.0-rc5"
       }
     },
-    "timestamp": "2026-06-19 19:27:18",
-    "version": "2.39.0"
+    "timestamp": "2026-07-14 09:27:26",
+    "version": "2.40.0-rc5"
   }
 }


### PR DESCRIPTION
Event
```
{
  "armoryServices": [
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Dinghy",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Gate",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Terraformer",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Igor",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Kayenta",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Orca",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Rosco",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Clouddriver",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Deck",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Echo",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Fiat",
      "previousVersion": "2.40.0-rc4"
    },
    {
      "commitMessages": [],
      "currentVersion": "2.40.0-rc5",
      "name": "Armory Front50",
      "previousVersion": "2.40.0-rc4"
    }
  ],
  "armoryVersion": "2.40.0-rc5",
  "ossServices": [
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Dinghy",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Gate",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Terraformer",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Igor",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Kayenta",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Orca",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Rosco",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Clouddriver",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Deck",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Echo",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Fiat",
      "previousVersion": "1.40.0"
    },
    {
      "commitMessages": [],
      "currentVersion": "1.40.0",
      "name": "Spinnaker Front50",
      "previousVersion": "1.40.0"
    }
  ],
  "ossVersion": "1.40.0",
  "prerelease": true,
  "stack": {
    "artifactSources": {
      "dockerRegistry": "docker.io/armory"
    },
    "dependencies": {
      "redis": {
        "commit": null,
        "version": "2:2.8.4-2"
      }
    },
    "services": {
      "clouddriver": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "deck": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "dinghy": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "echo": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "fiat": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "front50": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "gate": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "igor": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "kayenta": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "monitoring-daemon": {
        "commit": null,
        "version": "2.26.0"
      },
      "monitoring-third-party": {
        "commit": null,
        "version": "2.26.0"
      },
      "orca": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "rosco": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      },
      "terraformer": {
        "commit": "5316cdf53a2c78f78c116ff478012d58f9974e27",
        "version": "2.40.0-rc5"
      }
    },
    "timestamp": "2026-07-14 09:27:26",
    "version": "2.40.0-rc5"
  }
}
```